### PR TITLE
Exports json objects so they can be used in a user's AssetModifier

### DIFF
--- a/converter/COLLADA2GLTF/GLTF/GLTFAccessor.h
+++ b/converter/COLLADA2GLTF/GLTF/GLTFAccessor.h
@@ -43,7 +43,7 @@ namespace GLTF
         size_t /* vertexAttributeByteSize*/,
         void* /* context */);
     
-    class GLTFAccessor : public JSONObject {
+    class COLLADA2GLTF_EXPORT GLTFAccessor : public JSONObject {
     private:
         void _generateID();
 

--- a/converter/COLLADA2GLTF/GLTF/GLTFAnimation.h
+++ b/converter/COLLADA2GLTF/GLTF/GLTFAnimation.h
@@ -29,7 +29,7 @@ namespace GLTF
     class GLTFAnimationFlattener;
     class GLTFAsset;
         
-    class GLTFAnimation : public JSONObject {
+    class COLLADA2GLTF_EXPORT GLTFAnimation : public JSONObject {
     public:
         GLTFAnimation();
         virtual ~GLTFAnimation();

--- a/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -882,7 +882,7 @@ namespace GLTF
             }
         }
         
-        this->assetModifiers().push_back(shared_ptr<GLTFFlipUVModifier> (new GLTFFlipUVModifier()));
+        this->assetModifiers().insert(this->assetModifiers().begin(), shared_ptr<GLTFFlipUVModifier>(new GLTFFlipUVModifier()));
         
         this->launchModifiers();
         

--- a/converter/COLLADA2GLTF/GLTF/GLTFBuffer.h
+++ b/converter/COLLADA2GLTF/GLTF/GLTFBuffer.h
@@ -34,7 +34,7 @@
 
 namespace GLTF 
 {
-    class GLTFBuffer : public JSONObject {
+    class COLLADA2GLTF_EXPORT GLTFBuffer : public JSONObject {
     private:
         GLTFBuffer();
     public:
@@ -56,7 +56,7 @@ namespace GLTF
         bool _ownData;
     };
     
-    class GLTFBufferView : public JSONObject {
+    class COLLADA2GLTF_EXPORT GLTFBufferView : public JSONObject {
     public:
         GLTFBufferView();
         GLTFBufferView(std::shared_ptr <GLTF::GLTFBuffer> buffer, size_t byteOffset, size_t byteLength);

--- a/converter/COLLADA2GLTF/GLTF/GLTFEffect.h
+++ b/converter/COLLADA2GLTF/GLTF/GLTFEffect.h
@@ -33,7 +33,7 @@ namespace GLTF
     typedef std::shared_ptr<SemanticArray> SemanticArrayPtr;
     typedef std::map<std::string /* texcoord */, SemanticArrayPtr > TexCoordToSemanticsArrayPtr;
     
-    class GLTFEffect : public JSONObject {
+    class COLLADA2GLTF_EXPORT GLTFEffect : public JSONObject {
         
     public:
         GLTFEffect(const std::string &ID);

--- a/converter/COLLADA2GLTF/GLTF/GLTFExtras.h
+++ b/converter/COLLADA2GLTF/GLTF/GLTFExtras.h
@@ -26,7 +26,7 @@
 
 namespace GLTF 
 {
-        class GLTFExtras : public JSONObject {
+    class COLLADA2GLTF_EXPORT GLTFExtras : public JSONObject {
         
     public:
         GLTFExtras(const std::string &ID);

--- a/converter/COLLADA2GLTF/GLTF/GLTFMesh.h
+++ b/converter/COLLADA2GLTF/GLTF/GLTFMesh.h
@@ -36,7 +36,7 @@ namespace GLTF
     typedef std::map<unsigned int /* IndexSet */, std::shared_ptr<GLTF::GLTFAccessor> > IndexSetToMeshAttributeHashmap;
     typedef std::map<GLTF::Semantic , IndexSetToMeshAttributeHashmap > SemanticToMeshAttributeHashmap;
     
-    class GLTFMesh : public JSONObject {
+    class COLLADA2GLTF_EXPORT GLTFMesh : public JSONObject {
     public:
         GLTFMesh();
         GLTFMesh(const GLTFMesh &mesh);

--- a/converter/COLLADA2GLTF/GLTF/GLTFPrimitive.h
+++ b/converter/COLLADA2GLTF/GLTF/GLTFPrimitive.h
@@ -47,7 +47,7 @@ namespace GLTF
         size_t _indexOfSet;
     };
         
-    class GLTFPrimitive : public JSONObject
+    class COLLADA2GLTF_EXPORT GLTFPrimitive : public JSONObject
     {
     public:
         GLTFPrimitive();

--- a/converter/COLLADA2GLTF/GLTF/GLTFSkin.h
+++ b/converter/COLLADA2GLTF/GLTF/GLTFSkin.h
@@ -26,7 +26,7 @@
 
 namespace GLTF 
 {
-    class GLTFController : public JSONObject {
+    class COLLADA2GLTF_EXPORT GLTFController : public JSONObject {
     public:
         GLTFController();
         virtual ~GLTFController();
@@ -37,7 +37,7 @@ namespace GLTF
         std::shared_ptr<JSONObject> _extras;
     };
 
-    class GLTFSkin : public GLTFController
+    class COLLADA2GLTF_EXPORT GLTFSkin : public GLTFController
     {
     public:
         GLTFSkin();

--- a/converter/COLLADA2GLTF/JSON/JSONArray.h
+++ b/converter/COLLADA2GLTF/JSON/JSONArray.h
@@ -29,7 +29,7 @@
 
 namespace GLTF 
 {
-    class JSONArray : public JSONValue {
+    class COLLADA2GLTF_EXPORT JSONArray : public JSONValue {
         friend class JSONObject;
         
     private:

--- a/converter/COLLADA2GLTF/JSON/JSONNumber.h
+++ b/converter/COLLADA2GLTF/JSON/JSONNumber.h
@@ -29,7 +29,7 @@
 
 namespace GLTF 
 {
-    class JSONNumber : public JSONValue {
+    class COLLADA2GLTF_EXPORT JSONNumber : public JSONValue {
     private:
         JSONNumber():JSONValue(), _type(NOT_A_NUMBER) {}
         

--- a/converter/COLLADA2GLTF/JSON/JSONString.h
+++ b/converter/COLLADA2GLTF/JSON/JSONString.h
@@ -31,7 +31,7 @@ namespace GLTF
 {
 #define JSONSTRING(x) (shared_ptr <GLTF::JSONString> (new GLTF::JSONString(x)))
     
-    class JSONString : public JSONValue {
+    class COLLADA2GLTF_EXPORT JSONString : public JSONValue {
     private:
 
     public:        

--- a/converter/COLLADA2GLTF/assetModifiers/GLTFAssetModifier.h
+++ b/converter/COLLADA2GLTF/assetModifiers/GLTFAssetModifier.h
@@ -30,7 +30,7 @@ namespace GLTF
      *
      *
      */
-    class GLTFAssetModifier {
+    class COLLADA2GLTF_EXPORT GLTFAssetModifier {
     public:
         virtual bool init() { return true; };
         virtual void modify(std::shared_ptr<JSONObject> glTFAsset) = 0;


### PR DESCRIPTION
This will allow users to use the json objects within their own asset modifiers. Also, we now apply the UV Flip modifier first so the user defined modifiers have the benefit of having correct texture coordinates when they are run.
