### PR TITLE
VS2013 needs <stdarg.h> for va_start and va_end.

### DIFF
--- a/converter/COLLADA2GLTF/GLTFConverterContext.h
+++ b/converter/COLLADA2GLTF/GLTFConverterContext.h
@@ -1,6 +1,7 @@
 #ifndef __GLTFConverterContext__
 #define __GLTFConverterContext__
 
+#include <stdarg.h>
 #include "GLTF-OpenCOLLADA.h"
 
 namespace GLTF


### PR DESCRIPTION
Fix the build on Visual Studio 2013.  It also needs the fix from [OpenCOLLADA#225](https://github.com/KhronosGroup/OpenCOLLADA/pull/255)
