### PR TITLE
Fixed linux build.

### DIFF
--- a/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/converter/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -7,9 +7,9 @@
 #include "GLTFCleanupEvaluator.h"
 #include "geometryHelpers.h"
 #include "../shaders/commonProfileShaders.h"
+#include <GLTFOpenCOLLADAUtils.h>
 
 #if __cplusplus <= 199711L
-#include <GLTFOpenCOLLADAUtils.h>
 using namespace std::tr1;
 #endif
 using namespace std;


### PR DESCRIPTION
For some reason the include of `GLTFOpenCOLLADAUtils.h` was inside `#if __cplusplus <= 199711L`. I don't have a linux machine but I'm assuming this is the fix for the linux compile issue mentioned by @JHanley85 in #385.