### PR TITLE
Fixes issue that a 4 channel png automatically causes a transparent mesh

### DIFF
--- a/converter/COLLADA2GLTF/shaders/commonProfileShaders.cpp
+++ b/converter/COLLADA2GLTF/shaders/commonProfileShaders.cpp
@@ -117,7 +117,7 @@ namespace GLTF
                             for (int x = 0; (x < width) && !hasAlpha; x++) {
                                 png_bytep px = &(row[x * 4]);
                                 if (px[3] != 255) {
-                            hasAlpha =  true;
+                                    hasAlpha =  true;
                                 }
                             }
                         }


### PR DESCRIPTION
This was causing problems because opaque meshes were getting rendered transparent just because their png was 4 channels. We now check the alpha channels till we find a non-opaque pixel before we mark it as transparent.
