### PR TITLE
Changed file extension to .gltf. Fixed location of dll on windows.

### DIFF
--- a/converter/COLLADA2GLTF/CMakeLists.txt
+++ b/converter/COLLADA2GLTF/CMakeLists.txt
@@ -169,6 +169,11 @@ endif()
 
 add_library(collada2gltfConvert SHARED ${GLTF_SOURCES})
 
+#Make sure the dll is in the same directory as the executable
+if (WIN32)
+    set_target_properties(collada2gltfConvert PROPERTIES RUNTIME_OUTPUT_DIRECTORY "bin")
+endif()
+
 if (NOT WIN32)
 LIST(APPEND TARGET_LIBS ${PNG_LIBRARY} ${ZLIB_LIBRARY})
 endif()

--- a/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -279,13 +279,13 @@ namespace GLTF
             outputBundlePathURI.setPath(inputPathURI.getPathDir(), outputBundlePathURI.getPathFileBase(), outputBundlePathURI.getPathExtension());
             this->_bundleOutputPath = outputBundlePathURI.toNativePath();
             
-            COLLADABU::URI outputPathURI(outputBundlePathURI.getURIString() + "/" + outputBundlePathURI.getPathFileBase() + "." + "json");
+            COLLADABU::URI outputPathURI(outputBundlePathURI.getURIString() + "/" + outputBundlePathURI.getPathFileBase() + "." + "gltf");
             this->_outputFilePath = outputPathURI.toNativePath();
             //                this->log("outputBundlePath:%s\n",outputBundlePathURI.toNativePath().c_str());
             //                this->log("outputPath:%s\n",outputPathURI.toNativePath().c_str());
         } else {
             this->_bundleOutputPath = outputBundlePathURI.toNativePath();
-            COLLADABU::URI outputPathURI(outputBundlePathURI.getURIString() + "/" + outputBundlePathURI.getPathFileBase()  + "." + "json");
+            COLLADABU::URI outputPathURI(outputBundlePathURI.getURIString() + "/" + outputBundlePathURI.getPathFileBase()  + "." + "gltf");
             this->_outputFilePath = outputPathURI.toNativePath();
         }
         COLLADABU::Utils::createDirectoryIfNeeded(this->_bundleOutputPath.c_str());

--- a/converter/COLLADA2GLTF/main.cpp
+++ b/converter/COLLADA2GLTF/main.cpp
@@ -143,7 +143,7 @@ static bool processArgs(int argc, char * const * argv, GLTF::GLTFAsset *asset) {
     if (argc == 2) {
         if (fileExists(argv[1])) {
             asset->setInputFilePath(argv[1]);
-            asset->setOutputFilePath(replacePathExtensionWith(asset->getInputFilePath(), "json"));
+            asset->setOutputFilePath(replacePathExtensionWith(asset->getInputFilePath(), "gltf"));
             return true;
         }
     }
@@ -167,7 +167,7 @@ static bool processArgs(int argc, char * const * argv, GLTF::GLTFAsset *asset) {
                 hasOutputPath = true;
 				break;
             case 'o':
-                asset->setOutputFilePath(replacePathExtensionWith(optarg, "json"));
+                asset->setOutputFilePath(replacePathExtensionWith(optarg, "gltf"));
                 hasOutputPath = true;
 				break;
             case 'i':
@@ -236,7 +236,7 @@ static bool processArgs(int argc, char * const * argv, GLTF::GLTFAsset *asset) {
     }
     
     if (!hasOutputPath & hasInputPath) {
-        asset->setOutputFilePath(replacePathExtensionWith(asset->getInputFilePath(), "json"));
+        asset->setOutputFilePath(replacePathExtensionWith(asset->getInputFilePath(), "gltf"));
     }
     
     return true;


### PR DESCRIPTION
Change extension to .gltf from .json (#260)

The shared lib change put the dll in the wrong directory on Windows so it wouldn't run without moving it. This fixes it. Not quite sure why it didn't go in with the original pull request.
