### PR TITLE
Changed convert dll to be static by default.

### DIFF
--- a/converter/COLLADA2GLTF/CMakeLists.txt
+++ b/converter/COLLADA2GLTF/CMakeLists.txt
@@ -177,11 +177,16 @@ LIST(APPEND GLTF_SOURCES
     extensions/o3dgc-compression/GLTF-Open3DGC.h)
 endif()
 
-add_library(collada2gltfConvert SHARED ${GLTF_SOURCES})
-
-#Make sure the dll is in the same directory as the executable
-if (WIN32)
-    set_target_properties(collada2gltfConvert PROPERTIES RUNTIME_OUTPUT_DIRECTORY "bin")
+option(CONVERT_SHARED "CONVERT_SHARED" OFF)
+if (CONVERT_SHARED)
+    add_library(collada2gltfConvert SHARED ${GLTF_SOURCES})
+    #Make sure the dll is in the same directory as the executable
+    if (WIN32)
+        set_target_properties(collada2gltfConvert PROPERTIES RUNTIME_OUTPUT_DIRECTORY "bin")
+    endif()
+else()
+    add_library(collada2gltfConvert STATIC ${GLTF_SOURCES})
+    add_definitions(-DSTATIC_COLLADA2GLTF)
 endif()
 
 if (PNG_FOUND)

--- a/converter/COLLADA2GLTF/COLLADA2GLTFExport.h
+++ b/converter/COLLADA2GLTF/COLLADA2GLTFExport.h
@@ -27,6 +27,12 @@
 #ifndef __COLLADA2GLTFEXPORT_H__
 #define __COLLADA2GLTFEXPORT_H__
 
+#ifdef STATIC_COLLADA2GLTF
+
+#   define COLLADA2GLTF_EXPORT
+
+#else
+
 #	ifdef WIN32
 #		ifdef collada2gltfConvert_EXPORTS
 #			define COLLADA2GLTF_EXPORT __declspec(dllexport)  
@@ -36,5 +42,7 @@
 #	else
 #		define COLLADA2GLTF_EXPORT
 #	endif // WIN32
+
+#endif // STATIC_COLLADA2GLTF
 
 #endif


### PR DESCRIPTION
Fixes #314

By default the collada2gltfConvert project will created a static library by default. if you specify 

-DCONVERT_SHARED=ON

to cmake on the command line, then it will build the convert library as a shared library instead.
