### PR TITLE
Make MIME mappings robust by removing inherited entries.

### DIFF
--- a/webgl/web.config
+++ b/webgl/web.config
@@ -2,7 +2,9 @@
 <configuration>
     <system.webServer>
         <staticContent>
+            <remove fileExtension=".glsl" />
             <mimeMap fileExtension=".glsl" mimeType="text/plain" />
+            <remove fileExtension=".json" />
             <mimeMap fileExtension=".json" mimeType="application/json" />
         </staticContent>
     </system.webServer>


### PR DESCRIPTION
If MIME types are configured at the global level, or any parent level, the server will produce an error unless those inherited types are removed prior to re-assignment.  It does not produce an error to have a remove statement without the inherited type.

The server error looks something like this:

```
HTTP Error 500.19 - Internal Server Error
The requested page cannot be accessed because the related configuration data
for the page is invalid.

Cannot add duplicate collection entry of type 'mimeMap' with unique key
attribute 'fileExtension' set to '.json'
```

The attached edit fixes it for all cases.
