### PR TITLE
Fixed crash if there is an animation with no keyframes.

### DIFF
--- a/converter/COLLADA2GLTF/COLLADA2GLTFWriter.cpp
+++ b/converter/COLLADA2GLTF/COLLADA2GLTFWriter.cpp
@@ -1168,24 +1168,28 @@ namespace GLTF
 
             shared_ptr <GLTFAnimation> cvtAnimation = static_pointer_cast<GLTFAnimation>(animations->getObject(animationBindings[i].animation.toAscii()));
 
-            AnimationFlattenerForTargetUIDSharedPtr animationFlattenerMap = this->_asset->_flattenerMapsForAnimationID[cvtAnimation->getOriginalID()];
-            for (size_t j = 0 ; j < animatedTargets->size() ; j++) {
-                shared_ptr<JSONObject> animatedTarget = (*animatedTargets)[j];
-                shared_ptr<GLTFAnimationFlattener> animationFlattener;
-                std::string targetUID = animatedTarget->getString(kTarget);
-                if (animationFlattenerMap->count(targetUID) == 0) {
-                    //FIXME: assuming node here is wrong
-                    COLLADAFW::Node *node = (COLLADAFW::Node*)this->_asset->_uniqueIDToOpenCOLLADAObject[targetUID].get();
-                    animationFlattener = shared_ptr<GLTFAnimationFlattener> (new GLTFAnimationFlattener(node));
-                    (*animationFlattenerMap)[targetUID] = animationFlattener;
+            // Can be null if there are no keyframes
+            if (cvtAnimation)
+            {
+                AnimationFlattenerForTargetUIDSharedPtr animationFlattenerMap = this->_asset->_flattenerMapsForAnimationID[cvtAnimation->getOriginalID()];
+                for (size_t j = 0; j < animatedTargets->size(); j++) {
+                    shared_ptr<JSONObject> animatedTarget = (*animatedTargets)[j];
+                    shared_ptr<GLTFAnimationFlattener> animationFlattener;
+                    std::string targetUID = animatedTarget->getString(kTarget);
+                    if (animationFlattenerMap->count(targetUID) == 0) {
+                        //FIXME: assuming node here is wrong
+                        COLLADAFW::Node *node = (COLLADAFW::Node*)this->_asset->_uniqueIDToOpenCOLLADAObject[targetUID].get();
+                        animationFlattener = shared_ptr<GLTFAnimationFlattener>(new GLTFAnimationFlattener(node));
+                        (*animationFlattenerMap)[targetUID] = animationFlattener;
+                    }
                 }
-            }
 
-            cvtAnimation->registerAnimationFlatteners(animationFlattenerMap);
-            
-            if (!GLTF::writeAnimation(cvtAnimation, animationClass, animatedTargets, this->_asset.get())) {
-                //if an animation failed to convert, we don't want to keep track of it.
-                animations->removeValue(animationBindings[i].animation.toAscii());
+                cvtAnimation->registerAnimationFlatteners(animationFlattenerMap);
+
+                if (!GLTF::writeAnimation(cvtAnimation, animationClass, animatedTargets, this->_asset.get())) {
+                    //if an animation failed to convert, we don't want to keep track of it.
+                    animations->removeValue(animationBindings[i].animation.toAscii());
+                }
             }
         }
         

--- a/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -857,29 +857,34 @@ namespace GLTF
         for (size_t animationIndex = 0 ; animationIndex < animationsUIDs.size() ; animationIndex++) {
             std::string inputParameterName = "TIME";
             shared_ptr<GLTFAnimation> animation = static_pointer_cast<GLTFAnimation>(animations->getObject(animationsUIDs[animationIndex]));
-            shared_ptr<GLTFBufferView> timeBufferView = animation->getBufferViewForParameter(inputParameterName);
-            
-            if (animation->parameters()->contains(inputParameterName) == false) {
-                setupAndWriteAnimationParameter(animation.get(),
-                                                inputParameterName,
-                                                "FLOAT",
-                                                (unsigned char*)timeBufferView->getBufferDataByApplyingOffset(),
-                                                timeBufferView->getByteLength(), true,
-                                                this);
-            }
-            
-            std::vector<std::string> allTargets = animation->targets()->getAllKeys();
-            std::vector<GLTFAnimationFlattener*> flatteners;
-            for (size_t i = 0 ; i < allTargets.size() ; i++) {
-                std::string targetID = allTargets[i];
-                shared_ptr<GLTFAnimationFlattener> animationFlattener = animation->animationFlattenerForTargetUID(targetID);
-                if (std::find(flatteners.begin(), flatteners.end(), animationFlattener.get()) != flatteners.end()) {
-                    continue;
+
+            // Can be null if there are no keyframes
+            if (animation)
+            {
+                shared_ptr<GLTFBufferView> timeBufferView = animation->getBufferViewForParameter(inputParameterName);
+
+                if (animation->parameters()->contains(inputParameterName) == false) {
+                    setupAndWriteAnimationParameter(animation.get(),
+                        inputParameterName,
+                        "FLOAT",
+                        (unsigned char*)timeBufferView->getBufferDataByApplyingOffset(),
+                        timeBufferView->getByteLength(), true,
+                        this);
                 }
-                flatteners.push_back(animationFlattener.get());
-                animation->writeAnimationForTargetID(targetID, this);
+
+                std::vector<std::string> allTargets = animation->targets()->getAllKeys();
+                std::vector<GLTFAnimationFlattener*> flatteners;
+                for (size_t i = 0; i < allTargets.size(); i++) {
+                    std::string targetID = allTargets[i];
+                    shared_ptr<GLTFAnimationFlattener> animationFlattener = animation->animationFlattenerForTargetUID(targetID);
+                    if (std::find(flatteners.begin(), flatteners.end(), animationFlattener.get()) != flatteners.end()) {
+                        continue;
+                    }
+                    flatteners.push_back(animationFlattener.get());
+                    animation->writeAnimationForTargetID(targetID, this);
+                }
+                animations->setValue(animation->getID(), animation);
             }
-            animations->setValue(animation->getID(), animation);
             animations->removeValue(animationsUIDs[animationIndex]);
         }
         


### PR DESCRIPTION
I've ran into a few models that have animations with no keyframes. We correctly display a message about it but then we crash. We shouldn't crash.
