### PR TITLE
Add timing to converter

### DIFF
--- a/converter/COLLADA2GLTF/main.cpp
+++ b/converter/COLLADA2GLTF/main.cpp
@@ -29,6 +29,8 @@
 #include <getopt.h>
 
 #include <iostream>
+#include <sstream>
+#include <iomanip>
 
 #include "GitSHA1.h"
 #include "GLTF.h"
@@ -245,6 +247,8 @@ int main (int argc, char * const argv[]) {
             return -1;
         }
         
+        clock_t start = clock();
+
 #if !STDOUT_OUTPUT
         FILE* fd = fopen(converterContext.outputFilePath.c_str(), "w");
         if (fd) {
@@ -272,6 +276,10 @@ int main (int argc, char * const argv[]) {
             delete writer;
         }
 #endif
+
+        std::stringstream s;
+        s << std::setiosflags(std::ios::fixed) << std::setprecision(2) << float(clock() - start) / CLK_TCK;
+        std::cout << "Runtime: " << s.str() << " seconds" << std::endl;
     }
     return 0;
 }


### PR DESCRIPTION
This outputs the time it takes to run the converter.  I need to keep a close eye on it because some models take a while.

I did this on Windows.  Make sure it compiles on Mac.

P.S. why are we using `printf` everywhere and outputting garbage like `printf("\n\033[F\033[J");`?
