### PR TITLE
Fixed crash caused by freeing and array twice.

### DIFF
--- a/converter/COLLADA2GLTF/convert/meshConverter.cpp
+++ b/converter/COLLADA2GLTF/convert/meshConverter.cpp
@@ -411,10 +411,6 @@ namespace GLTF
             __AppendIndices(cvtPrimitive, primitiveIndicesVector, binormalIndices, TEXBINORMAL, 0);
         }
         
-        if (verticesCountArray) {
-            free(verticesCountArray);
-        }
-        
         //TODO:refactor
         if (openCOLLADAMeshPrimitive->hasTangentIndices()) {
             unsigned int triangulatedIndicesCount = 0;


### PR DESCRIPTION
Converter looks to be freeing verticesCountArray twice. It occasionally causes crashes on certain models.
