### PR TITLE
Added option to not combine all animations that target same node

### DIFF
--- a/converter/COLLADA2GLTF/COLLADA2GLTFWriter.cpp
+++ b/converter/COLLADA2GLTF/COLLADA2GLTFWriter.cpp
@@ -1046,7 +1046,7 @@ namespace GLTF
 			relPathFile = imageURI.getPathDir().substr(2) + imageURI.getPathFile();
 		}
         
-		if (_asset->getEmbedResources())
+        if (CONFIG_BOOL(_asset, "embedResources"))
 		{
 			COLLADABU::URI inputURI(_asset->getInputFilePath().c_str());
 			std::string imageFullPath = inputURI.getPathDir() + relPathFile;

--- a/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -151,7 +151,6 @@ namespace GLTF
     
 	GLTFAsset::GLTFAsset() :
         _isBundle(false),
-        _embedResources(false),
         _distanceScale(1.0)
     {
         this->_trackedResourcesPath = shared_ptr<JSONObject> (new JSONObject());
@@ -198,7 +197,7 @@ namespace GLTF
         if (this->_nameToOutputStream.count(streamName) == 0)
 		{
 			shared_ptr<GLTFOutputStream> outputStream;
-			if (_embedResources)
+            if (CONFIG_BOOL(this, "embedResources"))
 			{
 				outputStream = shared_ptr <GLTFOutputStream>(new GLTFOutputStream());
 			}
@@ -361,16 +360,6 @@ namespace GLTF
     std::string GLTFAsset::getInputFilePath() {
         return this->_inputFilePath;
     }
-
-	void GLTFAsset::setEmbedResources(bool embedResources)
-	{
-		this->_embedResources = embedResources;
-	}
-
-	bool GLTFAsset::getEmbedResources()
-	{
-		return this->_embedResources;
-	}
 
     void GLTFAsset::setDistanceScale(double distanceScale)
     {
@@ -1128,7 +1117,7 @@ namespace GLTF
         
         if (sharedBuffer->getByteLength() > 0) {
             
-            if (this->_embedResources == false) {
+            if (CONFIG_BOOL(this, "embedResources") == false) {
                 COLLADABU::URI uri(rawOutputStream->outputPath());
                 sharedBuffer->setString(kURI, COLLADABU::URI::uriEncode(uri.getPathFile()));
             } else {
@@ -1141,7 +1130,7 @@ namespace GLTF
         if (compressionBuffer->getByteLength() > 0) {
             std::string compressedBufferID = compressionOutputStream->id();
             buffersObject->setValue(compressedBufferID, compressionBuffer);
-            if (this->_embedResources == false) {
+            if (CONFIG_BOOL(this, "embedResources") == false) {
                 COLLADABU::URI uri(compressionOutputStream->outputPath());
                 compressionBuffer->setString(kURI, COLLADABU::URI::uriEncode(uri.getPathFile()));
             } else {

--- a/converter/COLLADA2GLTF/GLTF/GLTFAsset.h
+++ b/converter/COLLADA2GLTF/GLTF/GLTFAsset.h
@@ -96,9 +96,6 @@ namespace GLTF
         void setInputFilePath(const std::string& inputFilePath);
         std::string getInputFilePath();
 
-		void setEmbedResources(bool embedResources);
-		bool getEmbedResources();
-
         void setDistanceScale(double distanceScale);
         double getDistanceScale();
 
@@ -182,7 +179,6 @@ namespace GLTF
         size_t                          _geometryByteLength;
         size_t                          _animationByteLength;
         bool                            _isBundle;
-		bool							_embedResources;
         double                          _distanceScale;
 
         UniqueIDToJSONValue             _uniqueIDToJSONValue;

--- a/converter/COLLADA2GLTF/GLTF/GLTFConfig.cpp
+++ b/converter/COLLADA2GLTF/GLTF/GLTFConfig.cpp
@@ -62,6 +62,7 @@ namespace GLTF
         optionsRoot->setBool("outputConvertionMetaData", false);
         optionsRoot->setBool("verboseLogging", false);
 		optionsRoot->setBool("embedResources", false);
+        optionsRoot->setBool("noCombineAnimations", false);
         
         //create the path "extensions.Open3DGC.quantization" and set default for Open3DGC
         shared_ptr<JSONObject> extensions(new JSONObject());

--- a/converter/COLLADA2GLTF/convert/animationConverter.cpp
+++ b/converter/COLLADA2GLTF/convert/animationConverter.cpp
@@ -16,9 +16,11 @@ using namespace std;
 
 namespace GLTF
 {    
-    
 #define ANIMATIONFLATTENER_FOR_PATH_AND_TARGETID(path, targetID) std::string targetUIDWithPath = path+targetID;\
-    if (asset->_targetUIDWithPathToAnimationFlattener.count(targetUIDWithPath) > 0) {\
+    if (CONFIG_BOOL(asset, "noCombineAnimations")) {\
+        animationFlattener = cvtAnimation->animationFlattenerForTargetUID(targetID);\
+    }\
+    else if (asset->_targetUIDWithPathToAnimationFlattener.count(targetUIDWithPath) > 0) {\
         animationFlattener = asset->_targetUIDWithPathToAnimationFlattener[targetUIDWithPath];\
     } else {\
         animationFlattener = cvtAnimation->animationFlattenerForTargetUID(targetID);\

--- a/converter/COLLADA2GLTF/helpers/mathHelpers.cpp
+++ b/converter/COLLADA2GLTF/helpers/mathHelpers.cpp
@@ -167,8 +167,9 @@ namespace GLTF
         tr.setElement(2,3, 0);
         tr.setElement(3,3, 1);
         double tran[20];
+        memset(tran, 0, sizeof(tran));
         
-        if (!unmatrix(tr, tran)) {
+        if (!unmatrix(tr, tran) && (translation || rotation)) {
             printf("WARNING: matrix can't be decomposed \n");
         }
         

--- a/converter/COLLADA2GLTF/main.cpp
+++ b/converter/COLLADA2GLTF/main.cpp
@@ -85,7 +85,8 @@ static const OptionDescriptor options[] = {
     { "s",              no_argument,        "-s -> experimental mode"},
 	{ "h",              no_argument,        "-h -> help" },
 	{ "r",              no_argument,        "-r -> verbose logging" },
-	{ "e",				no_argument,		"-e -> embed all resources as Data URIs" }
+	{ "e",				no_argument,		"-e -> embed all resources as Data URIs" },
+    { "n",              no_argument,        "-n -> don't combine animations with the same target" }
 };
 
 static void buildOptions() {
@@ -227,8 +228,10 @@ static bool processArgs(int argc, char * const * argv, GLTF::GLTFAsset *asset) {
                
 			case 'e':
 				converterConfig->config()->setBool("embedResources", true);
-				asset->setEmbedResources(true);
 				break;
+            case 'n':
+                converterConfig->config()->setBool("noCombineAnimations", true);
+                break;
 			default:
                 shouldShowHelp = true;
 				break;

--- a/converter/COLLADA2GLTF/shaders/commonProfileShaders.cpp
+++ b/converter/COLLADA2GLTF/shaders/commonProfileShaders.cpp
@@ -344,7 +344,7 @@ namespace GLTF
             
             shadersObject->setValue(shaderId, shaderObject);
 			shaderObject->setUnsignedInt32(kType, type);
-			if (asset->getEmbedResources())
+            if (CONFIG_BOOL(asset, "embedResources"))
 			{
 				shaderObject->setString(kURI, create_dataUri(shaderString, "text/plain"));
 			}


### PR DESCRIPTION
Did a few things here:
1. Added -n option which doesn't combine animations of the same type with the same target node. We needed this for an aircraft that needed yaw, pitch and roll animations that were used individually.
2. Made embed resources just a config option so it fits with everything else.
3. Fixed decomposeMatrix to allow for a matrix that is scaled to 0. Useful in hiding things during an animation.
