### PR TITLE
Images weren't be checked for transparency

### DIFF
--- a/converter/COLLADA2GLTF/shaders/commonProfileShaders.cpp
+++ b/converter/COLLADA2GLTF/shaders/commonProfileShaders.cpp
@@ -215,9 +215,13 @@ namespace GLTF
                 if (images->contains(sourceUID)) {
                     shared_ptr<JSONObject> image = images->getObject(sourceUID);
                     std::string imagePath = image->getString(kURI);
-                    COLLADABU::URI inputURI(asset->getInputFilePath().c_str());
-                    std::string imageFullPath = inputURI.getPathDir() + imagePath;
-                    if (imageHasAlpha(imageFullPath.c_str()))
+                    if (!is_dataUri(imagePath))
+                    {
+                        COLLADABU::URI inputURI(asset->getInputFilePath().c_str());
+                        imagePath = inputURI.getPathDir() + imagePath;
+                    }
+
+                    if (imageHasAlpha(imagePath.c_str()))
                         return false;
                 } else {
                     static bool printedOnce = false;


### PR DESCRIPTION
Fixed issue where if the cwd isn't a models directory the parent path gets prepended to the texture data uri. This causes the png data to not be read and we set the blending flag incorrectly.