### PR TITLE
Fixed bin file to have same base name as output file and glsl files.

### DIFF
--- a/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -477,8 +477,8 @@ namespace GLTF
 
     std::string GLTFAsset::getSharedBufferId() {
         if (this->_sharedBufferId.length() == 0) {
-            COLLADABU::URI inputURI(this->getInputFilePath().c_str());
-            std::string fileName = inputURI.getPathFileBase();
+            COLLADABU::URI outputURI(this->getOutputFilePath().c_str());
+            std::string fileName = outputURI.getPathFileBase();
             this->_sharedBufferId = fileName;
         }
         return this->_sharedBufferId;


### PR DESCRIPTION
When you converted a model and the input and output names differed, the gltf and glsl files would have the same base name, but the .bin file would have the name of the input file. Not a huge deal but it looks odd and for randomly generated names used in unit tests it was making the results unpredictable.
