### PR TITLE
Had 2 definitions of the same variable

### DIFF
--- a/converter/COLLADA2GLTF/shaders/commonProfileShaders.cpp
+++ b/converter/COLLADA2GLTF/shaders/commonProfileShaders.cpp
@@ -1269,7 +1269,6 @@ namespace GLTF
         
         shared_ptr <JSONObject> techniquesObject = asset->root()->createObjectIfNeeded("techniques");
         
-        static TechniqueHashToTechniqueID techniqueHashToTechniqueID;
         if (techniqueHashToTechniqueID.count(techniqueHash) == 0) {
             techniqueHashToTechniqueID[techniqueHash] = "technique" + GLTFUtils::toString(techniqueHashToTechniqueID.size());
         }


### PR DESCRIPTION
The file static one ended up unused so the clearing out after conversion didn't actually do anything. Running in another process caused the technique ids to keep growing which was breaking unit tests.
