### PR TITLE
fixed linking Realtime Extensions library on some linux systems (undefin...

### DIFF
--- a/converter/COLLADA2GLTF/CMakeLists.txt
+++ b/converter/COLLADA2GLTF/CMakeLists.txt
@@ -160,6 +160,9 @@ if (USE_WEBGLLOADER)
 LIST(APPEND TARGET_LIBS WEBGLLOADER)
 endif()
 
+IF("${CMAKE_SYSTEM}" MATCHES "Linux")
+    LIST(APPEND TARGET_LIBS rt)
+endif("${CMAKE_SYSTEM}" MATCHES "Linux")
 
 target_link_libraries (collada2gltf ${TARGET_LIBS})
 


### PR DESCRIPTION
...ed reference to clock_gettime)

This should fix the problem discussed in: https://github.com/KhronosGroup/glTF/issues/211
It just links 'librt' explicitly when on a linux system.

I had the error discussed in the above thread occurring on Ubuntu 12.04.4 LTS and CentOS 6.5.

Please review.

Toni
