### PR TITLE
Fixed memory corruption

### DIFF
--- a/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -1153,11 +1153,7 @@ namespace GLTF
         
         indicesBufferView->setUnsignedInt32(kTarget, this->_profile->getGLenumForString("ELEMENT_ARRAY_BUFFER"));
         verticesBufferView->setUnsignedInt32(kTarget, this->_profile->getGLenumForString("ARRAY_BUFFER"));
-        
-        //---
-        //to run legacy evaluate, to be removed
-        this->addValueEvaluator(shared_ptr<GLTFAssetValueEvaluator> (this));
-        
+       
         this->_performValuesEvaluation();
         
         rawOutputStream->close();


### PR DESCRIPTION
Only 1 shared_ptr can be created with the naked pointer. All other shader_ptr objects must be created with another shared_ptr because the reference count is stored in the pointers, not the actual objects. Adding a shared_ptr to this caused the asset to get destroyed immediately after addValueEvaluator was called. This is generally towards the end of the app so it wouldn't always crash but running it as part of another process corrupted memory and caused a consistent crash.

Since evaluationWillStart, evaluate and evaluationDidComplete are all empty in GLTFAsset it doesn't affect anything removing this line.
