### PR TITLE
Add schema reference doc to spec

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -2042,7 +2042,7 @@ The material appearance of a primitive.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**technique**|`string`|The id of the [technique](#reference-technique).|No|
+|**technique**|`string`|The id of the [`technique`](#reference-technique).|No|
 |**values**|`object`|A dictionary object of parameter values.|No, default: `{}`|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
@@ -2154,7 +2154,7 @@ Geometry to be rendered with the given material.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**attributes**|`object`|A dictionary object of strings, where each string is the id of the [accessor](#reference-accessor) containing an attribute.|No, default: `{}`|
+|**attributes**|`object`|A dictionary object of strings, where each string is the id of the [`accessor`](#reference-accessor) containing an attribute.|No, default: `{}`|
 |**indices**|`string`|The id of the accessor that contains the indices.|No|
 |**material**|`string`|The id of the material to apply to this primitive when rendering.| :white_check_mark: Yes|
 |**mode**|`integer`|The type of primitives to render.|No, default: `4`|
@@ -2226,10 +2226,10 @@ A node in the node hierarchy.  A node can have either the `camera`, `meshes`, or
 |**camera**|`string`|The id of the [camera](#reference-camera) referenced by this node.|No|
 |**children**|`string[]`|The ids of this node's children.|No, default: `[]`|
 |**skeletons**|`string[]`|The id of skeleton nodes.|No|
-|**skin**|`string`|The id of the [skin](#reference-skin) referenced by this node.|No|
+|**skin**|`string`|The id of the [`skin`](#reference-skin) referenced by this node.|No|
 |**jointName**|`string`|Name used when this node is a joint in a skin.|No|
 |**matrix**|`number[16]`|A floating-point 4x4 transformation matrix stored in column-major order.|No, default: `[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]`|
-|**meshes**|`string[]`|The ids of the [meshes](#reference-mesh) in this node.|No|
+|**meshes**|`string[]`|The ids of the [`mesh`es](#reference-mesh) in this node.|No|
 |**rotation**|`number[4]`|The node's unit quaternion rotation in the order (x, y, z, w) where w is the scalar.|No, default: `[0,0,0,0.1]`|
 |**scale**|`number[3]`|The node's non-uniform scale.|No, default: `[1,1,1]`|
 |**translation**|`number[3]`|The node's translation.|No, default: `[0,0,0]`|
@@ -2358,8 +2358,8 @@ A shader program, including its vertex and fragment shader, and names of vertex 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**attributes**|`string[]`|Names of GLSL vertex shader attributes.|No, default: `[]`|
-|**fragmentShader**|`string`|The id of the fragment [shader](#reference-shader).| :white_check_mark: Yes|
-|**vertexShader**|`string`|The id of the vertex [shader](#reference-shader).| :white_check_mark: Yes|
+|**fragmentShader**|`string`|The id of the fragment [`shader`](#reference-shader).| :white_check_mark: Yes|
+|**vertexShader**|`string`|The id of the vertex [`shader`](#reference-shader).| :white_check_mark: Yes|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
@@ -2380,7 +2380,7 @@ Names of GLSL vertex shader attributes.
 
 ### program.fragmentShader :white_check_mark: 
 
-The id of the fragment shader.
+The id of the fragment [`shader`](#reference-shader).
 
 * **Type**: `string`
 * **Required**: Yes
@@ -2388,7 +2388,7 @@ The id of the fragment shader.
 
 ### program.vertexShader :white_check_mark: 
 
-The id of the vertex shader.
+The id of the vertex [`shader`](#reference-shader).
 
 * **Type**: `string`
 * **Required**: Yes
@@ -2511,7 +2511,7 @@ The root nodes of a scene.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**nodes**|`string[]`|The ids of each root [node](#reference-node).|No, default: `[]`|
+|**nodes**|`string[]`|The ids of each root [`node`](#reference-node).|No, default: `[]`|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
@@ -2523,7 +2523,7 @@ Additional properties are not allowed.
 
 ### scene.nodes
 
-The ids of each root [node](#reference-node).
+The ids of each root [`node`](#reference-node).
 
 * **Type**: `string[]`
    * Each element in the array must be unique.
@@ -2724,8 +2724,102 @@ Application-specific data.
 <a name="reference-texture"></a>
 ## texture
 
+A texture and its [`sampler`](#reference-sampler).
+
+**Related WebGL functions**: `createTexture()`, `deleteTexture()`, `bindTexture()`, `texImage2D()`, and `texParameterf()`
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**format**|`integer`|The texture's format.|No, default: `6408`|
+|**internalFormat**|`integer`|The texture's internal format.|No, default: `6408`|
+|**sampler**|`string`|The id of the [`sampler`](#reference-sampler) used by this texture.| :white_check_mark: Yes|
+|**source**|`string`|The id of the [`image`](#reference-image) used by this texture.| :white_check_mark: Yes|
+|**target**|`integer`|The target that the WebGL texture should be bound to.|No, default: `3553`|
+|**type**|`integer`|Texel datatype.|No, default: `5121`|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [texture.schema.json](schema/texture.schema.json)
 * **Example**: [textures.json](schema/examples/textures.json)
+
+### texture.format
+
+The texture's format.  Valid values correspond to WebGL enums: `6406` (ALPHA), `6407` (RGB), `6408` (RGBA), `6409` (LUMINANCE), and `6410` (LUMINANCE_ALPHA).
+
+* **Type**: `integer`
+* **Required**: No, default: `6408`
+* **Allowed values**: `6406`, `6407`, `6408`, `6409`, `6410`
+* **Related WebGL functions**: `texImage2D()` format parameter
+
+### texture.internalFormat
+
+The texture's internal format.  Valid values correspond to WebGL enums: `6406` (ALPHA), `6407` (RGB), `6408` (RGBA), `6409` (LUMINANCE), and `6410` (LUMINANCE_ALPHA).  Defaults to same value as format.
+
+* **Type**: `integer`
+* **Required**: No, default: `6408`
+* **Allowed values**: `6406`, `6407`, `6408`, `6409`, `6410`
+* **Related WebGL functions**: `texImage2D()` internalFormat parameter
+
+### texture.sampler :white_check_mark: 
+
+The id of the [`sampler`](#reference-sampler) used by this texture.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### texture.source :white_check_mark: 
+
+The id of the [`image`](#reference-image) used by this texture.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### texture.target
+
+The target that the WebGL texture should be bound to.  Valid values correspond to WebGL enums: `3553` (TEXTURE_2D).
+
+* **Type**: `integer`
+* **Required**: No, default: `3553`
+* **Allowed values**: `3553`
+* **Related WebGL functions**: `bindTexture()`
+
+### texture.type
+
+Texel datatype.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `33635` (UNSIGNED_SHORT_5_6_5), `32819` (UNSIGNED_SHORT_4_4_4_4), and `32820` (UNSIGNED_SHORT_5_5_5_1).
+
+* **Type**: `integer`
+* **Required**: No, default: `5121`
+* **Allowed values**: `5121`, `33635`, `32819`, `32820`
+* **Related WebGL functions**: `texImage2D()` type parameter
+
+### texture.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### texture.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### texture.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <a name="conformance"></a>

--- a/specification/README.md
+++ b/specification/README.md
@@ -1150,6 +1150,8 @@ For more information on glTF extensions, consult the [extensions registry specif
    * [uniform](#reference-technique.uniform)
 * [texture](#reference-texture)
 
+
+<!-- ======================================================================= -->
 <a name="reference-accessor"></a>
 ## accessor
 
@@ -1264,176 +1266,325 @@ Application-specific data.
 * **Required**: No
 
 
+<!-- ======================================================================= -->
 <a name="reference-animation"></a>
 ## animation
 
 * **JSON schema**: [animation.schema.json](schema/animation.schema.json)
 * **Example**: [animations.json](schema/examples/animations.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-animation.channel"></a>
 ## animation.channel
 
+Targets an animation's sampler at a node's property.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**sampler**|`string`|The id of a sampler in this animation to use to compute the value for the target.| :white_check_mark: Yes|
+|**target**|`[animation.channel.target](#reference-animation.channel.target)`|The id of the node and TRS property to target.| :white_check_mark: Yes|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 **JSON schema**: [animation.channel.schema.json](schema/animation.channel.schema.json)
 
+### channel.sampler :white_check_mark: 
+
+The id of a sampler in this animation to use to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS).
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### channel.target :white_check_mark: 
+
+The id of the node and TRS property to target.
+
+* **Type**: `[animation.channel.target](#reference-animation.channel.target)`
+* **Required**: Yes
+
+### channel.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### channel.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
+
+
+<!-- ======================================================================= -->
 <a name="reference-animation.channel.target"></a>
 ## animation.channel.target
 
+The id of the node and TRS property that an animation channel targets.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**id**|`string`|The id of the node to target.| :white_check_mark: Yes|
+|**path**|`string`|The name of the node's TRS property to modify.| :white_check_mark: Yes|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 **JSON schema**: [animation.channel.target.schema.json](schema/animation.channel.target.schema.json)
 
+### target.id :white_check_mark: 
+
+The id of the node to target.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### target.path :white_check_mark: 
+
+The name of the node's TRS property to modify.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**: `"translation"`, `"rotation"`, `"scale"`
+
+### target.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### target.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
+
+
+<!-- ======================================================================= -->
 <a name="reference-animation.parameter"></a>
 ## animation.parameter
 
 **JSON schema**: [animation.parameter.schema.json](schema/animation.parameter.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-animation.sampler"></a>
 ## animation.sampler
 
 **JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-asset"></a>
 ## asset
 
 * **JSON schema**: [asset.schema.json](schema/asset.schema.json)
 * **Example**: [asset.json](schema/examples/asset.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-asset.profile"></a>
 ## asset.profile
 
 **JSON schema**: [asset.profile.schema.json](schema/asset.profile.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-buffer"></a>
 ## buffer
 
 * **JSON schema**: [buffer.schema.json](schema/buffer.schema.json)
 * **Example**: [buffers.json](schema/examples/buffers.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-bufferView"></a>
 ## bufferView
 
 * **JSON schema**: [bufferView.schema.json](schema/bufferView.schema.json)
 * **Example**: [bufferViews.json](schema/examples/bufferViews.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-camera"></a>
 ## camera
 
 * **JSON schema**: [camera.schema.json](schema/camera.schema.json)
 * **Example**: [cameras.json](schema/examples/cameras.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-camera.orthographic"></a>
 ## camera.orthographic
 
 **JSON schema**: [camera.orthographic.schema.json](schema/camera.orthographic.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-camera.perspective"></a>
 ## camera.perspective
 
 **JSON schema**: [camera.perspective.schema.json](schema/camera.perspective.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-glTF"></a>
 ## glTF
 
 **JSON schema**: [glTF.schema.json](schema/glTF.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-image"></a>
 ## image
 
 * **JSON schema**: [image.schema.json](schema/image.schema.json)
 * **Example**: [images.json](schema/examples/images.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-material"></a>
 ## material
 
 * **JSON schema**: [material.schema.json](schema/material.schema.json)
 * **Example**: [materials.json](schema/examples/materials.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-material.values"></a>
 ## material.values
 
 **JSON schema**: [material.values.schema.json](schema/material.values.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-mesh"></a>
 ## mesh
 
 * **JSON schema**: [mesh.schema.json](schema/mesh.schema.json)
 * **Example**: [meshes.json](schema/examples/meshes.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-mesh.primitive"></a>
 ## mesh.primitive
 
 **JSON schema**: [mesh.primitive.schema.json](schema/mesh.primitive.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-mesh.primitive.attribute"></a>
 ## mesh.primitive.attribute
 
 **JSON schema**: [mesh.primitive.attribute.schema.json](schema/mesh.primitive.attribute.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-node"></a>
 ## node
 
 * **JSON schema**: [node.schema.json](schema/node.schema.json)
 * **Example**: [nodes.json](schema/examples/nodes.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-program"></a>
 ## program
 
 * **JSON schema**: [program.schema.json](schema/program.schema.json)
 * **Example**: [programs.json](schema/examples/programs.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-sampler"></a>
 ## sampler
 
 * **JSON schema**: [sampler.schema.json](schema/sampler.schema.json)
 * **Example**: [samplers.json](schema/examples/samplers.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-scene"></a>
 ## scene
 
 * **JSON schema**: [scene.schema.json](schema/scene.schema.json)
 * **Example**: [scenes.json](schema/examples/scenes.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-shader"></a>
 ## shader
 
 * **JSON schema**: [shader.schema.json](schema/shader.schema.json)
 * **Example**: [shaders.json](schema/examples/shaders.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-skin"></a>
 ## skin
 
 * **JSON schema**: [skin.schema.json](schema/skin.schema.json)
 * **Example**: [skins.json](schema/examples/skins.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-technique"></a>
 ## technique
 
 * **JSON schema**: [technique.schema.json](schema/technique.schema.json)
 * **Example**: [techniques.json](schema/examples/techniques.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-technique.attribute"></a>
 ## technique.attribute
 
 **JSON schema**: [technique.attribute.schema.json](schema/technique.attribute.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-technique.parameters"></a>
 ## technique.parameters
 
 **JSON schema**: [technique.parameters.schema.json](schema/technique.parameters.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-technique.states"></a>
 ## technique.states
 
 **JSON schema**: [technique.states.schema.json](schema/technique.states.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-technique.uniform"></a>
 ## technique.uniform
 
 **JSON schema**: [technique.uniform.schema.json](schema/technique.uniform.schema.json)
 
+
+<!-- ======================================================================= -->
 <a name="reference-texture"></a>
 ## texture
 
 * **JSON schema**: [texture.schema.json](schema/texture.schema.json)
 * **Example**: [textures.json](schema/examples/textures.json)
+
 
 <a name="binarytypes"></a>
 # Binary Types Reference

--- a/specification/README.md
+++ b/specification/README.md
@@ -1386,7 +1386,60 @@ Application-specific data.
 <a name="reference-animation.sampler"></a>
 ## animation.sampler
 
+Combines input and output parameters with an interpolation algorithm to define a keyframe graph (but not its target).
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**input**|`string`|The id of a parameter in this animation to use as keyframe input, e.g., time.| :white_check_mark: Yes|
+|**interpolation**|`string`|Interpolation algorithm.|No, default: `"LINEAR"`|
+|**output**|`string`|The id of a parameter in this animation to use as keyframe output.| :white_check_mark: Yes|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 **JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
+
+### sampler.input :white_check_mark: 
+
+The id of a parameter in this animation to use as keyframe input.  This parameter must have type `FLOAT`.  The values represent time in seconds with `time[0] >= 0.0`, and monotonically increasing values, i.e. `time[n + 1] >= time[n]`.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### sampler.interpolation
+
+Interpolation algorithm.  When an animation targets a node's rotation and the animation's interpolation is `"LINEAR"`, spherical linear interpolation (slerp) should be used to interpolate quaternions.
+
+* **Type**: `string`
+* **Required**: No, default: `"LINEAR"`
+* **Allowed values**: `"LINEAR"`
+
+### sampler.output :white_check_mark: 
+
+The id of a parameter in this animation to use as keyframe output.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### sampler.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### sampler.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -2215,9 +2215,10 @@ Application-specific data.
 <a name="acknowledgements"></a>
 # Acknowledgments
 
-* Brandon Jones, Google
+* Sarah Chow, Cesium
 * Tom Fili, Cesium
 * Scott Hunter, Analytical Graphics, Inc.
+* Brandon Jones, Google
 * Ed Mackey, Analytical Graphics, Inc.
 
 <a name="references"></a>

--- a/specification/README.md
+++ b/specification/README.md
@@ -1285,7 +1285,7 @@ Targets an animation's sampler at a node's property.
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**sampler**|`string`|The id of a sampler in this animation to use to compute the value for the target.| :white_check_mark: Yes|
-|**target**|`[animation.channel.target](#reference-animation.channel.target)`|The id of the node and TRS property to target.| :white_check_mark: Yes|
+|**target**|[`animation.channel.target`](#reference-animation.channel.target)|The id of the node and TRS property to target.| :white_check_mark: Yes|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
 
@@ -1305,7 +1305,7 @@ The id of a sampler in this animation to use to compute the value for the target
 
 The id of the node and TRS property to target.
 
-* **Type**: `[animation.channel.target](#reference-animation.channel.target)`
+* **Type**: [`animation.channel.target`](#reference-animation.channel.target)
 * **Required**: Yes
 
 ### channel.extensions

--- a/specification/README.md
+++ b/specification/README.md
@@ -1153,117 +1153,117 @@ For more information on glTF extensions, consult the [extensions registry specif
 <a name="reference-accessor"></a>
 ## accessor
 
-    A typed view into a [bufferView](#reference-bufferView).  A bufferView contain raw binary data.  An accessors provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.
+A typed view into a [bufferView](#reference-bufferView).  A bufferView contain raw binary data.  An accessors provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.
 
-    **Type**: `object`
+**Type**: `object`
 
-    **Properties**
+**Properties**
 
-    |   |Type|Description|Required|
-    |---|----|-----------|--------|
-    |**bufferView**|`string`|The id of the bufferView.| :white_check_mark: Yes|
-    |**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes.| :white_check_mark: Yes|
-    |**byteStride**|`integer`|The stride, in bytes, between attributes referenced by this accessor.|No, default: `0`|
-    |**componentType**|`integer`|The datatype of components in the attribute.| :white_check_mark: Yes|
-    |**count**|`integer`|The number of attributes referenced by this accessor.| :white_check_mark: Yes|
-    |**type**|`string`|Specifies if the attribute is a scalar, vector, or matrix.| :white_check_mark: Yes|
-    |**max**|`number[1-16]`|Maximum value of each component in this attribute.|No|
-    |**min**|`number[1-16]`|Minimum value of each component in this attribute.|No|
-    |**name**|`string`|The user-defined name of this object.|No|
-    |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-    |**extras**|`any`|Application-specific data.|No|
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**bufferView**|`string`|The id of the bufferView.| :white_check_mark: Yes|
+|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes.| :white_check_mark: Yes|
+|**byteStride**|`integer`|The stride, in bytes, between attributes referenced by this accessor.|No, default: `0`|
+|**componentType**|`integer`|The datatype of components in the attribute.| :white_check_mark: Yes|
+|**count**|`integer`|The number of attributes referenced by this accessor.| :white_check_mark: Yes|
+|**type**|`string`|Specifies if the attribute is a scalar, vector, or matrix.| :white_check_mark: Yes|
+|**max**|`number[1-16]`|Maximum value of each component in this attribute.|No|
+|**min**|`number[1-16]`|Minimum value of each component in this attribute.|No|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
 
-    Additional properties are not allowed.
+Additional properties are not allowed.
 
-    * **JSON schema**: [accessor.schema.json](schema/accessor.schema.json)
-    * **Example**: [accessors.json](schema/examples/accessors.json)
+* **JSON schema**: [accessor.schema.json](schema/accessor.schema.json)
+* **Example**: [accessors.json](schema/examples/accessors.json)
 
-    ### accessor.bufferView :white_check_mark: 
+### accessor.bufferView :white_check_mark: 
 
-    The id of the bufferView.
+The id of the bufferView.
 
-    * **Type**: `string`
-    * **Required**: Yes
-    * **Minimum Length**`: >= 1`
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
 
-    ### accessor.byteOffset :white_check_mark: 
+### accessor.byteOffset :white_check_mark: 
 
-    The offset relative to the start of the bufferView in bytes.  This must be a multiple of the size of the data type.
+The offset relative to the start of the bufferView in bytes.  This must be a multiple of the size of the data type.
 
-    * **Type**: `integer`
-    * **Required**: Yes
-    * **Minimum**:` >= 0`
-    * **Related WebGL functions**: `vertexAttribPointer()` offset parameter
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**:` >= 0`
+* **Related WebGL functions**: `vertexAttribPointer()` offset parameter
 
-    ### accessor.byteStride
+### accessor.byteStride
 
-    The stride, in bytes, between attributes referenced by this accessor.  When this is zero, the attributes are tightly packed.
+The stride, in bytes, between attributes referenced by this accessor.  When this is zero, the attributes are tightly packed.
 
-    * **Type**: `integer`
-    * **Required**: No, default: `0`
-    * **Minimum**:` >= 0`
-    * **Maximum**:` <= 255`
-    * **Related WebGL functions**: `vertexAttribPointer()` stride parameter
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**:` >= 0`
+* **Maximum**:` <= 255`
+* **Related WebGL functions**: `vertexAttribPointer()` stride parameter
 
-    ### accessor.componentType :white_check_mark: 
+### accessor.componentType :white_check_mark: 
 
-    The datatype of components in the attribute.  Valid values correspond to WebGL enums: `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), and `5126` (FLOAT).  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, and `Float32Array`, respectively.
+The datatype of components in the attribute.  Valid values correspond to WebGL enums: `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), and `5126` (FLOAT).  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, and `Float32Array`, respectively.
 
-    * **Type**: `integer`
-    * **Required**: Yes
-    * **Allowed values**: `5120`, `5121`, `5122`, `5123`, `5126`
+* **Type**: `integer`
+* **Required**: Yes
+* **Allowed values**: `5120`, `5121`, `5122`, `5123`, `5126`
 
-    ### accessor.count :white_check_mark: 
+### accessor.count :white_check_mark: 
 
-    The number of attributes referenced by this accessor, not to be confused with the number of bytes or number of components.
+The number of attributes referenced by this accessor, not to be confused with the number of bytes or number of components.
 
-    * **Type**: `integer`
-    * **Required**: Yes
-    * **Minimum**:` >= 1`
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**:` >= 1`
 
-    ### accessor.type :white_check_mark: 
+### accessor.type :white_check_mark: 
 
-    Specifies if the attribute is a scalar, vector, or matrix, and the number of elements in the vector or matrix.
+Specifies if the attribute is a scalar, vector, or matrix, and the number of elements in the vector or matrix.
 
-    * **Type**: `string`
-    * **Required**: Yes
-    * **Allowed values**: `"SCALAR"`, `"VEC2"`, `"VEC3"`, `"VEC4"`, `"MAT2"`, `"MAT3"`, `"MAT4"`
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**: `"SCALAR"`, `"VEC2"`, `"VEC3"`, `"VEC4"`, `"MAT2"`, `"MAT3"`, `"MAT4"`
 
-    ### accessor.max
+### accessor.max
 
-    Maximum value of each component in this attribute.  When both min and max arrays are defined, they have the same length.  The length is determined by the value of the type property.
+Maximum value of each component in this attribute.  When both min and max arrays are defined, they have the same length.  The length is determined by the value of the type property.
 
-    * **Type**: `number[1-16]`
-    * **Required**: No
+* **Type**: `number[1-16]`
+* **Required**: No
 
-    ### accessor.min
+### accessor.min
 
-    Minimum value of each component in this attribute.  When both min and max arrays are defined, they have the same length.  The length is determined by the value of the type property.
+Minimum value of each component in this attribute.  When both min and max arrays are defined, they have the same length.  The length is determined by the value of the type property.
 
-    * **Type**: `number[1-16]`
-    * **Required**: No
+* **Type**: `number[1-16]`
+* **Required**: No
 
-    ### accessor.name
+### accessor.name
 
-    The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
 
-    * **Type**: `string`
-    * **Required**: No
+* **Type**: `string`
+* **Required**: No
 
-    ### accessor.extensions
+### accessor.extensions
 
-    Dictionary object with extension-specific objects.
+Dictionary object with extension-specific objects.
 
-    * **Type**: `object`
-    * **Required**: No
-    * **Type of each property**: `object`
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
 
-    ### accessor.extras
+### accessor.extras
 
-    Application-specific data.
+Application-specific data.
 
-    * **Type**: `any`
-    * **Required**: No
+* **Type**: `any`
+* **Required**: No
 
 
 <a name="reference-animation"></a>

--- a/specification/README.md
+++ b/specification/README.md
@@ -1108,48 +1108,48 @@ For more information on glTF extensions, consult the [extensions registry specif
 <a name="properties"></a>
 # Properties Reference
 
-* [accessor](#reference-accessor)
-* [animation](#reference-animation)
-   * [channel](#reference-animation.channel)
-      * [target](#reference-animation.channel.target)
-   * [sampler](#reference-animation.sampler)
-* [asset](#reference-asset)
-   * [profile](#reference-asset.profile)
-* [buffer](#reference-buffer)
-* [bufferView](#reference-bufferView)
-* [camera](#reference-camera)
-   * [orthographic](#reference-camera.orthographic)
-   * [perspective](#reference-camera.perspective)
-* [glTF](#reference-glTF) (root object for an asset)
-* [image](#reference-image)
-* [material](#reference-material)
-* [mesh](#reference-mesh)
-   * [primitive](#reference-mesh.primitive)
-* [node](#reference-node)
-* [program](#reference-program)
-* [sampler](#reference-sampler)
-* [scene](#reference-scene)
-* [shader](#reference-shader)
-* [skin](#reference-skin)
-* [technique](#reference-technique)
-   * [parameters](#reference-technique.parameters)
-   * [states](#reference-technique.states)
-      * [functions](#reference-technique.states.functions)
-* [texture](#reference-texture)
+* [`accessor`](#reference-accessor)
+* [`animation`](#reference-animation)
+   * [`channel`](#reference-animation.channel)
+      * [`target`](#reference-animation.channel.target)
+   * [`sampler`](#reference-animation.sampler)
+* [`asset`](#reference-asset)
+   * [`profile`](#reference-asset.profile)
+* [`buffer`](#reference-buffer)
+* [`bufferView`](#reference-bufferView)
+* [`camera`](#reference-camera)
+   * [`orthographic`](#reference-camera.orthographic)
+   * [`perspective`](#reference-camera.perspective)
+* [`glTF`](#reference-glTF) (root object for an asset)
+* [`image`](#reference-image)
+* [`material`](#reference-material)
+* [`mesh`](#reference-mesh)
+   * [`primitive`](#reference-mesh.primitive)
+* [`node`](#reference-node)
+* [`program`](#reference-program)
+* [`sampler`](#reference-sampler)
+* [`scene`](#reference-scene)
+* [`shader`](#reference-shader)
+* [`skin`](#reference-skin)
+* [`technique`](#reference-technique)
+   * [`parameters`](#reference-technique.parameters)
+   * [`states`](#reference-technique.states)
+      * [`functions`](#reference-technique.states.functions)
+* [`texture`](#reference-texture)
 
 
 <!-- ======================================================================= -->
 <a name="reference-accessor"></a>
 ## accessor
 
-A typed view into a [bufferView](#reference-bufferView).  A bufferView contain raw binary data.  An accessors provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.
+A typed view into a [`bufferView`](#reference-bufferView).  A bufferView contain raw binary data.  An accessors provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.
 
 **Properties**
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**bufferView**|`string`|The id of the bufferView.| :white_check_mark: Yes|
-|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes.| :white_check_mark: Yes|
+|**bufferView**|`string`|The id of the [`bufferView`](#reference-bufferView).| :white_check_mark: Yes|
+|**byteOffset**|`integer`|The offset relative to the start of the [`bufferView`](#reference-bufferView) in bytes.| :white_check_mark: Yes|
 |**byteStride**|`integer`|The stride, in bytes, between attributes referenced by this accessor.|No, default: `0`|
 |**componentType**|`integer`|The datatype of components in the attribute.| :white_check_mark: Yes|
 |**count**|`integer`|The number of attributes referenced by this accessor.| :white_check_mark: Yes|
@@ -1167,7 +1167,7 @@ Additional properties are not allowed.
 
 ### accessor.bufferView :white_check_mark: 
 
-The id of the bufferView.
+The id of the [`bufferView`](#reference-bufferView).
 
 * **Type**: `string`
 * **Required**: Yes
@@ -1175,7 +1175,7 @@ The id of the bufferView.
 
 ### accessor.byteOffset :white_check_mark: 
 
-The offset relative to the start of the bufferView in bytes.  This must be a multiple of the size of the data type.
+The offset relative to the start of the [`bufferView`](#reference-bufferView) in bytes.  This must be a multiple of the size of the data type.
 
 * **Type**: `integer`
 * **Required**: Yes
@@ -1319,8 +1319,6 @@ Application-specific data.
 
 * **Type**: `any`
 * **Required**: No
-
-
 
 
 <!-- ======================================================================= -->
@@ -1681,14 +1679,14 @@ Application-specific data.
 <a name="reference-bufferView"></a>
 ## bufferView
 
-A view into a [buffer](#reference-buffer) generally representing a subset of the buffer.
+A view into a [`buffer`](#reference-buffer) generally representing a subset of the buffer.
 
 **Properties**
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**buffer**|`string`|The id of the buffer.| :white_check_mark: Yes|
-|**byteOffset**|`integer`|The offset into the buffer in bytes.| :white_check_mark: Yes|
+|**buffer**|`string`|The id of the [`buffer`](#reference-buffer).| :white_check_mark: Yes|
+|**byteOffset**|`integer`|The offset into the [`buffer`](#reference-buffer) in bytes.| :white_check_mark: Yes|
 |**byteLength**|`integer`|The length of the bufferView in bytes.|No, default: `0`|
 |**target**|`integer`|The target that the WebGL buffer should be bound to.|No|
 |**name**|`string`|The user-defined name of this object.|No|
@@ -1702,7 +1700,7 @@ Additional properties are not allowed.
 
 ### bufferView.buffer :white_check_mark: 
 
-The id of the buffer.
+The id of the [`buffer`](#reference-buffer).
 
 * **Type**: `string`
 * **Required**: Yes
@@ -1710,7 +1708,7 @@ The id of the buffer.
 
 ### bufferView.byteOffset :white_check_mark: 
 
-The offset into the buffer in bytes.
+The offset into the [`buffer`](#reference-buffer) in bytes.
 
 * **Type**: `integer`
 * **Required**: Yes
@@ -2303,7 +2301,7 @@ An array of primitives, each defining geometry to be rendered with a material.
 
 ### mesh.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a mesh and a buffer could have the same name, or two meshes could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -2405,13 +2403,13 @@ A node in the node hierarchy.  A node can have either the `camera`, `meshes`, or
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**camera**|`string`|The id of the [camera](#reference-camera) referenced by this node.|No|
+|**camera**|`string`|The id of the [`camera`](#reference-camera) referenced by this node.|No|
 |**children**|`string[]`|The ids of this node's children.|No, default: `[]`|
 |**skeletons**|`string[]`|The id of skeleton nodes.|No|
 |**skin**|`string`|The id of the [`skin`](#reference-skin) referenced by this node.|No|
 |**jointName**|`string`|Name used when this node is a joint in a skin.|No|
 |**matrix**|`number[16]`|A floating-point 4x4 transformation matrix stored in column-major order.|No, default: `[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]`|
-|**meshes**|`string[]`|The ids of the [`mesh`es](#reference-mesh) in this node.|No|
+|**meshes**|`string[]`|The ids of the [`mesh`](#reference-mesh) objects in this node.|No|
 |**rotation**|`number[4]`|The node's unit quaternion rotation in the order (x, y, z, w) where w is the scalar.|No, default: `[0,0,0,0.1]`|
 |**scale**|`number[3]`|The node's non-uniform scale.|No, default: `[1,1,1]`|
 |**translation**|`number[3]`|The node's translation.|No, default: `[0,0,0]`|
@@ -2506,7 +2504,7 @@ The node's translation.
 
 ### node.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a node and a buffer could have the same name, or two nodes could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -2578,7 +2576,7 @@ The id of the vertex [`shader`](#reference-shader).
 
 ### program.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a program and a buffer could have the same name, or two programs could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -2662,7 +2660,7 @@ t wrapping mode.  Valid values correspond to WebGL enums: `33071` (CLAMP_TO_EDGE
 
 ### sampler.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a sampler and a buffer could have the same name, or two samplers could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -2714,7 +2712,7 @@ The ids of each root [`node`](#reference-node).
 
 ### scene.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a scene and a buffer could have the same name, or two scenes could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -2776,7 +2774,7 @@ The shader stage.  Allowed values are `35632` (FRAGMENT_SHADER) and `35633` (VER
 
 ### shader.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a shader and a buffer could have the same name, or two shaders could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -2845,7 +2843,7 @@ Joint names of the joints (nodes with a `jointName` property) in this skin.  The
 
 ### skin.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a skin and a buffer could have the same name, or two skins could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -2931,7 +2929,7 @@ Fixed-function rendering states.
 
 ### technique.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a technique and a buffer could have the same name, or two techniques could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -3299,7 +3297,7 @@ Texel datatype.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE),
 
 ### texture.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a texture and a buffer could have the same name, or two textures could even have the same name.
 
 * **Type**: `string`
 * **Required**: No

--- a/specification/README.md
+++ b/specification/README.md
@@ -2995,9 +2995,149 @@ Application-specific data.
 
 <!-- ======================================================================= -->
 <a name="reference-technique.states.functions"></a>
-## technique.states.functions
+## functions
+
+Arguments for fixed-function rendering state functions other than `enable()`/`disable()`.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**blendColor**|`number[4]`|Floating-point values passed to `blendColor()`. [red, green, blue, alpha]|No, default: `[0,0,0,0]`|
+|**blendEquationSeparate**|`integer[2]`|Integer values passed to `blendEquationSeparate()`.|No, default: `[32774,32774]`|
+|**blendFuncSeparate**|`integer[4]`|Integer values passed to `blendFuncSeparate()`.|No, default: `[1,1,0,0]`|
+|**colorMask**|`boolean[4]`|Boolean values passed to `colorMask()`. [red, green, blue, alpha].|No, default: `[true,true,true,true]`|
+|**cullFace**|`integer[1]`|Integer value passed to `cullFace()`.|No, default: `[1029]`|
+|**depthFunc**|`integer[1]`|Integer values passed to depthFunc().|No, default: `[513]`|
+|**depthMask**|`boolean[1]`|Boolean value passed to `depthMask()`.|No, default: `[true]`|
+|**depthRange**|`number[2]`|Floating-point values passed to `depthRange()`. [zNear, zFar]|No, default: `[0,1]`|
+|**frontFace**|`integer[1]`|Integer value passed to `frontFace()`.|No, default: `[2305]`|
+|**lineWidth**|`number[1]`|Floating-point value passed to `lineWidth()`.|No, default: `[1]`|
+|**polygonOffset**|`number[2]`|Floating-point value passed to `polygonOffset()`.  [factor, units]|No, default: `[0,0]`|
+|**scissor**|`number[4]`|Floating-point value passed to `scissor()`.  [x, y, width, height].|No, default: `[0,0,0,0]`|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
 
 **JSON schema**: [technique.states.functions.schema.json](schema/technique.states.functions.schema.json)
+
+### functions.blendColor
+
+Floating-point values passed to `blendColor()`. [red, green, blue, alpha]
+
+* **Type**: `number[4]`
+* **Required**: No, default: `[0,0,0,0]`
+* **Related WebGL functions**: `blendColor()`
+
+### functions.blendEquationSeparate
+
+Integer values passed to `blendEquationSeparate()`. [rgb, alpha]. Valid values correspond to WebGL enums: `32774` (FUNC_ADD), `32778` (FUNC_SUBTRACT), and `32779` (FUNC_REVERSE_SUBTRACT).
+
+* **Type**: `integer[2]`
+   * Each element in the array must be one of the following values: `32774`, `32778`, `32779`.
+* **Required**: No, default: `[32774,32774]`
+* **Related WebGL functions**: `blendEquationSeparate()`
+
+### functions.blendFuncSeparate
+
+Integer values passed to `blendFuncSeparate()`. [srcRGB, srcAlpha, dstRGB, dstAlpha]. Valid values correspond to WebGL enums: `0` (ZERO), `1` (ONE), `768` (SRC_COLOR), `769` (ONE_MINUS_SRC_COLOR), `774` (DST_COLOR), `775` (ONE_MINUS_DST_COLOR), `770` (SRC_ALPHA), `771` (ONE_MINUS_SRC_ALPHA), `772` (DST_ALPHA), `773` (ONE_MINUS_DST_ALPHA), `32769` (CONSTANT_COLOR), `32770` (ONE_MINUS_CONSTANT_COLOR), `32771` (CONSTANT_ALPHA), `32772` (ONE_MINUS_CONSTANT_ALPHA), and `776` (SRC_ALPHA_SATURATE).
+
+* **Type**: `integer[4]`
+   * Each element in the array must be one of the following values: `0`, `1`, `768`, `769`, `774`, `775`, `770`, `771`, `772`, `773`, `32769`, `32770`, `32771`, `32772`, `776`.
+* **Required**: No, default: `[1,1,0,0]`
+* **Related WebGL functions**: `blendFuncSeparate()`
+
+### functions.colorMask
+
+Boolean values passed to `colorMask()`. [red, green, blue, alpha].
+
+* **Type**: `boolean[4]`
+* **Required**: No, default: `[true,true,true,true]`
+* **Related WebGL functions**: `colorMask()`
+
+### functions.cullFace
+
+Integer value passed to `cullFace()`. Valid values correspond to WebGL enums: `1028` (FRONT), `1029` (BACK), and `1032` (FRONT_AND_BACK).
+
+* **Type**: `integer[1]`
+   * Each element in the array must be one of the following values: `1028`, `1029`, `1032`.
+* **Required**: No, default: `[1029]`
+* **Related WebGL functions**: `cullFace()`
+
+### functions.depthFunc
+
+Integer values passed to depthFunc(). Valid values correspond to WebGL enums: `512` (NEVER), `513` (LESS), `515` (LEQUAL), `514` (EQUAL), `516` (GREATER), `517` (NOTEQUAL), `518` (GEQUAL), and `519` (ALWAYS).
+
+* **Type**: `integer[1]`
+   * Each element in the array must be one of the following values: `512`, `513`, `515`, `514`, `516`, `517`, `518`, `519`.
+* **Required**: No, default: `[513]`
+* **Related WebGL functions**: `depthFunc()`
+
+### functions.depthMask
+
+Boolean value passed to `depthMask()`.
+
+* **Type**: `boolean[1]`
+* **Required**: No, default: `[true]`
+* **Related WebGL functions**: `depthMask()`
+
+### functions.depthRange
+
+Floating-point values passed to `depthRange()`. [zNear, zFar]
+
+* **Type**: `number[2]`
+* **Required**: No, default: `[0,1]`
+* **Related WebGL functions**: `depthRange()`
+
+### functions.frontFace
+
+Integer value passed to frontFace().  Valid values correspond to WebGL enums: `2304` (CW) and `2305` (CCW).
+
+* **Type**: `integer[1]`
+   * Each element in the array must be one of the following values: `2304`, `2305`.
+* **Required**: No, default: `[2305]`
+* **Related WebGL functions**: `frontFace()`
+
+### functions.lineWidth
+
+Floating-point value passed to `lineWidth()`.
+
+* **Type**: `number[1]`
+   * Each element in the array must be greater than `0`.
+* **Required**: No, default: `[1]`
+* **Related WebGL functions**: `lineWidth()`
+
+### functions.polygonOffset
+
+Floating-point value passed to `polygonOffset()`.  [factor, units]
+
+* **Type**: `number[2]`
+* **Required**: No, default: `[0,0]`
+* **Related WebGL functions**: `polygonOffset()`
+
+### functions.scissor
+
+Floating-point value passed to `scissor()`.  [x, y, width, height].  The default is the dimensions of the canvas when the WebGL context is created.  width and height must be greater than zero.
+
+* **Type**: `number[4]`
+* **Required**: No, default: `[0,0,0,0]`
+* **Related WebGL functions**: `scissor()`
+
+### functions.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### functions.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1986,7 +1986,7 @@ The root object for a glTF asset.
 |**cameras**|`object`|A dictionary object of [`camera`](#reference-camera) objects.|No, default: `{}`|
 |**images**|`object`|A dictionary object of [`image`](#reference-image) objects.|No, default: `{}`|
 |**materials**|`object`|A dictionary object of [`material`](#reference-material) objects.|No, default: `{}`|
-|**meshes**|`object`|A dictionary object of [`mesh`](#reference-mesh)es.|No, default: `{}`|
+|**meshes**|`object`|A dictionary object of [`mesh`](#reference-mesh) objects.|No, default: `{}`|
 |**nodes**|`object`|A dictionary object of [`node`](#reference-node) objects.|No, default: `{}`|
 |**programs**|`object`|A dictionary object of [`program`](#reference-program) objects.|No, default: `{}`|
 |**samplers**|`object`|A dictionary object of [`sampler`](#reference-sampler) objects.|No, default: `{}`|
@@ -2069,7 +2069,7 @@ A dictionary object of [`material`](#reference-material) objects.  The name of e
 
 ### glTF.meshes
 
-A dictionary object of [`mesh`](#reference-mesh)es.  The name of each mesh is an id in the global glTF namespace that is used to reference the mesh.  A mesh is a set of primitives to be rendered.
+A dictionary object of [`mesh`](#reference-mesh) objects.  The name of each mesh is an id in the global glTF namespace that is used to reference the mesh.  A mesh is a set of primitives to be rendered.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`

--- a/specification/README.md
+++ b/specification/README.md
@@ -2037,8 +2037,60 @@ Application-specific data.
 <a name="reference-material"></a>
 ## material
 
+The material appearance of a primitive.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**technique**|`string`|The id of the technique.|No|
+|**values**|`object`|A dictionary object of parameter values.|No, default: `{}`|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [material.schema.json](schema/material.schema.json)
 * **Example**: [materials.json](schema/examples/materials.json)
+
+### material.technique
+
+The id of the technique.  If this is not supplied, and no extension is present that defines material properties, then the primitive should be rendered using a default material with 50% gray emissive color.
+
+* **Type**: `string`
+* **Required**: No
+* **Minimum Length**`: >= 1`
+
+### material.values
+
+A dictionary object of parameter values.  Parameters with the same name as the technique's parameter override the technique's parameter value.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `number`, `boolean`, `string`, `number[]`, or `boolean[]`
+
+### material.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### material.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### material.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -2102,7 +2102,7 @@ A set of primitives to be rendered.  A node can contain one or more meshes.  A n
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**primitives**|[`mesh.primitive[]`](reference-mesh.primitive)|An array of primitives, each defining geometry to be rendered with a material.|No, default: `[]`|
+|**primitives**|[`mesh.primitive[]`](#reference-mesh.primitive)|An array of primitives, each defining geometry to be rendered with a material.|No, default: `[]`|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
@@ -2116,7 +2116,7 @@ Additional properties are not allowed.
 
 An array of primitives, each defining geometry to be rendered with a material.
 
-* **Type**: [`mesh.primitive[]`](reference-mesh.primitive)
+* **Type**: [`mesh.primitive[]`](#reference-mesh.primitive)
 * **Required**: No, default: `[]`
 
 ### mesh.name

--- a/specification/README.md
+++ b/specification/README.md
@@ -2619,8 +2619,69 @@ Application-specific data.
 <a name="reference-skin"></a>
 ## skin
 
+Joints and matrices defining a skin.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**bindShapeMatrix**|`number[16]`|Floating-point 4x4 transformation matrix stored in column-major order.|No, default: `[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]`|
+|**inverseBindMatrices**|`string`|The id of the accessor containing the floating-point 4x4 inverse-bind matrices.| :white_check_mark: Yes|
+|**jointNames**|`string[]`|Joint names of the joints (nodes with a `jointName` property) in this skin.| :white_check_mark: Yes|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [skin.schema.json](schema/skin.schema.json)
 * **Example**: [skins.json](schema/examples/skins.json)
+
+### skin.bindShapeMatrix
+
+Floating-point 4x4 transformation matrix stored in column-major order.
+
+* **Type**: `number[16]`
+* **Required**: No, default: `[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]`
+
+### skin.inverseBindMatrices :white_check_mark: 
+
+The id of the accessor containing the floating-point 4x4 inverse-bind matrices.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### skin.jointNames :white_check_mark: 
+
+Joint names of the joints (nodes with a `jointName` property) in this skin.  The array length is the same as the `count` property of the `inverseBindMatrices` accessor, and the same as the length of any skeletons array referencing the skin.
+
+* **Type**: `string[]`
+   * Each element in the array must be unique.
+   * Each element in the array must have length greater than or equal to `1`.
+* **Required**: Yes
+
+### skin.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### skin.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### skin.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -2553,14 +2553,66 @@ Application-specific data.
 * **Required**: No
 
 
-
-
 <!-- ======================================================================= -->
 <a name="reference-shader"></a>
 ## shader
 
+A vertex or fragment shader.
+
+**Related WebGL functions**: `createShader()`, `deleteShader()`, `shaderSource()`, `compileShader()`, `getShaderParameter()`, and `getShaderInfoLog()`
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**uri**|`string`|The uri of the GLSL source.| :white_check_mark: Yes|
+|**type**|`integer`|The shader stage.| :white_check_mark: Yes|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [shader.schema.json](schema/shader.schema.json)
 * **Example**: [shaders.json](schema/examples/shaders.json)
+
+### shader.uri :white_check_mark: 
+
+The uri of the GLSL source.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Format**: uri
+
+### shader.type :white_check_mark: 
+
+The shader stage.  Allowed values are `35632` (FRAGMENT_SHADER) and `35633` (VERTEX_SHADER).
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Allowed values**: `35632`, `35633`
+
+### shader.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### shader.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### shader.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1133,7 +1133,6 @@ For more information on glTF extensions, consult the [extensions registry specif
 * [material](#reference-material)
 * [mesh](#reference-mesh)
    * [primitive](#reference-mesh.primitive)
-      * [attribute](#reference-mesh.primitive.attribute)
 * [node](#reference-node)
 * [program](#reference-program)
 * [sampler](#reference-sampler)
@@ -2097,22 +2096,121 @@ Application-specific data.
 <a name="reference-mesh"></a>
 ## mesh
 
+A set of primitives to be rendered.  A node can contain one or more meshes.  A node's transform places the mesh in the scene.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**primitives**|[`mesh.primitive[]`](reference-mesh.primitive)|An array of primitives, each defining geometry to be rendered with a material.|No, default: `[]`|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [mesh.schema.json](schema/mesh.schema.json)
 * **Example**: [meshes.json](schema/examples/meshes.json)
+
+### mesh.primitives
+
+An array of primitives, each defining geometry to be rendered with a material.
+
+* **Type**: [`mesh.primitive[]`](reference-mesh.primitive)
+* **Required**: No, default: `[]`
+
+### mesh.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### mesh.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### mesh.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->
 <a name="reference-mesh.primitive"></a>
 ## mesh.primitive
 
+Geometry to be rendered with the given material.
+
+**Related WebGL functions**: `drawElements()` and `drawArrays()`
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**attributes**|`object`|A dictionary object of strings, where each string is the id of the [accessor](#reference-accessor) containing an attribute.|No, default: `{}`|
+|**indices**|`string`|The id of the accessor that contains the indices.|No|
+|**material**|`string`|The id of the material to apply to this primitive when rendering.| :white_check_mark: Yes|
+|**mode**|`integer`|The type of primitives to render.|No, default: `4`|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 **JSON schema**: [mesh.primitive.schema.json](schema/mesh.primitive.schema.json)
 
+### primitive.attributes
 
-<!-- ======================================================================= -->
-<a name="reference-mesh.primitive.attribute"></a>
-## mesh.primitive.attribute
+A dictionary object of strings, where each string is the id of the accessor containing an attribute.
 
-**JSON schema**: [mesh.primitive.attribute.schema.json](schema/mesh.primitive.attribute.schema.json)
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `string`
+
+### primitive.indices
+
+The id of the accessor that contains the indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.
+
+* **Type**: `string`
+* **Required**: No
+* **Minimum Length**`: >= 1`
+
+### primitive.material :white_check_mark: 
+
+The id of the material to apply to this primitive when rendering.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### primitive.mode
+
+The type of primitives to render.  Allowed values are 0 (`POINTS`), 1 (`LINES`), 2 (`LINE_LOOP`), 3 (`LINE_STRIP`), 4 (`TRIANGLES`), 5 (`TRIANGLE_STRIP`), and 6 (`TRIANGLE_FAN`).
+
+* **Type**: `integer`
+* **Required**: No, default: `4`
+* **Allowed values**: `0`, `1`, `2`, `3`, `4`, `5`, `6`
+
+### primitive.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### primitive.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1154,13 +1154,13 @@ For more information on glTF extensions, consult the [extensions registry specif
 ## accessor
 
 * **JSON schema**: [accessor.schema.json](schema/accessor.schema.json)
-* **Example**: [accessors.json](/schema/examples/accessors.json)
+* **Example**: [accessors.json](schema/examples/accessors.json)
 
 <a name="reference-animation"></a>
 ## animation
 
 * **JSON schema**: [animation.schema.json](schema/animation.schema.json)
-* **Example**: [animations.json](/schema/examples/animations.json)
+* **Example**: [animations.json](schema/examples/animations.json)
 
 <a name="reference-animation.channel"></a>
 ### channel
@@ -1186,7 +1186,7 @@ For more information on glTF extensions, consult the [extensions registry specif
 ## asset
 
 * **JSON schema**: [asset.schema.json](schema/asset.schema.json)
-* **Example**: [asset.json](/schema/examples/asset.json)
+* **Example**: [asset.json](schema/examples/asset.json)
 
 <a name="reference-asset.profile"></a>
 ### profile
@@ -1197,19 +1197,19 @@ For more information on glTF extensions, consult the [extensions registry specif
 ## buffer
 
 * **JSON schema**: [buffer.schema.json](schema/buffer.schema.json)
-* **Example**: [buffers.json](/schema/examples/buffers.json)
+* **Example**: [buffers.json](schema/examples/buffers.json)
 
 <a name="reference-bufferView"></a>
 ## bufferView
 
 * **JSON schema**: [bufferView.schema.json](schema/bufferView.schema.json)
-* **Example**: [bufferViews.json](/schema/examples/bufferViews.json)
+* **Example**: [bufferViews.json](schema/examples/bufferViews.json)
 
 <a name="reference-camera"></a>
 ## camera
 
 * **JSON schema**: [camera.schema.json](schema/camera.schema.json)
-* **Example**: [cameras.json](/schema/examples/cameras.json)
+* **Example**: [cameras.json](schema/examples/cameras.json)
 
 <a name="reference-camera.orthographic"></a>
 ### orthographic
@@ -1230,13 +1230,13 @@ For more information on glTF extensions, consult the [extensions registry specif
 ## image
 
 * **JSON schema**: [image.schema.json](schema/image.schema.json)
-* **Example**: [images.json](/schema/examples/images.json)
+* **Example**: [images.json](schema/examples/images.json)
 
 <a name="reference-material"></a>
 ## material
 
 * **JSON schema**: [material.schema.json](schema/material.schema.json)
-* **Example**: [materials.json](/schema/examples/materials.json)
+* **Example**: [materials.json](schema/examples/materials.json)
 
 <a name="reference-material.values"></a>
 ### values
@@ -1247,7 +1247,7 @@ For more information on glTF extensions, consult the [extensions registry specif
 ## mesh
 
 * **JSON schema**: [mesh.schema.json](schema/mesh.schema.json)
-* **Example**: [meshes.json](/schema/examples/meshes.json)
+* **Example**: [meshes.json](schema/examples/meshes.json)
 
 <a name="reference-mesh.primitive"></a>
 ### primitive
@@ -1263,43 +1263,43 @@ For more information on glTF extensions, consult the [extensions registry specif
 ## node
 
 * **JSON schema**: [node.schema.json](schema/node.schema.json)
-* **Example**: [nodes.json](/schema/examples/nodes.json)
+* **Example**: [nodes.json](schema/examples/nodes.json)
 
 <a name="reference-program"></a>
 ## program
 
 * **JSON schema**: [program.schema.json](schema/program.schema.json)
-* **Example**: [programs.json](/schema/examples/programs.json)
+* **Example**: [programs.json](schema/examples/programs.json)
 
 <a name="reference-sampler"></a>
 ## sampler
 
 * **JSON schema**: [sampler.schema.json](schema/sampler.schema.json)
-* **Example**: [samplers.json](/schema/examples/samplers.json)
+* **Example**: [samplers.json](schema/examples/samplers.json)
 
 <a name="reference-scene"></a>
 ## scene
 
 * **JSON schema**: [scene.schema.json](schema/scene.schema.json)
-* **Example**: [scenes.json](/schema/examples/scenes.json)
+* **Example**: [scenes.json](schema/examples/scenes.json)
 
 <a name="reference-shader"></a>
 ## shader
 
 * **JSON schema**: [shader.schema.json](schema/shader.schema.json)
-* **Example**: [shaders.json](/schema/examples/shaders.json)
+* **Example**: [shaders.json](schema/examples/shaders.json)
 
 <a name="reference-skin"></a>
 ## skin
 
 * **JSON schema**: [skin.schema.json](schema/skin.schema.json)
-* **Example**: [skins.json](/schema/examples/skins.json)
+* **Example**: [skins.json](schema/examples/skins.json)
 
 <a name="reference-technique"></a>
 ## technique
 
 * **JSON schema**: [technique.schema.json](schema/technique.schema.json)
-* **Example**: [techniques.json](/schema/examples/techniques.json)
+* **Example**: [techniques.json](schema/examples/techniques.json)
 
 <a name="reference-technique.attribute"></a>
 ### attribute
@@ -1325,7 +1325,7 @@ For more information on glTF extensions, consult the [extensions registry specif
 ## texture
 
 * **JSON schema**: [texture.schema.json](schema/texture.schema.json)
-* **Example**: [textures.json](/schema/examples/textures.json)
+* **Example**: [textures.json](schema/examples/textures.json)
 
 <a name="binarytypes"></a>
 # Binary Types Reference

--- a/specification/README.md
+++ b/specification/README.md
@@ -2870,8 +2870,86 @@ Application-specific data.
 <a name="reference-technique"></a>
 ## technique
 
+A template for a material appearances.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**parameters**|`object`|A dictionary object of [`technique.parameters`](#reference-technique.parameters) objects.|No, default: `{}`|
+|**attributes**|`object`|A dictionary object of strings that maps GLSL attribute names to technique parameter ids.|No, default: `{}`|
+|**program**|`string`|The id of the program.| :white_check_mark: Yes|
+|**uniforms**|`object`|A dictionary object of strings that maps GLSL uniform names to technique parameter ids.|No, default: `{}`|
+|**states**|[`technique.states`](#reference-technique.states)|Fixed-function rendering states.|No, default: `{}`|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [technique.schema.json](schema/technique.schema.json)
 * **Example**: [techniques.json](schema/examples/techniques.json)
+
+### technique.parameters
+
+A dictionary object of [`technique.parameters`](#reference-technique.parameters) objects.  Each parameter defines an attribute or uniform input, and an optional semantic and value.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### technique.attributes
+
+A dictionary object of strings that maps GLSL attribute names to technique parameter ids.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `string`
+
+### technique.program :white_check_mark: 
+
+The id of the program.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### technique.uniforms
+
+A dictionary object of strings that maps GLSL uniform names to technique parameter ids.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `string`
+
+### technique.states
+
+Fixed-function rendering states.
+
+* **Type**: [`technique.states`](#reference-technique.states)
+* **Required**: No, default: `{}`
+
+### technique.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### technique.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### technique.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -2505,8 +2505,54 @@ Application-specific data.
 <a name="reference-scene"></a>
 ## scene
 
+The root nodes of a scene.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**nodes**|`string[]`|The ids of each root [node](#reference-node).|No, default: `[]`|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [scene.schema.json](schema/scene.schema.json)
 * **Example**: [scenes.json](schema/examples/scenes.json)
+
+### scene.nodes
+
+The ids of each root [node](#reference-node).
+
+* **Type**: `string[]`
+   * Each element in the array must be unique.
+   * Each element in the array must have length greater than or equal to `1`.
+* **Required**: No, default: `[]`
+
+### scene.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### scene.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### scene.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
+
+
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1312,7 +1312,7 @@ A dictionary object of [`animation.sampler`](#reference-animation.sampler)s that
 
 ### animation.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., an animation and a buffer could have the same name, or two animations could even have the same name.
 
 * **Type**: `string`
 * **Required**: No

--- a/specification/README.md
+++ b/specification/README.md
@@ -1499,15 +1499,124 @@ Application-specific data.
 <a name="reference-asset"></a>
 ## asset
 
+Metadata about the glTF asset.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**copyright**|`string`|A copyright message suitable for display to credit the content creator.|No|
+|**generator**|`string`|Tool that generated this glTF model.  Useful for debugging.|No|
+|**premultipliedAlpha**|`boolean`|Specifies if the shaders were generated with premultiplied alpha.|No, default: `false`|
+|**profile**|[`asset.profile`](#reference-asset.profile)|Specifies the target rendering API and version, e.g., WebGL 1.0.3.|No, default: `{}`|
+|**version**|`string`|The glTF version.| :white_check_mark: Yes|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [asset.schema.json](schema/asset.schema.json)
 * **Example**: [asset.json](schema/examples/asset.json)
+
+### asset.copyright
+
+A copyright message suitable for display to credit the content creator.
+
+* **Type**: `string`
+* **Required**: No
+
+### asset.generator
+
+Tool that generated this glTF model.  Useful for debugging.
+
+* **Type**: `string`
+* **Required**: No
+
+### asset.premultipliedAlpha
+
+Specifies if the shaders were generated with premultiplied alpha.
+
+* **Type**: `boolean`
+* **Required**: No, default: `false`
+* **Related WebGL functions**: `getContext()` with premultipliedAlpha
+
+### asset.profile
+
+Specifies the target rendering API and version, e.g., WebGL 1.0.3.
+
+* **Type**: [`asset.profile`](#reference-asset.profile)
+* **Required**: No, default: `{}`
+
+### asset.version :white_check_mark: 
+
+The glTF version.
+
+* **Type**: `string`
+* **Required**: Yes
+
+### asset.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### asset.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->
 <a name="reference-asset.profile"></a>
 ## asset.profile
 
+Specifies the target rendering API and version, e.g., WebGL 1.0.3.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**api**|`string`|Specifies the target rendering API.|No, default: `"WebGL"`|
+|**version**|`string`|The API version.|No, default: `"1.0.3"`|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 **JSON schema**: [asset.profile.schema.json](schema/asset.profile.schema.json)
+
+### profile.api
+
+Specifies the target rendering API.
+
+* **Type**: `string`
+* **Required**: No, default: `"WebGL"`
+
+### profile.version
+
+The API version.
+
+* **Type**: `string`
+* **Required**: No, default: `"1.0.3"`
+
+### profile.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### profile.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1121,7 +1121,6 @@ For more information on glTF extensions, consult the [extensions registry specif
 * [animation](#reference-animation)
    * [channel](#reference-animation.channel)
       * [target](#reference-animation.channel.target)
-   * [parameter](#reference-animation.parameter)
    * [sampler](#reference-animation.sampler)
 * [asset](#reference-asset)
    * [profile](#reference-asset.profile)
@@ -1270,8 +1269,70 @@ Application-specific data.
 <a name="reference-animation"></a>
 ## animation
 
+A keyframe animation.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**channels**|[`animation.channel[]`](#reference-animation.channel)|An array of channels, each of which targets an animation's sampler at a node's property.|No, default: `[]`|
+|**parameters**|`object`|A dictionary object of strings whose values are ids of accessors with keyframe data, e.g., time, translation, rotation, etc.|No, default: `{}`|
+|**samplers**|`object`|A dictionary object of [`animation.sampler`](#reference-animation.sampler)s that combines input and output parameters with an interpolation algorithm to define a keyframe graph (but not its target).|No, default: `{}`|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [animation.schema.json](schema/animation.schema.json)
 * **Example**: [animations.json](schema/examples/animations.json)
+
+### animation.channels
+
+An array of channels, each of which targets an animation's sampler at a node's property.
+
+* **Type**: [`animation.channel[]`](#reference-animation.channel)
+* **Required**: No, default: `[]`
+
+### animation.parameters
+
+A dictionary object of strings whose values are ids of accessors with keyframe data, e.g., time, translation, rotation, etc.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `string`
+
+### animation.samplers
+
+A dictionary object of [`animation.sampler`](#reference-animation.sampler)s that combines input and output parameters with an interpolation algorithm to define a keyframe graph (but not its target).
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### animation.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### animation.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### animation.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
+
+
 
 
 <!-- ======================================================================= -->
@@ -1373,13 +1434,6 @@ Application-specific data.
 
 * **Type**: `any`
 * **Required**: No
-
-
-<!-- ======================================================================= -->
-<a name="reference-animation.parameter"></a>
-## animation.parameter
-
-**JSON schema**: [animation.parameter.schema.json](schema/animation.parameter.schema.json)
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1688,14 +1688,85 @@ Application-specific data.
 * **Required**: No
 
 
-
-
 <!-- ======================================================================= -->
 <a name="reference-bufferView"></a>
 ## bufferView
 
+A view into a [buffer](#reference-buffer) generally representing a subset of the buffer.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**buffer**|`string`|The id of the buffer.| :white_check_mark: Yes|
+|**byteOffset**|`integer`|The offset into the buffer in bytes.| :white_check_mark: Yes|
+|**byteLength**|`integer`|The length of the bufferView in bytes.|No, default: `0`|
+|**target**|`integer`|The target that the WebGL buffer should be bound to.|No|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [bufferView.schema.json](schema/bufferView.schema.json)
 * **Example**: [bufferViews.json](schema/examples/bufferViews.json)
+
+### bufferView.buffer :white_check_mark: 
+
+The id of the buffer.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### bufferView.byteOffset :white_check_mark: 
+
+The offset into the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**:` >= 0`
+
+### bufferView.byteLength
+
+The length of the bufferView in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**:` >= 0`
+
+### bufferView.target
+
+The target that the WebGL buffer should be bound to.  Valid values correspond to WebGL enums: `34962` (ARRAY_BUFFER) and `34963` (ELEMENT_ARRAY_BUFFER).  When this is not provided, the bufferView contains animation or skin data.
+
+* **Type**: `integer`
+* **Required**: No
+* **Allowed values**: `34962`, `34963`
+* **Related WebGL functions**: `bindBuffer()`
+
+### bufferView.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### bufferView.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### bufferView.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
+
+
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -2421,8 +2421,84 @@ Application-specific data.
 <a name="reference-sampler"></a>
 ## sampler
 
+Texture sampler properties for filtering and wrapping modes.
+
+**Related WebGL functions**: `texParameterf()`
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**magFilter**|`integer`|Magnification filter.|No, default: `9729`|
+|**minFilter**|`integer`|Minification filter.|No, default: `9986`|
+|**wrapS**|`integer`|s wrapping mode.|No, default: `10497`|
+|**wrapT**|`integer`|t wrapping mode.|No, default: `10497`|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [sampler.schema.json](schema/sampler.schema.json)
 * **Example**: [samplers.json](schema/examples/samplers.json)
+
+### sampler.magFilter
+
+Magnification filter.  Valid values correspond to WebGL enums: `9728` (NEAREST) and `9729` (LINEAR).
+
+* **Type**: `integer`
+* **Required**: No, default: `9729`
+* **Allowed values**: `9728`, `9729`
+* **Related WebGL functions**: `texParameterf()` with pname equal to TEXTURE_MAG_FILTER
+
+### sampler.minFilter
+
+Minification filter.  Valid values correspond to WebGL enums: `9728` (NEAREST), `9729` (LINEAR), `9984` (NEAREST_MIPMAP_NEAREST), `9985` (LINEAR_MIPMAP_NEAREST), `9986` (NEAREST_MIPMAP_LINEAR), and `9987` (LINEAR_MIPMAP_LINEAR).
+
+* **Type**: `integer`
+* **Required**: No, default: `9986`
+* **Allowed values**: `9728`, `9729`, `9984`, `9985`, `9986`, `9987`
+* **Related WebGL functions**: `texParameterf()` with pname equal to TEXTURE_MIN_FILTER
+
+### sampler.wrapS
+
+s wrapping mode.  Valid values correspond to WebGL enums: `33071` (CLAMP_TO_EDGE), `33648` (MIRRORED_REPEAT), and `10497` (REPEAT).
+
+* **Type**: `integer`
+* **Required**: No, default: `10497`
+* **Allowed values**: `33071`, `33648`, `10497`
+* **Related WebGL functions**: `texParameterf()` with pname equal to TEXTURE_WRAP_S
+
+### sampler.wrapT
+
+t wrapping mode.  Valid values correspond to WebGL enums: `33071` (CLAMP_TO_EDGE), `33648` (MIRRORED_REPEAT), and `10497` (REPEAT).
+
+* **Type**: `integer`
+* **Required**: No, default: `10497`
+* **Allowed values**: `33071`, `33648`, `10497`
+* **Related WebGL functions**: `texParameterf()` with pname equal to TEXTURE_WRAP_T
+
+### sampler.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### sampler.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### sampler.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1131,7 +1131,6 @@ For more information on glTF extensions, consult the [extensions registry specif
 * [glTF](#reference-glTF) (root property for model)
 * [image](#reference-image)
 * [material](#reference-material)
-   * [values](#reference-material.values)
 * [mesh](#reference-mesh)
    * [primitive](#reference-mesh.primitive)
       * [attribute](#reference-mesh.primitive.attribute)
@@ -2043,13 +2042,6 @@ Application-specific data.
 
 
 <!-- ======================================================================= -->
-<a name="reference-material.values"></a>
-## material.values
-
-**JSON schema**: [material.values.schema.json](schema/material.values.schema.json)
-
-
-<!-- ======================================================================= -->
 <a name="reference-mesh"></a>
 ## mesh
 
@@ -2162,58 +2154,6 @@ Application-specific data.
 * **JSON schema**: [texture.schema.json](schema/texture.schema.json)
 * **Example**: [textures.json](schema/examples/textures.json)
 
-
-<<<<<<< HEAD
-<a name="binarytypes"></a>
-# Binary Types Reference
-
-This section will describe the format for each of the GL types stored in the binary file. A reference to the GL spec for each type might be enough
-
-<mark>*Todo: Patrick please advise on how to tackle this*</mark>
-=======
-<a name="schema"></a>
-# JSON Schema
-
-   * <a href="schema/accessor.schema.json">`accessor`</a>
-   * <a href="schema/animation.schema.json">`animation`</a>
-   * <a href="schema/animationChannel.schema.json">`animation/channel`</a>
-   * <a href="schema/animationChannelTarget.schema.json">`animation/channel/target`</a>
-   * <a href="schema/animationParameter.schema.json">`animation/parameter`</a>
-   * <a href="schema/animationSampler.schema.json">`animation/sampler`</a>
-   * <a href="schema/asset.schema.json">`asset`</a>
-   * <a href="schema/buffer.schema.json">`buffer`</a>
-   * <a href="schema/bufferView.schema.json">`bufferView`</a>
-   * <a href="schema/camera.schema.json">`camera`</a>
-   * <a href="schema/cameraOrthographic.schema.json">`camera/orthographic`</a>
-   * <a href="schema/cameraPerspective.schema.json">`camera/perspective`</a>
-   * <a href="schema/extension.schema.json">`extension`</a>
-   * <a href="schema/extras.schema.json">`extras`</a>
-   * <a href="schema/glTF.schema.json">`glTF`</a> (root property for model)
-   * <a href="schema/image.schema.json">`image`</a>
-   * <a href="schema/material.schema.json">`material`</a>
-   * <a href="schema/materialInstanceTechnique.schema.json">`material/instanceTechnique`</a>
-   * <a href="schema/materialInstanceTechniqueValues.schema.json">`material/instanceTechnique/values`</a>
-   * <a href="schema/mesh.schema.json">`mesh`</a>
-   * <a href="schema/meshPrimitive.schema.json">`mesh/primitive`</a>
-   * <a href="schema/meshPrimitiveAttribute.schema.json">`mesh/primitive/attribute`</a>
-   * <a href="schema/node.schema.json">`node`</a>
-   * <a href="schema/program.schema.json">`program`</a>
-   * <a href="schema/sampler.schema.json">`sampler`</a>
-   * <a href="schema/scene.schema.json">`scene`</a>
-   * <a href="schema/shader.schema.json">`shader`</a>
-   * <a href="schema/skin.schema.json">`skin`</a>
-   * <a href="schema/technique.schema.json">`technique`</a>
-   * <a href="schema/techniqueParameters.schema.json">`technique/parameters`</a>
-   * <a href="schema/techniquePass.schema.json">`technique/pass`</a>
-   * <a href="schema/techniquePassDetails.schema.json">`technique/pass/details`</a>
-   * <a href="schema/techniquePassDetailsCommonProfile.schema.json">`technique/pass/details/commonProfile`</a>
-   * <a href="schema/techniquePassDetailsCommonProfileTexcoordBindings.schema.json">`technique/pass/details/commonProfile/texcoordBindings`</a>
-   * <a href="schema/techniquePassInstanceProgram.schema.json">`technique/pass/instanceProgram`</a>
-   * <a href="schema/techniquePassInstanceProgramAttribute.schema.json">`technique/pass/instanceProgram/attribute`</a>
-   * <a href="schema/techniquePassInstanceProgramUniform.schema.json">`technique/pass/instanceProgram/uniform`</a>
-   * <a href="schema/techniquePassStates.schema.json">`technique/pass/states`</a>
-   * <a href="schema/texture.schema.json">`texture`</a>
->>>>>>> origin/spec-1.0
 
 <a name="conformance"></a>
 # Conformance

--- a/specification/README.md
+++ b/specification/README.md
@@ -42,7 +42,6 @@ Contributors
   * [Specifying Extensions](#specifying-extensions)
 * [Properties Reference](#properties)
 * [Acknowledgements](#acknowledgements)
-* [References](#references)
 
 <a name="introduction"></a>
 # Introduction
@@ -3326,9 +3325,3 @@ Application-specific data.
 * Scott Hunter, Analytical Graphics, Inc.
 * Brandon Jones, Google
 * Ed Mackey, Analytical Graphics, Inc.
-
-<a name="references"></a>
-# References
-
-* [WebGL 1.0.2 spec](https://www.khronos.org/registry/webgl/specs/1.0/)
-* [COLLADA 1.5 spec](http://www.khronos.org/files/collada_spec_1_5.pdf)

--- a/specification/README.md
+++ b/specification/README.md
@@ -2349,8 +2349,72 @@ Application-specific data.
 <a name="reference-program"></a>
 ## program
 
+A shader program, including its vertex and fragment shader, and names of vertex shader attributes.
+
+**Related WebGL functions**: `attachShader()`, `bindAttribLocation()`, `createProgram()`, `deleteProgram()`, `getProgramParameter()`, `getProgramInfoLog()`, `linkProgram()`, `useProgram()`, and `validateProgram()`
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**attributes**|`string[]`|Names of GLSL vertex shader attributes.|No, default: `[]`|
+|**fragmentShader**|`string`|The id of the fragment [shader](#reference-shader).| :white_check_mark: Yes|
+|**vertexShader**|`string`|The id of the vertex [shader](#reference-shader).| :white_check_mark: Yes|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [program.schema.json](schema/program.schema.json)
 * **Example**: [programs.json](schema/examples/programs.json)
+
+### program.attributes
+
+Names of GLSL vertex shader attributes.
+
+* **Type**: `string[]`
+   * Each element in the array must have length between `1` and `256`.
+* **Required**: No, default: `[]`
+* **Related WebGL functions**: `bindAttribLocation()`
+
+### program.fragmentShader :white_check_mark: 
+
+The id of the fragment shader.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### program.vertexShader :white_check_mark: 
+
+The id of the vertex shader.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Minimum Length**`: >= 1`
+
+### program.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### program.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### program.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1132,10 +1132,8 @@ For more information on glTF extensions, consult the [extensions registry specif
 * [shader](#reference-shader)
 * [skin](#reference-skin)
 * [technique](#reference-technique)
-   * [attribute](#reference-technique.attribute)
    * [parameters](#reference-technique.parameters)
    * [states](#reference-technique.states)
-   * [uniform](#reference-technique.uniform)
 * [texture](#reference-texture)
 
 
@@ -2876,17 +2874,70 @@ Application-specific data.
 
 
 <!-- ======================================================================= -->
-<a name="reference-technique.attribute"></a>
-## technique.attribute
-
-**JSON schema**: [technique.attribute.schema.json](schema/technique.attribute.schema.json)
-
-
-<!-- ======================================================================= -->
 <a name="reference-technique.parameters"></a>
 ## technique.parameters
 
+An attribute or uniform input to a [`technique`](#reference-technique), and an optional semantic and value.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**count**|`integer`|When defined, the parameter is an array of count elements of the specified type.  Otherwise, the parameter is not an array.|No|
+|**type**|`integer`|The datatype.| :white_check_mark: Yes|
+|**semantic**|`string`|Identifies a parameter with a well-known meaning.|No|
+|**value**|`number`, `boolean`, `string`, `number[]`, or `boolean[]`|The value of the parameter.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 **JSON schema**: [technique.parameters.schema.json](schema/technique.parameters.schema.json)
+
+### parameter.count
+
+When defined, the parameter is an array of count elements of the specified type.  Otherwise, the parameter is not an array.  When defined, `value` is array with length equal to count times the number of components in the type, e.g., `3` for `FLOAT_VEC3`.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**:` >= 1`
+
+### parameter.type :white_check_mark: 
+
+The datatype.  Allowed values are `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), `5124` (INT), `5125` (UNSIGNED_INT), `5126` (FLOAT), `35664` (FLOAT_VEC2), `35665` (FLOAT_VEC3), `35666` (FLOAT_VEC4), `35667` (INT_VEC2), `35668` (INT_VEC3), `35669` (INT_VEC4), `35670` (BOOL), `35671` (BOOL_VEC2), `35672` (BOOL_VEC3), `35673` (BOOL_VEC4), `35674` (FLOAT_MAT2), `35675` (FLOAT_MAT3), `35676` (FLOAT_MAT4), and `35678` (SAMPLER_2D).
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Allowed values**: `5120`, `5121`, `5122`, `5123`, `5124`, `5125`, `5126`, `35664`, `35665`, `35666`, `35667`, `35668`, `35669`, `35670`, `35671`, `35672`, `35673`, `35674`, `35675`, `35676`, `35678`
+
+### parameter.semantic
+
+Identifies a parameter with a well-known meaning.  Uniform semantics include `"LOCAL"` (FLOAT_MAT4), `"MODEL"` (FLOAT_MAT4), `"VIEW"` (FLOAT_MAT4), `"PROJECTION"` (FLOAT_MAT4), `"MODELVIEW"` (FLOAT_MAT4), `"MODELVIEWPROJECTION"` (FLOAT_MAT4), `"MODELINVERSE"` (FLOAT_MAT4), `"VIEWINVERSE"` (FLOAT_MAT4), `"PROJECTIONINVERSE"` (FLOAT_MAT4), `"MODELVIEWINVERSE"` (FLOAT_MAT4), `"MODELVIEWPROJECTIONINVERSE"` (FLOAT_MAT4), `"MODELINVERSETRANSPOSE"` (FLOAT_MAT3), `"MODELVIEWINVERSETRANSPOSE"` (FLOAT_MAT3), `"VIEWPORT"` (FLOAT_VEC4).  Attribute semantics include `"POSITION"`, `"NORMAL"`, `"TEXCOORD"`, `"COLOR"`, `"JOINT"`, `"JOINTMATRIX"`, and `"WEIGHT"`.  Attribute semantics can be of the form `[semantic]_[set_index]`, e.g, `"TEXCOORD_0"`.
+
+* **Type**: `string`
+* **Required**: No
+
+### parameter.value
+
+The value of the parameter.  A [`material`](#reference-material) value with the same name, when specified, overrides this value.
+
+* **Type**: `number`, `boolean`, `string`, `number[]`, or `boolean[]`
+* **Required**: No
+
+### parameter.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### parameter.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->
@@ -2894,13 +2945,6 @@ Application-specific data.
 ## technique.states
 
 **JSON schema**: [technique.states.schema.json](schema/technique.states.schema.json)
-
-
-<!-- ======================================================================= -->
-<a name="reference-technique.uniform"></a>
-## technique.uniform
-
-**JSON schema**: [technique.uniform.schema.json](schema/technique.uniform.schema.json)
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1128,7 +1128,7 @@ For more information on glTF extensions, consult the [extensions registry specif
 * [camera](#reference-camera)
    * [orthographic](#reference-camera.orthographic)
    * [perspective](#reference-camera.perspective)
-* [glTF](#reference-glTF) (root property for model)
+* [glTF](#reference-glTF) (root object for an asset)
 * [image](#reference-image)
 * [material](#reference-material)
 * [mesh](#reference-mesh)
@@ -1972,13 +1972,204 @@ Application-specific data.
 <a name="reference-glTF"></a>
 ## glTF
 
+The root object for a glTF asset.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**accessors**|`object`|A dictionary object of [`accessor`](#reference-accessor)s.|No, default: `{}`|
+|**animations**|`object`|A dictionary object of keyframe [`animation`](#reference-animation)s.|No, default: `{}`|
+|**asset**|[`asset`](#reference-asset)|Metadata about the glTF asset.|No, default: `{}`|
+|**buffers**|`object`|A dictionary object of [`buffer`](#reference-buffer)s.|No, default: `{}`|
+|**bufferViews**|`object`|A dictionary object of [`bufferView`](#reference-bufferView)s.|No, default: `{}`|
+|**cameras**|`object`|A dictionary object of [`camera`](#reference-camera)s.|No, default: `{}`|
+|**images**|`object`|A dictionary object of [`image`](#reference-image)s.|No, default: `{}`|
+|**materials**|`object`|A dictionary object of [`material`](#reference-material)s.|No, default: `{}`|
+|**meshes**|`object`|A dictionary object of [`mesh`](#reference-mesh)es.|No, default: `{}`|
+|**nodes**|`object`|A dictionary object of [`node`](#reference-node)s.|No, default: `{}`|
+|**programs**|`object`|A dictionary object of [`program`](#reference-program)s.|No, default: `{}`|
+|**samplers**|`object`|A dictionary object of [`sampler`](#reference-sampler)s.|No, default: `{}`|
+|**scene**|`string`|The id of the default scene.|No|
+|**scenes**|`object`|A dictionary object of [`scene`](#reference-scene)s.|No, default: `{}`|
+|**shaders**|`object`|A dictionary object of [`shader`](#reference-shader)s.|No, default: `{}`|
+|**skins**|`object`|A dictionary object of [`skin`](#reference-skin)s.|No, default: `{}`|
+|**techniques**|`object`|A dictionary object of [`technique`](#reference-technique)s.|No, default: `{}`|
+|**textures**|`object`|A dictionary object of [`texture`](#reference-texture)s.|No, default: `{}`|
+|**extensionsUsed**|`string[]`|Names of extensions used somewhere in this asset.|No, default: `[]`|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 **JSON schema**: [glTF.schema.json](schema/glTF.schema.json)
 
-TODO
-TODO
-TODO
-TODO
-TODO
+### glTF.accessors
+
+A dictionary object of [`accessor`](#reference-accessor)s.  The name of each accessor is an id in the global glTF namespace that is used to reference the accessor.  An accessor is a A typed view into a bufferView.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.animations
+
+A dictionary object of keyframe [`animation`](#reference-animation)s.  The name of each animation is an id in the global glTF namespace that is used to reference the animation.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.asset
+
+Metadata about the glTF asset.
+
+* **Type**: [`asset`](#reference-asset)
+* **Required**: No, default: `{}`
+
+### glTF.buffers
+
+A dictionary object of [`buffer`](#reference-buffer)s.  The name of each buffer is an id in the global glTF namespace that is used to reference the buffer.  A buffer points to binary geometry, animation, or skins.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.bufferViews
+
+A dictionary object of [`bufferView`](#reference-bufferView)s.  The name of each bufferView is an id in the global glTF namespace that is used to reference the bufferView.  A bufferView is a view into a buffer generally representing a subset of the buffer.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.cameras
+
+A dictionary object of [`camera`](#reference-camera)s.  The name of each camera is an id in the global glTF namespace that is used to reference the camera.  A camera defines a projection matrix.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.images
+
+A dictionary object of [`image`](#reference-image)s.  The name of each image is an id in the global glTF namespace that is used to reference the image.  An image defines data used to create a texture.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.materials
+
+A dictionary object of [`material`](#reference-material)s.  The name of each material is an id in the global glTF namespace that is used to reference the material.  A material defines the appearance of a primitive.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.meshes
+
+A dictionary object of [`mesh`](#reference-mesh)es.  The name of each mesh is an id in the global glTF namespace that is used to reference the mesh.  A mesh is a set of primitives to be rendered.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.nodes
+
+A dictionary object of [`node`](#reference-node)s in the node hierarchy.  The name of each node is an id in the global glTF namespace that is used to reference the node.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.programs
+
+A dictionary object of shader [`program`](#reference-program)s.  The name of each program is an id in the global glTF namespace that is used to reference the program.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.samplers
+
+A dictionary object of [`sampler`](#reference-sampler)s.  The name of each sampler is an id in the global glTF namespace that is used to reference the sampler.  A sampler contains properties for texture filtering and wrapping modes.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.scene
+
+The id of the default scene.
+
+* **Type**: `string`
+* **Required**: No
+* **Minimum Length**`: >= 1`
+
+### glTF.scenes
+
+A dictionary object of [`scene`](#reference-scene)s.  The name of each scene is an id in the global glTF namespace that is used to reference the scene.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.shaders
+
+A dictionary object of [`shader`](#reference-shader)s.  The name of each shader is an id in the global glTF namespace that is used to reference the shader.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.skins
+
+A dictionary object of [`skin`](#reference-skin)s.  The name of each skin is an id in the global glTF namespace that is used to reference the skin.  A skin is defined by joints and matrices.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.techniques
+
+A dictionary object of [`technique`](#reference-technique)s.  The name of each technique is an id in the global glTF namespace that is used to reference the technique.  A technique is a template for a material appearance.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.textures
+
+A dictionary object of [`texture`](#reference-texture)s.  The name of each texture is an id in the global glTF namespace that is used to reference the texture.
+
+* **Type**: `object`
+* **Required**: No, default: `{}`
+* **Type of each property**: `object`
+
+### glTF.extensionsUsed
+
+Names of extensions used somewhere in this asset.
+
+* **Type**: `string[]`
+   * Each element in the array must be unique.
+* **Required**: No, default: `[]`
+* **Related WebGL functions**: `getSupportedExtensions()` and `getExtension()`
+
+### glTF.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### glTF.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1134,6 +1134,7 @@ For more information on glTF extensions, consult the [extensions registry specif
 * [technique](#reference-technique)
    * [parameters](#reference-technique.parameters)
    * [states](#reference-technique.states)
+      * [functions](#reference-technique.states.functions)
 * [texture](#reference-texture)
 
 
@@ -2942,9 +2943,61 @@ Application-specific data.
 
 <!-- ======================================================================= -->
 <a name="reference-technique.states"></a>
-## technique.states
+## states
+
+Fixed-function rendering states.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**enable**|`integer[]`|WebGL states to enable.|No, default: `[]`|
+|**functions**|[`technique.states.functions`](#reference-technique.states.functions)|Arguments for fixed-function rendering state functions other than `enable()`/`disable()`.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
 
 **JSON schema**: [technique.states.schema.json](schema/technique.states.schema.json)
+
+### states.enable
+
+WebGL states to enable.  States not in the array are disabled.  Valid values for each element correspond to WebGL enums: `3042` (BLEND), `2884` (CULL_FACE), `2929` (DEPTH_TEST), `32823` (POLYGON_OFFSET_FILL), `32926` (SAMPLE_ALPHA_TO_COVERAGE), and `3089` (SCISSOR_TEST).
+
+* **Type**: `integer[]`
+   * Each element in the array must be unique.
+   * Each element in the array must be one of the following values: `3042`, `2884`, `2929`, `32823`, `32926`, `3089`.
+* **Required**: No, default: `[]`
+* **Related WebGL functions**: `enable()` and `disable()`
+
+### states.functions
+
+Arguments for fixed-function rendering state functions other than `enable()`/`disable()`.
+
+* **Type**: [`technique.states.functions`](#reference-technique.states.functions)
+* **Required**: No
+
+### states.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### states.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
+
+
+<!-- ======================================================================= -->
+<a name="reference-technique.states.functions"></a>
+## technique.states.functions
+
+**JSON schema**: [technique.states.functions.schema.json](schema/technique.states.functions.schema.json)
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1666,7 +1666,7 @@ XMLHttpRequest `responseType`.
 
 ### buffer.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a buffer and a bufferView could have the same name, or two buffers could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -1745,7 +1745,7 @@ The target that the WebGL buffer should be bound to.  Valid values correspond to
 
 ### bufferView.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a bufferView and a buffer could have the same name, or two bufferViews could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -1812,7 +1812,7 @@ Specifies if the camera uses a perspective or orthographic projection.  Based on
 
 ### camera.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a camera and a buffer could have the same name, or two cameras could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -2012,7 +2012,7 @@ The uri of the image.  Relative paths are relative to the .gltf file.  Instead o
 
 ### image.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., an image and a buffer could have the same name, or two images could even have the same name.
 
 * **Type**: `string`
 * **Required**: No
@@ -2072,7 +2072,7 @@ A dictionary object of parameter values.  Parameters with the same name as the t
 
 ### material.name
 
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+The user-defined name of this object.  This is not necessarily unique, e.g., a material and a buffer could have the same name, or two materials could even have the same name.
 
 * **Type**: `string`
 * **Required**: No

--- a/specification/README.md
+++ b/specification/README.md
@@ -8,7 +8,7 @@ The GL Transmission Format (glTF) is a runtime asset delivery format for GL APIs
 
 
 > 
-_This is a draft specification; it is incomplete and may change before ratification.  We have made it available early in the spirit of transparency to receive community feedback.  Please create [issues](https://github.com/KhronosGroup/glTF/issues) with your feedback._
+_This is a draft specification; there may be minor changes before ratification is finalized.  Please provide feedback by submitting [issues](https://github.com/KhronosGroup/glTF/issues)._
 
 Editors
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -1118,11 +1118,11 @@ For more information on glTF extensions, consult the [extensions registry specif
 # Properties Reference
 
 * [accessor](#reference-accessor)
+* [animation](#reference-animation)
    * [channel](#reference-animation.channel)
       * [target](#reference-animation.channel.target)
    * [parameter](#reference-animation.parameter)
    * [sampler](#reference-animation.sampler)
-* [animation](#reference-animation)
 * [asset](#reference-asset)
    * [profile](#reference-asset.profile)
 * [buffer](#reference-buffer)
@@ -1156,6 +1156,11 @@ For more information on glTF extensions, consult the [extensions registry specif
 
 **JSON schema**: [accessor.schema.json](schema/accessor.schema.json)
 
+<a name="reference-animation"></a>
+## animation
+
+**JSON schema**: [animation.schema.json](schema/animation.schema.json)
+
 <a name="reference-animation.channel"></a>
 ### channel
 
@@ -1175,11 +1180,6 @@ For more information on glTF extensions, consult the [extensions registry specif
 ### sampler
 
 **JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
-
-<a name="reference-animation"></a>
-## animation
-
-**JSON schema**: [animation.schema.json](schema/animation.schema.json)
 
 <a name="reference-asset"></a>
 ## asset

--- a/specification/README.md
+++ b/specification/README.md
@@ -1623,8 +1623,71 @@ Application-specific data.
 <a name="reference-buffer"></a>
 ## buffer
 
+A buffer points to binary geometry, animation, or skins.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**uri**|`string`|The uri of the buffer.| :white_check_mark: Yes|
+|**byteLength**|`integer`|The length of the buffer in bytes.|No, default: `0`|
+|**type**|`string`|XMLHttpRequest `responseType`.|No, default: `"arraybuffer"`|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [buffer.schema.json](schema/buffer.schema.json)
 * **Example**: [buffers.json](schema/examples/buffers.json)
+
+### buffer.uri :white_check_mark: 
+
+The uri of the buffer.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Format**: uri
+
+### buffer.byteLength
+
+The length of the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**:` >= 0`
+
+### buffer.type
+
+XMLHttpRequest `responseType`.
+
+* **Type**: `string`
+* **Required**: No, default: `"arraybuffer"`
+* **Allowed values**: `"arraybuffer"`, `"text"`
+
+### buffer.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### buffer.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### buffer.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
+
+
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -42,7 +42,6 @@ Contributors
   * [Specifying Extensions](#specifying-extensions)
 * [Properties Reference](#properties)
 * [Binary Types Reference](#binarytypes)
-* [JSON Schema](#schema)
 * [Conformance](#conformance)
 * [Acknowledgements](#acknowledgements)
 * [References](#references)
@@ -1118,7 +1117,199 @@ For more information on glTF extensions, consult the [extensions registry specif
 <a name="properties"></a>
 # Properties Reference
 
-This section will have a detailed reference on each property. e.g. `asset`. This is more than what is currently in the schema. A one-line description and comment isn't enough, we need to fully specify behavior for each property.
+* [accessor](#reference-accessor)
+   * [channel](#reference-animation.channel)
+      * [target](#reference-animation.channel.target)
+   * [parameter](#reference-animation.parameter)
+   * [sampler](#reference-animation.sampler)
+* [animation](#reference-animation)
+* [asset](#reference-asset)
+   * [profile](#reference-asset.profile)
+* [buffer](#reference-buffer)
+* [bufferView](#reference-bufferView)
+* [camera](#reference-camera)
+   * [orthographic](#reference-camera.orthographic)
+   * [perspective](#reference-camera.perspective)
+* [glTF](#reference-glTF) (root property for model)
+* [image](#reference-image)
+* [material](#reference-material)
+   * [values](#reference-material.values)
+* [mesh](#reference-mesh)
+   * [primitive](#reference-mesh.primitive)
+      * [attribute](#reference-mesh.primitive.attribute)
+* [node](#reference-node)
+* [program](#reference-program)
+* [sampler](#reference-sampler)
+* [scene](#reference-scene)
+* [shader](#reference-shader)
+* [skin](#reference-skin)
+* [technique](#reference-technique)
+   * [attribute](#reference-technique.attribute)
+   * [parameters](#reference-technique.parameters)
+   * [states](#reference-technique.states)
+   * [uniform](#reference-technique.uniform)
+* [texture](#reference-texture)
+
+
+<a name="reference-accessor"></a>
+## accessor
+
+**JSON schema**: [accessor.schema.json](schema/accessor.schema.json)
+
+<a name="reference-animation.channel"></a>
+### channel
+
+**JSON schema**: [animation.channel.schema.json](schema/animation.channel.schema.json)
+
+<a name="reference-animation.channel.target"></a>
+#### target
+
+**JSON schema**: [animation.channel.target.schema.json](schema/animation.channel.target.schema.json)
+
+<a name="reference-animation.parameter"></a>
+### parameter
+
+**JSON schema**: [animation.parameter.schema.json](schema/animation.parameter.schema.json)
+
+<a name="reference-animation.sampler"></a>
+### sampler
+
+**JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
+
+<a name="reference-animation"></a>
+## animation
+
+**JSON schema**: [animation.schema.json](schema/animation.schema.json)
+
+<a name="reference-asset"></a>
+## asset
+
+**JSON schema**: [asset.schema.json](schema/asset.schema.json)
+
+<a name="reference-asset.profile"></a>
+### profile
+
+**JSON schema**: [asset.profile.schema.json](schema/asset.profile.schema.json)
+
+<a name="reference-buffer"></a>
+## buffer
+
+**JSON schema**: [buffer.schema.json](schema/buffer.schema.json)
+
+<a name="reference-bufferView"></a>
+## bufferView
+
+**JSON schema**: [bufferView.schema.json](schema/bufferView.schema.json)
+
+<a name="reference-camera"></a>
+## camera
+
+**JSON schema**: [camera.schema.json](schema/camera.schema.json)
+
+<a name="reference-camera.orthographic"></a>
+### orthographic
+
+**JSON schema**: [camera.orthographic.schema.json](schema/camera.orthographic.schema.json)
+
+<a name="reference-camera.perspective"></a>
+### perspective
+
+**JSON schema**: [camera.perspective.schema.json](schema/camera.perspective.schema.json)
+
+<a name="reference-glTF"></a>
+## glTF
+
+**JSON schema**: [glTF.schema.json](schema/glTF.schema.json)
+
+<a name="reference-image"></a>
+## image
+
+**JSON schema**: [image.schema.json](schema/image.schema.json)
+
+<a name="reference-material"></a>
+## material
+
+**JSON schema**: [material.schema.json](schema/material.schema.json)
+
+<a name="reference-material.values"></a>
+### values
+
+**JSON schema**: [material.values.schema.json](schema/material.values.schema.json)
+
+<a name="reference-mesh"></a>
+## mesh
+
+**JSON schema**: [mesh.schema.json](schema/mesh.schema.json)
+
+<a name="reference-mesh.primitive"></a>
+### primitive
+
+**JSON schema**: [mesh.primitive.schema.json](schema/mesh.primitive.schema.json)
+
+<a name="reference-mesh.primitive.attribute"></a>
+#### attribute
+
+**JSON schema**: [mesh.primitive.attribute.schema.json](schema/mesh.primitive.attribute.schema.json)
+
+<a name="reference-node"></a>
+## node
+
+**JSON schema**: [node.schema.json](schema/node.schema.json)
+
+<a name="reference-program"></a>
+## program
+
+**JSON schema**: [program.schema.json](schema/program.schema.json)
+
+<a name="reference-sampler"></a>
+## sampler
+
+**JSON schema**: [sampler.schema.json](schema/sampler.schema.json)
+
+<a name="reference-scene"></a>
+## scene
+
+**JSON schema**: [scene.schema.json](schema/scene.schema.json)
+
+<a name="reference-shader"></a>
+## shader
+
+**JSON schema**: [shader.schema.json](schema/shader.schema.json)
+
+<a name="reference-skin"></a>
+## skin
+
+**JSON schema**: [skin.schema.json](schema/skin.schema.json)
+
+<a name="reference-technique"></a>
+## technique
+
+**JSON schema**: [technique.schema.json](schema/technique.schema.json)
+
+<a name="reference-technique.attribute"></a>
+### attribute
+
+**JSON schema**: [technique.attribute.schema.json](schema/technique.attribute.schema.json)
+
+<a name="reference-technique.parameters"></a>
+### parameters
+
+**JSON schema**: [technique.parameters.schema.json](schema/technique.parameters.schema.json)
+
+<a name="reference-technique.states"></a>
+### states
+
+**JSON schema**: [technique.states.schema.json](schema/technique.states.schema.json)
+
+<a name="reference-technique.uniform"></a>
+### uniform
+
+**JSON schema**: [technique.uniform.schema.json](schema/technique.uniform.schema.json)
+
+<a name="reference-texture"></a>
+## texture
+
+**JSON schema**: [texture.schema.json](schema/texture.schema.json)
 
 <a name="binarytypes"></a>
 # Binary Types Reference
@@ -1126,49 +1317,6 @@ This section will have a detailed reference on each property. e.g. `asset`. This
 This section will describe the format for each of the GL types stored in the binary file. A reference to the GL spec for each type might be enough
 
 <mark>*Todo: Patrick please advise on how to tackle this*</mark>
-
-<a name="schema"></a>
-# JSON Schema
-
-   * <a href="schema/accessor.schema.json">`accessor`</a>
-   * <a href="schema/animation.schema.json">`animation`</a>
-   * <a href="schema/animationChannel.schema.json">`animation/channel`</a>
-   * <a href="schema/animationChannelTarget.schema.json">`animation/channel/target`</a>
-   * <a href="schema/animationParameter.schema.json">`animation/parameter`</a>
-   * <a href="schema/animationSampler.schema.json">`animation/sampler`</a>
-   * <a href="schema/asset.schema.json">`asset`</a>
-   * <a href="schema/buffer.schema.json">`buffer`</a>
-   * <a href="schema/bufferView.schema.json">`bufferView`</a>
-   * <a href="schema/camera.schema.json">`camera`</a>
-   * <a href="schema/cameraOrthographic.schema.json">`camera/orthographic`</a>
-   * <a href="schema/cameraPerspective.schema.json">`camera/perspective`</a>
-   * <a href="schema/extension.schema.json">`extension`</a>
-   * <a href="schema/extras.schema.json">`extras`</a>
-   * <a href="schema/glTF.schema.json">`glTF`</a> (root property for model)
-   * <a href="schema/image.schema.json">`image`</a>
-   * <a href="schema/material.schema.json">`material`</a>
-   * <a href="schema/materialInstanceTechnique.schema.json">`material/instanceTechnique`</a>
-   * <a href="schema/materialInstanceTechniqueValues.schema.json">`material/instanceTechnique/values`</a>
-   * <a href="schema/mesh.schema.json">`mesh`</a>
-   * <a href="schema/meshPrimitive.schema.json">`mesh/primitive`</a>
-   * <a href="schema/meshPrimitiveAttribute.schema.json">`mesh/primitive/attribute`</a>
-   * <a href="schema/node.schema.json">`node`</a>
-   * <a href="schema/program.schema.json">`program`</a>
-   * <a href="schema/sampler.schema.json">`sampler`</a>
-   * <a href="schema/scene.schema.json">`scene`</a>
-   * <a href="schema/shader.schema.json">`shader`</a>
-   * <a href="schema/skin.schema.json">`skin`</a>
-   * <a href="schema/technique.schema.json">`technique`</a>
-   * <a href="schema/techniqueParameters.schema.json">`technique/parameters`</a>
-   * <a href="schema/techniquePass.schema.json">`technique/pass`</a>
-   * <a href="schema/techniquePassDetails.schema.json">`technique/pass/details`</a>
-   * <a href="schema/techniquePassDetailsCommonProfile.schema.json">`technique/pass/details/commonProfile`</a>
-   * <a href="schema/techniquePassDetailsCommonProfileTexcoordBindings.schema.json">`technique/pass/details/commonProfile/texcoordBindings`</a>
-   * <a href="schema/techniquePassInstanceProgram.schema.json">`technique/pass/instanceProgram`</a>
-   * <a href="schema/techniquePassInstanceProgramAttribute.schema.json">`technique/pass/instanceProgram/attribute`</a>
-   * <a href="schema/techniquePassInstanceProgramUniform.schema.json">`technique/pass/instanceProgram/uniform`</a>
-   * <a href="schema/techniquePassStates.schema.json">`technique/pass/states`</a>
-   * <a href="schema/texture.schema.json">`texture`</a>
 
 <a name="conformance"></a>
 # Conformance
@@ -1178,8 +1326,8 @@ This section will describe the format for each of the GL types stored in the bin
 <a name="acknowledgements"></a>
 # Acknowledgments
 
-* Brandon Jones, for the first version of Three.js loader and all his support in the early days of this project.
-* Tom Fili, Analytical Graphics, Inc.
+* Brandon Jones, Google
+* Tom Fili, Cesium
 * Scott Hunter, Analytical Graphics, Inc.
 * Ed Mackey, Analytical Graphics, Inc.
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -1767,28 +1767,207 @@ Application-specific data.
 * **Required**: No
 
 
-
-
 <!-- ======================================================================= -->
 <a name="reference-camera"></a>
 ## camera
 
+A camera's projection.  A node can reference a camera id to apply a transform to place the camera in the scene.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**orthographic**|[`camera.orthographic`](#reference-camera.orthographic)|An orthographic camera containing properties to create an orthographic projection matrix.|No|
+|**perspective**|[`camera.perspective`](#reference-camera.perspective)|A perspective camera containing properties to create a perspective projection matrix.|No|
+|**type**|`string`|Specifies if the camera uses a perspective or orthographic projection.| :white_check_mark: Yes|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [camera.schema.json](schema/camera.schema.json)
 * **Example**: [cameras.json](schema/examples/cameras.json)
+
+### camera.orthographic
+
+An orthographic camera containing properties to create an orthographic projection matrix.
+
+* **Type**: [`camera.orthographic`](#reference-camera.orthographic)
+* **Required**: No
+
+### camera.perspective
+
+A perspective camera containing properties to create a perspective projection matrix.
+
+* **Type**: [`camera.perspective`](#reference-camera.perspective)
+* **Required**: No
+
+### camera.type :white_check_mark: 
+
+Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's `perspective` or `orthographic` property will be defined.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**: `"perspective"`, `"orthographic"`
+
+### camera.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### camera.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### camera.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->
 <a name="reference-camera.orthographic"></a>
 ## camera.orthographic
 
+An orthographic camera containing properties to create an orthographic projection matrix.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**xmag**|`number`|The floating-point horizontal magnification of the view.| :white_check_mark: Yes|
+|**ymag**|`number`|The floating-point vertical magnification of the view.| :white_check_mark: Yes|
+|**zfar**|`number`|The floating-point distance to the far clipping plane.| :white_check_mark: Yes|
+|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 **JSON schema**: [camera.orthographic.schema.json](schema/camera.orthographic.schema.json)
+
+### orthographic.xmag :white_check_mark: 
+
+The floating-point horizontal magnification of the view.
+
+* **Type**: `number`
+* **Required**: Yes
+
+### orthographic.ymag :white_check_mark: 
+
+The floating-point vertical magnification of the view.
+
+* **Type**: `number`
+* **Required**: Yes
+
+### orthographic.zfar :white_check_mark: 
+
+The floating-point distance to the far clipping plane.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**:` >= 0`
+
+### orthographic.znear :white_check_mark: 
+
+The floating-point distance to the near clipping plane.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**:` >= 0`
+
+### orthographic.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### orthographic.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->
 <a name="reference-camera.perspective"></a>
 ## camera.perspective
 
+A perspective camera containing properties to create a perspective projection matrix.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**aspectRatio**|`number`|The floating-point aspect ratio of the field of view.|No|
+|**yfov**|`number`|The floating-point vertical field of view in radians.| :white_check_mark: Yes|
+|**zfar**|`number`|The floating-point distance to the far clipping plane.| :white_check_mark: Yes|
+|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 **JSON schema**: [camera.perspective.schema.json](schema/camera.perspective.schema.json)
+
+### perspective.aspectRatio
+
+The floating-point aspect ratio of the field of view.  When this is undefined, the aspect ratio of the canvas is used.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**:` >= 0`
+
+### perspective.yfov :white_check_mark: 
+
+The floating-point vertical field of view in radians.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**:` >= 0`
+
+### perspective.zfar :white_check_mark: 
+
+The floating-point distance to the far clipping plane.  zfar must be greater than znear.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**:` > 0`
+
+### perspective.znear :white_check_mark: 
+
+The floating-point distance to the near clipping plane.  zfar must be greater than znear.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**:` > 0`
+
+### perspective.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### perspective.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -41,7 +41,6 @@ Contributors
   * [Metadata](#metadata)
   * [Specifying Extensions](#specifying-extensions)
 * [Properties Reference](#properties)
-* [Conformance](#conformance)
 * [Acknowledgements](#acknowledgements)
 * [References](#references)
 
@@ -101,8 +100,6 @@ Version 1.0 of glTF does not define compression for geometry and other rich data
 
 <a name="mimetypes"></a>
 ## File Extensions and MIME Types
-
-<mark>*Todo: someone needs to get a MIME type RFC going with IANA...*</mark>
 
 * `*.gltf` files use `model/gltf+json`
 * `*.bin` files use `application/octet-stream`
@@ -292,9 +289,6 @@ The next example defines the transformation for a camera node using the `matrix`
         "name": "Camera01"
     },
 ```
-
-
-<mark>*Todo:conformance - what if author supplies both matrix and TRS? Which wins? Undefined?*</mark>
 
 ### Coordinate System and Units
 
@@ -1085,8 +1079,6 @@ Only the `version` property is required. Example:
     "version": 0.8
 }
 ```
-
-<mark>*Todo: Patrick what do we say about profiles, if anything?.*</mark>
 
 <a name="specifying-extensions"></a>
 ## Specifying Extensions
@@ -3012,11 +3004,6 @@ Application-specific data.
 * **Type**: `any`
 * **Required**: No
 
-
-<a name="conformance"></a>
-# Conformance
-
-<mark>*Todo: how do we tackle this?*</mark>
 
 <a name="acknowledgements"></a>
 # Acknowledgments

--- a/specification/README.md
+++ b/specification/README.md
@@ -2043,7 +2043,7 @@ The material appearance of a primitive.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**technique**|`string`|The id of the technique.|No|
+|**technique**|`string`|The id of the [technique](#reference-technique).|No|
 |**values**|`object`|A dictionary object of parameter values.|No, default: `{}`|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|

--- a/specification/README.md
+++ b/specification/README.md
@@ -1155,8 +1155,6 @@ For more information on glTF extensions, consult the [extensions registry specif
 
 A typed view into a [bufferView](#reference-bufferView).  A bufferView contain raw binary data.  An accessors provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.
 
-**Type**: `object`
-
 **Properties**
 
 |   |Type|Description|Required|
@@ -1273,22 +1271,22 @@ Application-specific data.
 * **Example**: [animations.json](schema/examples/animations.json)
 
 <a name="reference-animation.channel"></a>
-### channel
+## animation.channel
 
 **JSON schema**: [animation.channel.schema.json](schema/animation.channel.schema.json)
 
 <a name="reference-animation.channel.target"></a>
-#### target
+## animation.channel.target
 
 **JSON schema**: [animation.channel.target.schema.json](schema/animation.channel.target.schema.json)
 
 <a name="reference-animation.parameter"></a>
-### parameter
+## animation.parameter
 
 **JSON schema**: [animation.parameter.schema.json](schema/animation.parameter.schema.json)
 
 <a name="reference-animation.sampler"></a>
-### sampler
+## animation.sampler
 
 **JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
 
@@ -1299,7 +1297,7 @@ Application-specific data.
 * **Example**: [asset.json](schema/examples/asset.json)
 
 <a name="reference-asset.profile"></a>
-### profile
+## asset.profile
 
 **JSON schema**: [asset.profile.schema.json](schema/asset.profile.schema.json)
 
@@ -1322,12 +1320,12 @@ Application-specific data.
 * **Example**: [cameras.json](schema/examples/cameras.json)
 
 <a name="reference-camera.orthographic"></a>
-### orthographic
+## camera.orthographic
 
 **JSON schema**: [camera.orthographic.schema.json](schema/camera.orthographic.schema.json)
 
 <a name="reference-camera.perspective"></a>
-### perspective
+## camera.perspective
 
 **JSON schema**: [camera.perspective.schema.json](schema/camera.perspective.schema.json)
 
@@ -1349,7 +1347,7 @@ Application-specific data.
 * **Example**: [materials.json](schema/examples/materials.json)
 
 <a name="reference-material.values"></a>
-### values
+## material.values
 
 **JSON schema**: [material.values.schema.json](schema/material.values.schema.json)
 
@@ -1360,12 +1358,12 @@ Application-specific data.
 * **Example**: [meshes.json](schema/examples/meshes.json)
 
 <a name="reference-mesh.primitive"></a>
-### primitive
+## mesh.primitive
 
 **JSON schema**: [mesh.primitive.schema.json](schema/mesh.primitive.schema.json)
 
 <a name="reference-mesh.primitive.attribute"></a>
-#### attribute
+## mesh.primitive.attribute
 
 **JSON schema**: [mesh.primitive.attribute.schema.json](schema/mesh.primitive.attribute.schema.json)
 
@@ -1412,22 +1410,22 @@ Application-specific data.
 * **Example**: [techniques.json](schema/examples/techniques.json)
 
 <a name="reference-technique.attribute"></a>
-### attribute
+## technique.attribute
 
 **JSON schema**: [technique.attribute.schema.json](schema/technique.attribute.schema.json)
 
 <a name="reference-technique.parameters"></a>
-### parameters
+## technique.parameters
 
 **JSON schema**: [technique.parameters.schema.json](schema/technique.parameters.schema.json)
 
 <a name="reference-technique.states"></a>
-### states
+## technique.states
 
 **JSON schema**: [technique.states.schema.json](schema/technique.states.schema.json)
 
 <a name="reference-technique.uniform"></a>
-### uniform
+## technique.uniform
 
 **JSON schema**: [technique.uniform.schema.json](schema/technique.uniform.schema.json)
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -1976,13 +1976,62 @@ Application-specific data.
 
 **JSON schema**: [glTF.schema.json](schema/glTF.schema.json)
 
+TODO
+TODO
+TODO
+TODO
+TODO
+
 
 <!-- ======================================================================= -->
 <a name="reference-image"></a>
 ## image
 
+Image data used to create a texture.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**uri**|`string`|The uri of the image.| :white_check_mark: Yes|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [image.schema.json](schema/image.schema.json)
 * **Example**: [images.json](schema/examples/images.json)
+
+### image.uri :white_check_mark: 
+
+The uri of the image.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.  The image format must be jpg, png, bmp, or gif.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Format**: uri
+
+### image.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### image.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### image.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/README.md
+++ b/specification/README.md
@@ -1150,16 +1150,17 @@ For more information on glTF extensions, consult the [extensions registry specif
    * [uniform](#reference-technique.uniform)
 * [texture](#reference-texture)
 
-
 <a name="reference-accessor"></a>
 ## accessor
 
-**JSON schema**: [accessor.schema.json](schema/accessor.schema.json)
+* **JSON schema**: [accessor.schema.json](schema/accessor.schema.json)
+* **Example**: [accessors.json](/schema/examples/accessors.json)
 
 <a name="reference-animation"></a>
 ## animation
 
-**JSON schema**: [animation.schema.json](schema/animation.schema.json)
+* **JSON schema**: [animation.schema.json](schema/animation.schema.json)
+* **Example**: [animations.json](/schema/examples/animations.json)
 
 <a name="reference-animation.channel"></a>
 ### channel
@@ -1184,7 +1185,8 @@ For more information on glTF extensions, consult the [extensions registry specif
 <a name="reference-asset"></a>
 ## asset
 
-**JSON schema**: [asset.schema.json](schema/asset.schema.json)
+* **JSON schema**: [asset.schema.json](schema/asset.schema.json)
+* **Example**: [asset.json](/schema/examples/asset.json)
 
 <a name="reference-asset.profile"></a>
 ### profile
@@ -1194,17 +1196,20 @@ For more information on glTF extensions, consult the [extensions registry specif
 <a name="reference-buffer"></a>
 ## buffer
 
-**JSON schema**: [buffer.schema.json](schema/buffer.schema.json)
+* **JSON schema**: [buffer.schema.json](schema/buffer.schema.json)
+* **Example**: [buffers.json](/schema/examples/buffers.json)
 
 <a name="reference-bufferView"></a>
 ## bufferView
 
-**JSON schema**: [bufferView.schema.json](schema/bufferView.schema.json)
+* **JSON schema**: [bufferView.schema.json](schema/bufferView.schema.json)
+* **Example**: [bufferViews.json](/schema/examples/bufferViews.json)
 
 <a name="reference-camera"></a>
 ## camera
 
-**JSON schema**: [camera.schema.json](schema/camera.schema.json)
+* **JSON schema**: [camera.schema.json](schema/camera.schema.json)
+* **Example**: [cameras.json](/schema/examples/cameras.json)
 
 <a name="reference-camera.orthographic"></a>
 ### orthographic
@@ -1224,12 +1229,14 @@ For more information on glTF extensions, consult the [extensions registry specif
 <a name="reference-image"></a>
 ## image
 
-**JSON schema**: [image.schema.json](schema/image.schema.json)
+* **JSON schema**: [image.schema.json](schema/image.schema.json)
+* **Example**: [images.json](/schema/examples/images.json)
 
 <a name="reference-material"></a>
 ## material
 
-**JSON schema**: [material.schema.json](schema/material.schema.json)
+* **JSON schema**: [material.schema.json](schema/material.schema.json)
+* **Example**: [materials.json](/schema/examples/materials.json)
 
 <a name="reference-material.values"></a>
 ### values
@@ -1239,7 +1246,8 @@ For more information on glTF extensions, consult the [extensions registry specif
 <a name="reference-mesh"></a>
 ## mesh
 
-**JSON schema**: [mesh.schema.json](schema/mesh.schema.json)
+* **JSON schema**: [mesh.schema.json](schema/mesh.schema.json)
+* **Example**: [meshes.json](/schema/examples/meshes.json)
 
 <a name="reference-mesh.primitive"></a>
 ### primitive
@@ -1254,37 +1262,44 @@ For more information on glTF extensions, consult the [extensions registry specif
 <a name="reference-node"></a>
 ## node
 
-**JSON schema**: [node.schema.json](schema/node.schema.json)
+* **JSON schema**: [node.schema.json](schema/node.schema.json)
+* **Example**: [nodes.json](/schema/examples/nodes.json)
 
 <a name="reference-program"></a>
 ## program
 
-**JSON schema**: [program.schema.json](schema/program.schema.json)
+* **JSON schema**: [program.schema.json](schema/program.schema.json)
+* **Example**: [programs.json](/schema/examples/programs.json)
 
 <a name="reference-sampler"></a>
 ## sampler
 
-**JSON schema**: [sampler.schema.json](schema/sampler.schema.json)
+* **JSON schema**: [sampler.schema.json](schema/sampler.schema.json)
+* **Example**: [samplers.json](/schema/examples/samplers.json)
 
 <a name="reference-scene"></a>
 ## scene
 
-**JSON schema**: [scene.schema.json](schema/scene.schema.json)
+* **JSON schema**: [scene.schema.json](schema/scene.schema.json)
+* **Example**: [scenes.json](/schema/examples/scenes.json)
 
 <a name="reference-shader"></a>
 ## shader
 
-**JSON schema**: [shader.schema.json](schema/shader.schema.json)
+* **JSON schema**: [shader.schema.json](schema/shader.schema.json)
+* **Example**: [shaders.json](/schema/examples/shaders.json)
 
 <a name="reference-skin"></a>
 ## skin
 
-**JSON schema**: [skin.schema.json](schema/skin.schema.json)
+* **JSON schema**: [skin.schema.json](schema/skin.schema.json)
+* **Example**: [skins.json](/schema/examples/skins.json)
 
 <a name="reference-technique"></a>
 ## technique
 
-**JSON schema**: [technique.schema.json](schema/technique.schema.json)
+* **JSON schema**: [technique.schema.json](schema/technique.schema.json)
+* **Example**: [techniques.json](/schema/examples/techniques.json)
 
 <a name="reference-technique.attribute"></a>
 ### attribute
@@ -1309,7 +1324,8 @@ For more information on glTF extensions, consult the [extensions registry specif
 <a name="reference-texture"></a>
 ## texture
 
-**JSON schema**: [texture.schema.json](schema/texture.schema.json)
+* **JSON schema**: [texture.schema.json](schema/texture.schema.json)
+* **Example**: [textures.json](/schema/examples/textures.json)
 
 <a name="binarytypes"></a>
 # Binary Types Reference

--- a/specification/README.md
+++ b/specification/README.md
@@ -1153,8 +1153,118 @@ For more information on glTF extensions, consult the [extensions registry specif
 <a name="reference-accessor"></a>
 ## accessor
 
-* **JSON schema**: [accessor.schema.json](schema/accessor.schema.json)
-* **Example**: [accessors.json](schema/examples/accessors.json)
+    A typed view into a [bufferView](#reference-bufferView).  A bufferView contain raw binary data.  An accessors provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.
+
+    **Type**: `object`
+
+    **Properties**
+
+    |   |Type|Description|Required|
+    |---|----|-----------|--------|
+    |**bufferView**|`string`|The id of the bufferView.| :white_check_mark: Yes|
+    |**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes.| :white_check_mark: Yes|
+    |**byteStride**|`integer`|The stride, in bytes, between attributes referenced by this accessor.|No, default: `0`|
+    |**componentType**|`integer`|The datatype of components in the attribute.| :white_check_mark: Yes|
+    |**count**|`integer`|The number of attributes referenced by this accessor.| :white_check_mark: Yes|
+    |**type**|`string`|Specifies if the attribute is a scalar, vector, or matrix.| :white_check_mark: Yes|
+    |**max**|`number[1-16]`|Maximum value of each component in this attribute.|No|
+    |**min**|`number[1-16]`|Minimum value of each component in this attribute.|No|
+    |**name**|`string`|The user-defined name of this object.|No|
+    |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+    |**extras**|`any`|Application-specific data.|No|
+
+    Additional properties are not allowed.
+
+    * **JSON schema**: [accessor.schema.json](schema/accessor.schema.json)
+    * **Example**: [accessors.json](schema/examples/accessors.json)
+
+    ### accessor.bufferView :white_check_mark: 
+
+    The id of the bufferView.
+
+    * **Type**: `string`
+    * **Required**: Yes
+    * **Minimum Length**`: >= 1`
+
+    ### accessor.byteOffset :white_check_mark: 
+
+    The offset relative to the start of the bufferView in bytes.  This must be a multiple of the size of the data type.
+
+    * **Type**: `integer`
+    * **Required**: Yes
+    * **Minimum**:` >= 0`
+    * **Related WebGL functions**: `vertexAttribPointer()` offset parameter
+
+    ### accessor.byteStride
+
+    The stride, in bytes, between attributes referenced by this accessor.  When this is zero, the attributes are tightly packed.
+
+    * **Type**: `integer`
+    * **Required**: No, default: `0`
+    * **Minimum**:` >= 0`
+    * **Maximum**:` <= 255`
+    * **Related WebGL functions**: `vertexAttribPointer()` stride parameter
+
+    ### accessor.componentType :white_check_mark: 
+
+    The datatype of components in the attribute.  Valid values correspond to WebGL enums: `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), and `5126` (FLOAT).  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, and `Float32Array`, respectively.
+
+    * **Type**: `integer`
+    * **Required**: Yes
+    * **Allowed values**: `5120`, `5121`, `5122`, `5123`, `5126`
+
+    ### accessor.count :white_check_mark: 
+
+    The number of attributes referenced by this accessor, not to be confused with the number of bytes or number of components.
+
+    * **Type**: `integer`
+    * **Required**: Yes
+    * **Minimum**:` >= 1`
+
+    ### accessor.type :white_check_mark: 
+
+    Specifies if the attribute is a scalar, vector, or matrix, and the number of elements in the vector or matrix.
+
+    * **Type**: `string`
+    * **Required**: Yes
+    * **Allowed values**: `"SCALAR"`, `"VEC2"`, `"VEC3"`, `"VEC4"`, `"MAT2"`, `"MAT3"`, `"MAT4"`
+
+    ### accessor.max
+
+    Maximum value of each component in this attribute.  When both min and max arrays are defined, they have the same length.  The length is determined by the value of the type property.
+
+    * **Type**: `number[1-16]`
+    * **Required**: No
+
+    ### accessor.min
+
+    Minimum value of each component in this attribute.  When both min and max arrays are defined, they have the same length.  The length is determined by the value of the type property.
+
+    * **Type**: `number[1-16]`
+    * **Required**: No
+
+    ### accessor.name
+
+    The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+    * **Type**: `string`
+    * **Required**: No
+
+    ### accessor.extensions
+
+    Dictionary object with extension-specific objects.
+
+    * **Type**: `object`
+    * **Required**: No
+    * **Type of each property**: `object`
+
+    ### accessor.extras
+
+    Application-specific data.
+
+    * **Type**: `any`
+    * **Required**: No
+
 
 <a name="reference-animation"></a>
 ## animation

--- a/specification/README.md
+++ b/specification/README.md
@@ -1274,7 +1274,7 @@ A keyframe animation.
 |---|----|-----------|--------|
 |**channels**|[`animation.channel[]`](#reference-animation.channel)|An array of channels, each of which targets an animation's sampler at a node's property.|No, default: `[]`|
 |**parameters**|`object`|A dictionary object of strings whose values are ids of accessors with keyframe data, e.g., time, translation, rotation, etc.|No, default: `{}`|
-|**samplers**|`object`|A dictionary object of [`animation.sampler`](#reference-animation.sampler)s that combines input and output parameters with an interpolation algorithm to define a keyframe graph (but not its target).|No, default: `{}`|
+|**samplers**|`object`|A dictionary object of [`animation.sampler`](#reference-animation.sampler) objects that combines input and output parameters with an interpolation algorithm to define a keyframe graph (but not its target).|No, default: `{}`|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
@@ -1301,7 +1301,7 @@ A dictionary object of strings whose values are ids of accessors with keyframe d
 
 ### animation.samplers
 
-A dictionary object of [`animation.sampler`](#reference-animation.sampler)s that combines input and output parameters with an interpolation algorithm to define a keyframe graph (but not its target).
+A dictionary object of [`animation.sampler`](#reference-animation.sampler) objects that combines input and output parameters with an interpolation algorithm to define a keyframe graph (but not its target).
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -1978,24 +1978,24 @@ The root object for a glTF asset.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**accessors**|`object`|A dictionary object of [`accessor`](#reference-accessor)s.|No, default: `{}`|
-|**animations**|`object`|A dictionary object of keyframe [`animation`](#reference-animation)s.|No, default: `{}`|
+|**accessors**|`object`|A dictionary object of [`accessor`](#reference-accessor) objects.|No, default: `{}`|
+|**animations**|`object`|A dictionary object of keyframe [`animation`](#reference-animation) objects.|No, default: `{}`|
 |**asset**|[`asset`](#reference-asset)|Metadata about the glTF asset.|No, default: `{}`|
-|**buffers**|`object`|A dictionary object of [`buffer`](#reference-buffer)s.|No, default: `{}`|
-|**bufferViews**|`object`|A dictionary object of [`bufferView`](#reference-bufferView)s.|No, default: `{}`|
-|**cameras**|`object`|A dictionary object of [`camera`](#reference-camera)s.|No, default: `{}`|
-|**images**|`object`|A dictionary object of [`image`](#reference-image)s.|No, default: `{}`|
-|**materials**|`object`|A dictionary object of [`material`](#reference-material)s.|No, default: `{}`|
+|**buffers**|`object`|A dictionary object of [`buffer`](#reference-buffer) objects.|No, default: `{}`|
+|**bufferViews**|`object`|A dictionary object of [`bufferView`](#reference-bufferView) objects.|No, default: `{}`|
+|**cameras**|`object`|A dictionary object of [`camera`](#reference-camera) objects.|No, default: `{}`|
+|**images**|`object`|A dictionary object of [`image`](#reference-image) objects.|No, default: `{}`|
+|**materials**|`object`|A dictionary object of [`material`](#reference-material) objects.|No, default: `{}`|
 |**meshes**|`object`|A dictionary object of [`mesh`](#reference-mesh)es.|No, default: `{}`|
-|**nodes**|`object`|A dictionary object of [`node`](#reference-node)s.|No, default: `{}`|
-|**programs**|`object`|A dictionary object of [`program`](#reference-program)s.|No, default: `{}`|
-|**samplers**|`object`|A dictionary object of [`sampler`](#reference-sampler)s.|No, default: `{}`|
+|**nodes**|`object`|A dictionary object of [`node`](#reference-node) objects.|No, default: `{}`|
+|**programs**|`object`|A dictionary object of [`program`](#reference-program) objects.|No, default: `{}`|
+|**samplers**|`object`|A dictionary object of [`sampler`](#reference-sampler) objects.|No, default: `{}`|
 |**scene**|`string`|The id of the default scene.|No|
-|**scenes**|`object`|A dictionary object of [`scene`](#reference-scene)s.|No, default: `{}`|
-|**shaders**|`object`|A dictionary object of [`shader`](#reference-shader)s.|No, default: `{}`|
-|**skins**|`object`|A dictionary object of [`skin`](#reference-skin)s.|No, default: `{}`|
-|**techniques**|`object`|A dictionary object of [`technique`](#reference-technique)s.|No, default: `{}`|
-|**textures**|`object`|A dictionary object of [`texture`](#reference-texture)s.|No, default: `{}`|
+|**scenes**|`object`|A dictionary object of [`scene`](#reference-scene) objects.|No, default: `{}`|
+|**shaders**|`object`|A dictionary object of [`shader`](#reference-shader) objects.|No, default: `{}`|
+|**skins**|`object`|A dictionary object of [`skin`](#reference-skin) objects.|No, default: `{}`|
+|**techniques**|`object`|A dictionary object of [`technique`](#reference-technique) objects.|No, default: `{}`|
+|**textures**|`object`|A dictionary object of [`texture`](#reference-texture) objects.|No, default: `{}`|
 |**extensionsUsed**|`string[]`|Names of extensions used somewhere in this asset.|No, default: `[]`|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
@@ -2006,7 +2006,7 @@ Additional properties are not allowed.
 
 ### glTF.accessors
 
-A dictionary object of [`accessor`](#reference-accessor)s.  The name of each accessor is an id in the global glTF namespace that is used to reference the accessor.  An accessor is a A typed view into a bufferView.
+A dictionary object of [`accessor`](#reference-accessor) objects.  The name of each accessor is an id in the global glTF namespace that is used to reference the accessor.  An accessor is a A typed view into a bufferView.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2014,7 +2014,7 @@ A dictionary object of [`accessor`](#reference-accessor)s.  The name of each acc
 
 ### glTF.animations
 
-A dictionary object of keyframe [`animation`](#reference-animation)s.  The name of each animation is an id in the global glTF namespace that is used to reference the animation.
+A dictionary object of keyframe [`animation`](#reference-animation) objects.  The name of each animation is an id in the global glTF namespace that is used to reference the animation.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2029,7 +2029,7 @@ Metadata about the glTF asset.
 
 ### glTF.buffers
 
-A dictionary object of [`buffer`](#reference-buffer)s.  The name of each buffer is an id in the global glTF namespace that is used to reference the buffer.  A buffer points to binary geometry, animation, or skins.
+A dictionary object of [`buffer`](#reference-buffer) objects.  The name of each buffer is an id in the global glTF namespace that is used to reference the buffer.  A buffer points to binary geometry, animation, or skins.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2037,7 +2037,7 @@ A dictionary object of [`buffer`](#reference-buffer)s.  The name of each buffer 
 
 ### glTF.bufferViews
 
-A dictionary object of [`bufferView`](#reference-bufferView)s.  The name of each bufferView is an id in the global glTF namespace that is used to reference the bufferView.  A bufferView is a view into a buffer generally representing a subset of the buffer.
+A dictionary object of [`bufferView`](#reference-bufferView) objects.  The name of each bufferView is an id in the global glTF namespace that is used to reference the bufferView.  A bufferView is a view into a buffer generally representing a subset of the buffer.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2045,7 +2045,7 @@ A dictionary object of [`bufferView`](#reference-bufferView)s.  The name of each
 
 ### glTF.cameras
 
-A dictionary object of [`camera`](#reference-camera)s.  The name of each camera is an id in the global glTF namespace that is used to reference the camera.  A camera defines a projection matrix.
+A dictionary object of [`camera`](#reference-camera) objects.  The name of each camera is an id in the global glTF namespace that is used to reference the camera.  A camera defines a projection matrix.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2053,7 +2053,7 @@ A dictionary object of [`camera`](#reference-camera)s.  The name of each camera 
 
 ### glTF.images
 
-A dictionary object of [`image`](#reference-image)s.  The name of each image is an id in the global glTF namespace that is used to reference the image.  An image defines data used to create a texture.
+A dictionary object of [`image`](#reference-image) objects.  The name of each image is an id in the global glTF namespace that is used to reference the image.  An image defines data used to create a texture.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2061,7 +2061,7 @@ A dictionary object of [`image`](#reference-image)s.  The name of each image is 
 
 ### glTF.materials
 
-A dictionary object of [`material`](#reference-material)s.  The name of each material is an id in the global glTF namespace that is used to reference the material.  A material defines the appearance of a primitive.
+A dictionary object of [`material`](#reference-material) objects.  The name of each material is an id in the global glTF namespace that is used to reference the material.  A material defines the appearance of a primitive.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2077,7 +2077,7 @@ A dictionary object of [`mesh`](#reference-mesh)es.  The name of each mesh is an
 
 ### glTF.nodes
 
-A dictionary object of [`node`](#reference-node)s in the node hierarchy.  The name of each node is an id in the global glTF namespace that is used to reference the node.
+A dictionary object of [`node`](#reference-node) objects in the node hierarchy.  The name of each node is an id in the global glTF namespace that is used to reference the node.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2085,7 +2085,7 @@ A dictionary object of [`node`](#reference-node)s in the node hierarchy.  The na
 
 ### glTF.programs
 
-A dictionary object of shader [`program`](#reference-program)s.  The name of each program is an id in the global glTF namespace that is used to reference the program.
+A dictionary object of shader [`program`](#reference-program) objects.  The name of each program is an id in the global glTF namespace that is used to reference the program.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2093,7 +2093,7 @@ A dictionary object of shader [`program`](#reference-program)s.  The name of eac
 
 ### glTF.samplers
 
-A dictionary object of [`sampler`](#reference-sampler)s.  The name of each sampler is an id in the global glTF namespace that is used to reference the sampler.  A sampler contains properties for texture filtering and wrapping modes.
+A dictionary object of [`sampler`](#reference-sampler) objects.  The name of each sampler is an id in the global glTF namespace that is used to reference the sampler.  A sampler contains properties for texture filtering and wrapping modes.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2109,7 +2109,7 @@ The id of the default scene.
 
 ### glTF.scenes
 
-A dictionary object of [`scene`](#reference-scene)s.  The name of each scene is an id in the global glTF namespace that is used to reference the scene.
+A dictionary object of [`scene`](#reference-scene) objects.  The name of each scene is an id in the global glTF namespace that is used to reference the scene.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2117,7 +2117,7 @@ A dictionary object of [`scene`](#reference-scene)s.  The name of each scene is 
 
 ### glTF.shaders
 
-A dictionary object of [`shader`](#reference-shader)s.  The name of each shader is an id in the global glTF namespace that is used to reference the shader.
+A dictionary object of [`shader`](#reference-shader) objects.  The name of each shader is an id in the global glTF namespace that is used to reference the shader.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2125,7 +2125,7 @@ A dictionary object of [`shader`](#reference-shader)s.  The name of each shader 
 
 ### glTF.skins
 
-A dictionary object of [`skin`](#reference-skin)s.  The name of each skin is an id in the global glTF namespace that is used to reference the skin.  A skin is defined by joints and matrices.
+A dictionary object of [`skin`](#reference-skin) objects.  The name of each skin is an id in the global glTF namespace that is used to reference the skin.  A skin is defined by joints and matrices.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2133,7 +2133,7 @@ A dictionary object of [`skin`](#reference-skin)s.  The name of each skin is an 
 
 ### glTF.techniques
 
-A dictionary object of [`technique`](#reference-technique)s.  The name of each technique is an id in the global glTF namespace that is used to reference the technique.  A technique is a template for a material appearance.
+A dictionary object of [`technique`](#reference-technique) objects.  The name of each technique is an id in the global glTF namespace that is used to reference the technique.  A technique is a template for a material appearance.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`
@@ -2141,7 +2141,7 @@ A dictionary object of [`technique`](#reference-technique)s.  The name of each t
 
 ### glTF.textures
 
-A dictionary object of [`texture`](#reference-texture)s.  The name of each texture is an id in the global glTF namespace that is used to reference the texture.
+A dictionary object of [`texture`](#reference-texture) objects.  The name of each texture is an id in the global glTF namespace that is used to reference the texture.
 
 * **Type**: `object`
 * **Required**: No, default: `{}`

--- a/specification/README.md
+++ b/specification/README.md
@@ -2217,8 +2217,132 @@ Application-specific data.
 <a name="reference-node"></a>
 ## node
 
+A node in the node hierarchy.  A node can have either the `camera`, `meshes`, or `skeletons`/`skin`/`meshes` properties defined.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties.  If none are provided, the transform is the identity.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**camera**|`string`|The id of the [camera](#reference-camera) referenced by this node.|No|
+|**children**|`string[]`|The ids of this node's children.|No, default: `[]`|
+|**skeletons**|`string[]`|The id of skeleton nodes.|No|
+|**skin**|`string`|The id of the [skin](#reference-skin) referenced by this node.|No|
+|**jointName**|`string`|Name used when this node is a joint in a skin.|No|
+|**matrix**|`number[16]`|A floating-point 4x4 transformation matrix stored in column-major order.|No, default: `[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]`|
+|**meshes**|`string[]`|The ids of the [meshes](#reference-mesh) in this node.|No|
+|**rotation**|`number[4]`|The node's unit quaternion rotation in the order (x, y, z, w) where w is the scalar.|No, default: `[0,0,0,0.1]`|
+|**scale**|`number[3]`|The node's non-uniform scale.|No, default: `[1,1,1]`|
+|**translation**|`number[3]`|The node's translation.|No, default: `[0,0,0]`|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
+|**extras**|`any`|Application-specific data.|No|
+
+Additional properties are not allowed.
+
 * **JSON schema**: [node.schema.json](schema/node.schema.json)
 * **Example**: [nodes.json](schema/examples/nodes.json)
+
+### node.camera
+
+The id of the camera referenced by this node.
+
+* **Type**: `string`
+* **Required**: No
+* **Minimum Length**`: >= 1`
+
+### node.children
+
+The ids of this node's children.
+
+* **Type**: `string[]`
+   * Each element in the array must be unique.
+   * Each element in the array must have length greater than or equal to `1`.
+* **Required**: No, default: `[]`
+
+### node.skeletons
+
+The id of skeleton nodes.  Each node defines a subtree, which has a `jointName` of the corresponding element in the referenced `skin.joints`.
+
+* **Type**: `string[]`
+   * Each element in the array must be unique.
+   * Each element in the array must have length greater than or equal to `1`.
+* **Required**: No
+
+### node.skin
+
+The id of the skin referenced by this node.
+
+* **Type**: `string`
+* **Required**: No
+* **Minimum Length**`: >= 1`
+
+### node.jointName
+
+Name used when this node is a joint in a skin.
+
+* **Type**: `string`
+* **Required**: No
+* **Minimum Length**`: >= 1`
+
+### node.matrix
+
+A floating-point 4x4 transformation matrix stored in column-major order.
+
+* **Type**: `number[16]`
+* **Required**: No, default: `[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]`
+* **Related WebGL functions**: `uniformMatrix4fv()` with the transpose parameter equal to false
+
+### node.meshes
+
+The ids of the meshes in this node.  Multiple meshes are allowed so each can share the same transform matrix.
+
+* **Type**: `string[]`
+   * Each element in the array must be unique.
+   * Each element in the array must have length greater than or equal to `1`.
+* **Required**: No
+
+### node.rotation
+
+The node's unit quaternion rotation in the order (x, y, z, w) where w is the scalar.
+
+* **Type**: `number[4]`
+* **Required**: No, default: `[0,0,0,0.1]`
+
+### node.scale
+
+The node's non-uniform scale.
+
+* **Type**: `number[3]`
+* **Required**: No, default: `[1,1,1]`
+
+### node.translation
+
+The node's translation.
+
+* **Type**: `number[3]`
+* **Required**: No, default: `[0,0,0]`
+
+### node.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+### node.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `object`
+* **Required**: No
+* **Type of each property**: `object`
+
+### node.extras
+
+Application-specific data.
+
+* **Type**: `any`
+* **Required**: No
 
 
 <!-- ======================================================================= -->

--- a/specification/schema/accessor.schema.json
+++ b/specification/schema/accessor.schema.json
@@ -2,7 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "accessor",
     "type" : "object",
-    "description" : "A typed accessor into a bufferView.",
+    "description" : "A typed view into a bufferView.  A bufferView contain raw binary data.  An accessors provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
         "bufferView" : {
@@ -12,10 +12,10 @@
         },
         "byteOffset" : {
             "type" : "integer",
-            "description" : "The offset relative to the bufferView in bytes.",
+            "description" : "The offset relative to the start of the bufferView in bytes.",
             "minimum" : 0,
             "required" : true,
-            "gltf_detailedDescription" : "The offset relative to the bufferView in bytes.  This must be a multiple of the size of the data type.",
+            "gltf_detailedDescription" : "The offset relative to the start of the bufferView in bytes.  This must be a multiple of the size of the data type.",
             "gltf_webgl" : "`vertexAttribPointer()` offset parameter"
         },
         "byteStride" : {
@@ -32,19 +32,21 @@
             "description" : "The datatype of components in the attribute.",
             "enum" : [5120, 5121, 5122, 5123, 5126],
             "required" : true,
-            "gltf_detailedDescription" : "The datatype of components in the attribute.  Valid values are BYTE (5120), UNSIGNED_BYTE (5121), SHORT (5122), UNSIGNED_SHORT (5123), FLOAT (5126).  The corresponding typed arrays are Int8Array, Uint8Array, Int16Array, Uint16Array, and Float32Array."
+            "gltf_detailedDescription" : "The datatype of components in the attribute.  Valid values correspond to WebGL enums: `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), and `5126` (FLOAT).  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, and `Float32Array`, respectively."
         },
         "count" : {
             "type" : "integer",
-            "description" : "The number of attributes referenced by this accessor, not to be confused with the number of bytes or number of components.",
+            "description" : "The number of attributes referenced by this accessor.",
             "minimum" : 1,
-            "required" : true
+            "required" : true,
+            "gltf_detailedDescription" : "The number of attributes referenced by this accessor, not to be confused with the number of bytes or number of components."
         },
         "type" : {
             "type" : "string",
             "description" : "Specifies if the attribute is a scalar, vector, or matrix.",
             "enum" : ["SCALAR", "VEC2", "VEC3", "VEC4", "MAT2", "MAT3", "MAT4"],
-            "required" : true
+            "required" : true,
+            "gltf_detailedDescription" : "Specifies if the attribute is a scalar, vector, or matrix, and the number of elements in the vector or matrix."
         },        
         "max" : {
             "type" : "array",

--- a/specification/schema/animation.channel.schema.json
+++ b/specification/schema/animation.channel.schema.json
@@ -2,17 +2,18 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "channel",
     "type" : "object",
-    "description" : "Targets a sampler at a glTF property.",
+    "description" : "Targets an animation's sampler at a node's property.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
         "sampler" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
-            "description" : "The id of a sampler in this animation to use to compute the value for the target, e.g., a node's translation, rotation, or scale.",
-            "required" : true
+            "description" : "The id of a sampler in this animation to use to compute the value for the target.",
+            "required" : true,
+            "gltf_detailedDescription" : "The id of a sampler in this animation to use to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS)."
         },
         "target" : {
             "extends" : { "$ref" : "animation.channel.target.schema.json" },
-            "description" : "The glTF property to target from an animation channel.",
+            "description" : "The id of the node and TRS property to target.",
             "required" : true
         }
     },

--- a/specification/schema/animation.channel.target.schema.json
+++ b/specification/schema/animation.channel.target.schema.json
@@ -2,6 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "target",
     "type" : "object",
+    "description" : "The id of the node and TRS property that an animation channel targets.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
         "id" : {
@@ -11,7 +12,7 @@
         },
         "path" : {
             "type" : "string",
-            "description" : "The node property name to modify.",
+            "description" : "The name of the node's TRS property to modify.",
             "enum" : ["translation", "rotation", "scale"],
             "required" : true
         }

--- a/specification/schema/animation.sampler.schema.json
+++ b/specification/schema/animation.sampler.schema.json
@@ -2,20 +2,21 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "sampler",
     "type" : "object",
-    "description" : "Combines input and output parameters with an interpolation algorithm.",
+    "description" : "Combines input and output parameters with an interpolation algorithm to define a keyframe graph (but not its target).",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
         "input" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
-            "description" : "The id of a parameter in this animation to use as keyframe input, e.g., time.  This parameter must have type FLOAT.  The values represent time in seconds with time[0] >= 0.0, and monotonically increasing values, i.e. time[n + 1] >= time[n].",
-            "required" : true
+            "description" : "The id of a parameter in this animation to use as keyframe input, e.g., time.",
+            "required" : true,
+            "gltf_detailedDescription" : "The id of a parameter in this animation to use as keyframe input.  This parameter must have type `FLOAT`.  The values represent time in seconds with `time[0] >= 0.0`, and monotonically increasing values, i.e. `time[n + 1] >= time[n]`."
         },
         "interpolation" : {
             "type" : "string",
             "description" : "Interpolation algorithm.",
             "enum" : ["LINEAR"],
             "default" : "LINEAR",
-            "gltf_detailedDescription" : "Interpolation algorithm.  When an animation targets a node's rotation and the animation's interpolation is LINEAR, spherical linear interpolation (slerp) should be used to interpolate quaternions."
+            "gltf_detailedDescription" : "Interpolation algorithm.  When an animation targets a node's rotation and the animation's interpolation is `\"LINEAR\"`, spherical linear interpolation (slerp) should be used to interpolate quaternions."
         },
         "output" : {
             "extends" : { "$ref" : "glTFid.schema.json" },

--- a/specification/schema/animation.schema.json
+++ b/specification/schema/animation.schema.json
@@ -15,7 +15,7 @@
         },
         "parameters" : {
             "type" : "object",
-            "description" : "A dictionary object containing accessors with keyframe data, e.g., time, translation, rotation, etc.",
+            "description" : "A dictionary object of strings whose values are ids of accessors with keyframe data, e.g., time, translation, rotation, etc.",
             "properties" : {
             },
             "additionalProperties" : {

--- a/specification/schema/animation.schema.json
+++ b/specification/schema/animation.schema.json
@@ -2,17 +2,20 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "animation",
     "type" : "object",
-    "description" : "Keyframe animation.",
+    "description" : "A keyframe animation.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
         "channels" : {
             "type" : "array",
+            "description" : "An array of channels, each of which targets an animation's sampler at a node's property.",
             "items" : {
                 "$ref" : "animation.channel.schema.json"
             },
             "default" : []
         },
         "parameters" : {
+            "type" : "object",
+            "description" : "A dictionary object containing accessors with keyframe data, e.g., time, translation, rotation, etc.",
             "properties" : {
             },
             "additionalProperties" : {
@@ -21,6 +24,8 @@
             "default" : {}
         },
         "samplers" : {
+            "type" : "object",
+            "description" : "A dictionary object of samplers that combines input and output parameters with an interpolation algorithm to define a keyframe graph (but not its target).",
             "properties" : {
             },
             "additionalProperties" : {

--- a/specification/schema/asset.schema.json
+++ b/specification/schema/asset.schema.json
@@ -2,6 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "asset",
     "type" : "object",
+    "description" : "Metadata about the glTF asset.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
         "copyright" : {

--- a/specification/schema/buffer.schema.json
+++ b/specification/schema/buffer.schema.json
@@ -2,7 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "buffer",
     "type" : "object",
-    "description" : "Buffers contain geometry, animation, or skins.",
+    "description" : "A buffer points to binary geometry, animation, or skins.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
         "uri" : {
@@ -20,7 +20,7 @@
         },
         "type" : {
             "type" : "string",
-            "description" : "XMLHttpRequest responseType.",
+            "description" : "XMLHttpRequest `responseType`.",
             "enum" : ["arraybuffer", "text"],
             "default" : "arraybuffer"
         }

--- a/specification/schema/bufferView.schema.json
+++ b/specification/schema/bufferView.schema.json
@@ -2,7 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "bufferView",
     "type" : "object",
-    "description" : "A view into a buffer.",
+    "description" : "A view into a buffer generally representing a subset of the buffer.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
         "buffer" : {

--- a/specification/schema/bufferView.schema.json
+++ b/specification/schema/bufferView.schema.json
@@ -26,7 +26,7 @@
             "type" : "integer",
             "description" : "The target that the WebGL buffer should be bound to.",
             "enum" : [34962, 34963],
-            "gltf_detailedDescription" : "The target that the WebGL buffer should be bound to.  Valid values are 34962 (ARRAY_BUFFER) or 34963 (ELEMENT_ARRAY_BUFFER).  When this is not provided, the bufferView contains animation or skin data.",
+            "gltf_detailedDescription" : "The target that the WebGL buffer should be bound to.  Valid values correspond to WebGL enums: `34962` (ARRAY_BUFFER) and `34963` (ELEMENT_ARRAY_BUFFER).  When this is not provided, the bufferView contains animation or skin data.",
             "gltf_webgl" : "`bindBuffer()`"
         }
     },

--- a/specification/schema/camera.orthographic.schema.json
+++ b/specification/schema/camera.orthographic.schema.json
@@ -2,6 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "orthographic",
     "type" : "object",
+    "description" : "An orthographic camera containing properties to create an orthographic projection matrix.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
         "xmag" : {

--- a/specification/schema/camera.perspective.schema.json
+++ b/specification/schema/camera.perspective.schema.json
@@ -2,6 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "perspective",
     "type" : "object",
+    "description" : "A perspective camera containing properties to create a perspective projection matrix.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
         "aspectRatio" : {
@@ -20,13 +21,17 @@
             "type" : "number",
             "description" : "The floating-point distance to the far clipping plane.",
             "required" : true,
-            "exclusiveMinimum" : 0.0
+            "minimum" : 0.0,
+            "exclusiveMinimum" : true,
+            "gltf_detailedDescription" : "The floating-point distance to the far clipping plane.  zfar must be greater than znear."
         },
         "znear" : {
             "type" : "number",
             "description" : "The floating-point distance to the near clipping plane.",
             "required" : true,
-            "exclusiveMinimum" : 0.0
+            "minimum" : 0.0,
+            "exclusiveMinimum" : true,
+            "gltf_detailedDescription" : "The floating-point distance to the near clipping plane.  zfar must be greater than znear."
         }
     },
     "additionalProperties" : false

--- a/specification/schema/camera.schema.json
+++ b/specification/schema/camera.schema.json
@@ -2,7 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "camera",
     "type" : "object",
-    "description" : "A camera's projection.",
+    "description" : "A camera's projection.  A node can reference a camera id to apply a transform to place the camera in the scene.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
         "orthographic" : {
@@ -17,7 +17,8 @@
             "type" : "string",
             "description" : "Specifies if the camera uses a perspective or orthographic projection.",
             "enum" : ["perspective", "orthographic"],
-            "required" : true
+            "required" : true,
+            "gltf_detailedDescription" : "Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's `perspective` or `orthographic` property will be defined."
         }
     },
     "additionalProperties" : false

--- a/specification/schema/extension.schema.json
+++ b/specification/schema/extension.schema.json
@@ -2,7 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "extension",
     "type" : "object",
-    "description" : "Properties specific an extension.",
+    "description" : "Dictionary object with extension-specific objects.",
     "properties" : {
     },
     "additionalProperties" : {

--- a/specification/schema/extras.schema.json
+++ b/specification/schema/extras.schema.json
@@ -2,5 +2,5 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "extras",
     "type" : "any",
-    "description" : "Optional application-specific data."
+    "description" : "Application-specific data."
 }

--- a/specification/schema/glTF.schema.json
+++ b/specification/schema/glTF.schema.json
@@ -2,12 +2,12 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "glTF",
     "type" : "object",
-    "description" : "Root glTF property.",
+    "description" : "The root object for a glTF asset.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
         "extensionsUsed" : {
             "type" : "array",
-            "description" : "Names of extensions used throughout model.",
+            "description" : "Names of extensions used somewhere in this asset.",
             "items" : {
                 "type" : "string"
             },
@@ -16,141 +16,189 @@
             "gltf_webgl" : "`getSupportedExtensions()` and `getExtension()`"
         },
         "accessors" : {
+            "type" : "object",
+            "description" : "A dictionary object of accessors.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "accessor.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of accessors.  The name of each accessor is an id in the global glTF namespace that is used to reference the accessor.  An accessor is a A typed view into a bufferView."
         },
         "animations" : {
+            "type" : "object",
+            "description" : "A dictionary object of keyframe animations.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "animation.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of keyframe animations.  The name of each animation is an id in the global glTF namespace that is used to reference the animation."
         },
         "asset" : {
             "extends" : { "$ref" : "asset.schema.json" },
-            "description" : "Asset-management information.",
+            "description" : "Metadata about the glTF asset.",
             "default" : {}
         },
         "buffers" : {
+            "type" : "object",
+            "description" : "A dictionary object of buffers.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "buffer.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of buffers.  The name of each buffer is an id in the global glTF namespace that is used to reference the buffer.  A buffer points to binary geometry, animation, or skins."
         },
         "bufferViews" : {
+            "type" : "object",
+            "description" : "A dictionary object of bufferViews.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "bufferView.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of bufferViews.  The name of each bufferView is an id in the global glTF namespace that is used to reference the bufferView.  A bufferView is a view into a buffer generally representing a subset of the buffer."
         },
         "cameras" : {
+            "type" : "object",
+            "description" : "A dictionary object of cameras.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "camera.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of cameras.  The name of each camera is an id in the global glTF namespace that is used to reference the camera.  A camera defines a projection matrix."
         },
         "images" : {
+            "type" : "object",
+            "description" : "A dictionary object of images.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "image.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of images.  The name of each image is an id in the global glTF namespace that is used to reference the image.  An image defines data used to create a texture."
         },
         "materials" : {
+            "type" : "object",
+            "description" : "A dictionary object of materials.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "material.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of materials.  The name of each material is an id in the global glTF namespace that is used to reference the material.  A material defines the appearance of a primitive."
         },
         "meshes" : {
+            "type" : "object",
+            "description" : "A dictionary object of meshes.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "mesh.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of meshes.  The name of each mesh is an id in the global glTF namespace that is used to reference the mesh.  A mesh is a set of primitives to be rendered."
         },
         "nodes" : {
+            "type" : "object",
+            "description" : "A dictionary object of nodes.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "node.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of nodes in the node hierarchy.  The name of each node is an id in the global glTF namespace that is used to reference the node."
         },
         "programs" : {
+            "type" : "object",
+            "description" : "A dictionary object of programs.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "program.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of shader programs.  The name of each program is an id in the global glTF namespace that is used to reference the program."
         },
         "samplers" : {
+            "type" : "object",
+            "description" : "A dictionary object of samplers.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "sampler.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of samplers.  The name of each sampler is an id in the global glTF namespace that is used to reference the sampler.  A sampler contains properties for texture filtering and wrapping modes."
         },
         "scene" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
             "description" : "The id of the default scene."
         },
         "scenes" : {
+            "type" : "object",
+            "description" : "A dictionary object of scenes.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "scene.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of scenes.  The name of each scene is an id in the global glTF namespace that is used to reference the scene."
         },
         "shaders" : {
+            "type" : "object",
+            "description" : "A dictionary object of shaders.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "shader.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of shaders.  The name of each shader is an id in the global glTF namespace that is used to reference the shader."
         },
         "skins" : {
+            "type" : "object",
+            "description" : "A dictionary object of skins.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "skin.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of skins.  The name of each skin is an id in the global glTF namespace that is used to reference the skin.  A skin is defined by joints and matrices."
         },
         "techniques" : {
+            "type" : "object",
+            "description" : "A dictionary object of techniques.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "technique.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of techniques.  The name of each technique is an id in the global glTF namespace that is used to reference the technique.  A technique is a template for a material appearance."
         },
         "textures" : {
+            "type" : "object",
+            "description" : "A dictionary object of textures.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "texture.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of textures.  The name of each texture is an id in the global glTF namespace that is used to reference the texture."
         }
     },
     "dependencies" : {

--- a/specification/schema/material.schema.json
+++ b/specification/schema/material.schema.json
@@ -2,20 +2,24 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "material",
     "type" : "object",
-    "description" : "An instance of a technique with parameter value overrides.",
+    "description" : "The material appearance of a primitive.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties": {
         "technique" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
-            "description" : "The id of the technique. TODO: define technique when this is undefined"
+            "description" : "The id of the technique.",
+            "gltf_detailedDescription" : "The id of the technique.  If this is not supplied, and no extension is present that defines material properties, then the primitive should be rendered using a default material with 50% gray emissive color."
         },
         "values" : {
+            "type" : "object",
+            "description" : "A dictionary object of parameter values.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "material.values.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of parameter values.  Parameters with the same name as the technique's parameter override the technique's parameter value."
         }
     },
     "additionalProperties" : false

--- a/specification/schema/material.values.schema.json
+++ b/specification/schema/material.values.schema.json
@@ -2,5 +2,5 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "values",
     "type" : ["number", "boolean", "string", { "$ref" : "arrayValues.schema.json" }],
-    "description" : "Parameter values that override the values in the technique with the same parameter name."
+    "description" : "A dictionary object of parameter values.  Parameters with the same name as the technique's parameter override the technique's parameter value."
 }

--- a/specification/schema/mesh.primitive.attribute.schema.json
+++ b/specification/schema/mesh.primitive.attribute.schema.json
@@ -2,5 +2,5 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "attribute",
     "extends" : { "$ref" : "glTFid.schema.json" },
-    "description" : "The id of the accessor that contains the attribute."
+    "description" : "A dictionary object of strings, where each string is the id of the accessor containing an attribute."
 }

--- a/specification/schema/mesh.primitive.schema.json
+++ b/specification/schema/mesh.primitive.schema.json
@@ -2,10 +2,12 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "primitive",
     "type" : "object",
-    "description" : "Geometry and material.",
+    "description" : "Geometry to be rendered with the given material.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
         "attributes" : {
+            "type" : "object",
+            "description" : "A dictionary object of strings, where each string is the id of the accessor containing an attribute.",
             "properties" : {
             },
             "additionalProperties" : {
@@ -28,7 +30,7 @@
             "description" : "The type of primitives to render.",
             "enum" : [0, 1, 2, 3, 4, 5, 6],
             "default" : 4,
-            "gltf_detailedDescription" : "The type of primitives to render.  Allowed values are 0 (POINTS), 1 (LINES), 2 (LINE_LOOP), 3 (LINE_STRIP), 4 (TRIANGLES), 5 (TRIANGLE_STRIP), and 6 (TRIANGLE_FAN)."
+            "gltf_detailedDescription" : "The type of primitives to render.  Allowed values are 0 (`POINTS`), 1 (`LINES`), 2 (`LINE_LOOP`), 3 (`LINE_STRIP`), 4 (`TRIANGLES`), 5 (`TRIANGLE_STRIP`), and 6 (`TRIANGLE_FAN`)."
         }
     },
     "additionalProperties" : false,

--- a/specification/schema/mesh.schema.json
+++ b/specification/schema/mesh.schema.json
@@ -2,12 +2,12 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "mesh",
     "type" : "object",
-    "description" : "An array of primitives defining geometry and material.",
+    "description" : "A set of primitives to be rendered.  A node can contain one or more meshes.  A node's transform places the mesh in the scene.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
         "primitives" : {
             "type" : "array",
-            "description" : "Primitives that define geometry and material.",
+            "description" : "An array of primitives, each defining geometry to be rendered with a material.",
             "items" : {
                 "$ref" : "mesh.primitive.schema.json"
             },

--- a/specification/schema/node.schema.json
+++ b/specification/schema/node.schema.json
@@ -2,7 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "node",
     "type" : "object",
-    "description" : "A node in the node hierarchy.  A node can have either camera, meshes, or skeletons/skin/meshes properties defined.",
+    "description" : "A node in the node hierarchy.  A node can have either the `camera`, `meshes`, or `skeletons`/`skin`/`meshes` properties defined.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties.  If none are provided, the transform is the identity.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
         "camera" : {
@@ -25,7 +25,7 @@
                 "$ref" : "glTFid.schema.json"
             },
             "uniqueItems" : true,
-            "gltf_detailedDescription" : "The id of skeleton nodes.  Each node defines a subtree, which has a jointName of the corresponding element in the referenced skin.joints."            
+            "gltf_detailedDescription" : "The id of skeleton nodes.  Each node defines a subtree, which has a `jointName` of the corresponding element in the referenced `skin.joints`."            
         },
         "skin" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
@@ -44,7 +44,7 @@
             "minItems" : 16,
             "maxItems" : 16,
             "default" : [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ],
-            "gltf_detailedDescription" : "A floating-point 4x4 transformation matrix stored in column-major order.  A node will have either a matrix property defined or any combination of rotation, scale, and translation properties defined.  If none are provided, the transform is the identity.",
+            "gltf_detailedDescription" : "A floating-point 4x4 transformation matrix stored in column-major order.",
             "gltf_webgl" : "`uniformMatrix4fv()` with the transpose parameter equal to false"
         },
         "meshes" : {
@@ -64,8 +64,7 @@
             },
             "minItems" : 4,
             "maxItems" : 4,
-            "default" : [ 1.0, 0.0, 0.0, 0.0 ],
-            "gltf_detailedDescription" : "The node's unit quaternion rotation in the order (x, y, z, w) where w is the scalar.  A node will have either a matrix property defined or any combination of rotation, scale, and translation properties defined.  If none are provided, the transform is the identity."
+            "default" : [ 0.0, 0.0, 0.0, 0.1 ]
         },
         "scale" : {
             "type" : "array",
@@ -75,8 +74,7 @@
             },
             "minItems" : 3,
             "maxItems" : 3,
-            "default" : [ 1.0, 1.0, 1.0 ],
-            "gltf_detailedDescription" : "The node's non-uniform scale.  A node will have either a matrix property defined or any combination of rotation, scale, and translation properties defined.  If none are provided, the transform is the identity."
+            "default" : [ 1.0, 1.0, 1.0 ]
         },
         "translation" : {
             "type" : "array",
@@ -86,8 +84,7 @@
             },
             "minItems" : 3,
             "maxItems" : 3,
-            "default" : [ 0.0, 0.0, 0.0 ],
-            "gltf_detailedDescription" : "The node's translation.  A node will have either a matrix property defined or any combination of rotation, scale, and translation properties defined.  If none are provided, the transform is the identity."
+            "default" : [ 0.0, 0.0, 0.0 ]
         }
     },
     "dependencies" : {

--- a/specification/schema/program.schema.json
+++ b/specification/schema/program.schema.json
@@ -2,7 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "program",
     "type" : "object",
-    "description" : "A shader program.",
+    "description" : "A shader program, including its vertex and fragment shader, and names of vertex shader attributes.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties": {
         "attributes" : {

--- a/specification/schema/sampler.schema.json
+++ b/specification/schema/sampler.schema.json
@@ -10,7 +10,7 @@
             "description" : "Magnification filter.",
             "enum" : [9728, 9729],
             "default" : 9729,
-            "gltf_detailedDescription" : "Magnification filter.  Valid values are 9728 (NEAREST) or 9729 (LINEAR).",
+            "gltf_detailedDescription" : "Magnification filter.  Valid values correspond to WebGL enums: `9728` (NEAREST) and `9729` (LINEAR).",
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_MAG_FILTER"
         },
         "minFilter": {
@@ -18,7 +18,7 @@
             "description" : "Minification filter.",
             "enum" : [9728, 9729, 9984, 9985, 9986, 9987],
             "default" : 9986,
-            "gltf_detailedDescription" : "Minification filter.  Valid values are 9728 (NEAREST), 9729 (LINEAR), 9984 (NEAREST_MIPMAP_NEAREST), 9985 (LINEAR_MIPMAP_NEAREST), 9986 (NEAREST_MIPMAP_LINEAR), or 9987 (LINEAR_MIPMAP_LINEAR).",
+            "gltf_detailedDescription" : "Minification filter.  Valid values correspond to WebGL enums: `9728` (NEAREST), `9729` (LINEAR), `9984` (NEAREST_MIPMAP_NEAREST), `9985` (LINEAR_MIPMAP_NEAREST), `9986` (NEAREST_MIPMAP_LINEAR), and `9987` (LINEAR_MIPMAP_LINEAR).",
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_MIN_FILTER"
         },
         "wrapS": {
@@ -26,7 +26,7 @@
             "description" : "s wrapping mode.",
             "enum" : [33071, 33648, 10497],
             "default" : 10497,
-            "gltf_detailedDescription" : "s wrapping mode.  Valid values are 33071 (CLAMP_TO_EDGE), 33648 (MIRRORED_REPEAT), or 10497 (REPEAT).",
+            "gltf_detailedDescription" : "s wrapping mode.  Valid values correspond to WebGL enums: `33071` (CLAMP_TO_EDGE), `33648` (MIRRORED_REPEAT), and `10497` (REPEAT).",
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_WRAP_S"
         },
         "wrapT": {
@@ -34,7 +34,7 @@
             "description" : "t wrapping mode.",
             "enum" : [33071, 33648, 10497],
             "default" : 10497,
-            "gltf_detailedDescription" : "t wrapping mode.  Valid values are 33071 (CLAMP_TO_EDGE), 33648 (MIRRORED_REPEAT), or 10497 (REPEAT).",
+            "gltf_detailedDescription" : "t wrapping mode.  Valid values correspond to WebGL enums: `33071` (CLAMP_TO_EDGE), `33648` (MIRRORED_REPEAT), and `10497` (REPEAT).",
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_WRAP_T"
         }
     },

--- a/specification/schema/sampler.schema.json
+++ b/specification/schema/sampler.schema.json
@@ -2,7 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "sampler",
     "type" : "object",
-    "description" : "Texture sampler properties.",
+    "description" : "Texture sampler properties for filtering and wrapping modes.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
         "magFilter": {

--- a/specification/schema/scene.schema.json
+++ b/specification/schema/scene.schema.json
@@ -2,7 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "scene",
     "type" : "object",
-    "description" : "The root nodes of the scene.",
+    "description" : "The root nodes of a scene.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
         "nodes" : {

--- a/specification/schema/shader.schema.json
+++ b/specification/schema/shader.schema.json
@@ -17,7 +17,7 @@
             "description" : "The shader stage.",
             "enum" : [35632, 35633],
             "required" : true,
-            "gltf_detailedDescription" : "The shader stage.  Allowed values are 35632 (FRAGMENT_SHADER) and 35633 (VERTEX_SHADER)."
+            "gltf_detailedDescription" : "The shader stage.  Allowed values are `35632` (FRAGMENT_SHADER) and `35633` (VERTEX_SHADER)."
         }
     },
     "additionalProperties" : false,

--- a/specification/schema/skin.schema.json
+++ b/specification/schema/skin.schema.json
@@ -22,13 +22,13 @@
         },
         "jointNames" : {
             "type" : "array",
-            "description" : "Joint names of the joints (nodes with a jointName property) in this skin.",
+            "description" : "Joint names of the joints (nodes with a `jointName` property) in this skin.",
             "items" : {
                 "$ref" : "glTFid.schema.json"
             },
             "uniqueItems" : true,
             "required" : true,
-            "gltf_detailedDescription" : "Joint names of the joints (nodes with a jointName property) in this skin.  The array length is the same as the count property of the inverseBindMatrices accessor, and the same as the length of any skeletons array referencing the skin."
+            "gltf_detailedDescription" : "Joint names of the joints (nodes with a `jointName` property) in this skin.  The array length is the same as the `count` property of the `inverseBindMatrices` accessor, and the same as the length of any skeletons array referencing the skin."
         }
     },
     "additionalProperties" : false

--- a/specification/schema/technique.attribute.schema.json
+++ b/specification/schema/technique.attribute.schema.json
@@ -2,5 +2,5 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "attribute",
     "extends" : { "$ref" : "glTFid.schema.json" },
-    "description" : "Maps GLSL attribute names to technique parameter ids."
+    "description" : "A dictionary object of strings that maps GLSL attribute names to technique parameter ids."
 }

--- a/specification/schema/technique.parameters.schema.json
+++ b/specification/schema/technique.parameters.schema.json
@@ -2,26 +2,26 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "parameter",
     "type" : "object",
-    "description" : "Uniform and attribute inputs to a technique.",
+    "description" : "An attribute or uniform input to a technique, and an optional semantic and value.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
         "count" : {
             "type" : "integer",
-            "description" : "When not defined, the parameter is not an array.  When defined, the parameter is an array of count elements of the specified type.",
+            "description" : "When defined, the parameter is an array of count elements of the specified type.  Otherwise, the parameter is not an array.",
             "minimum" : 1,
-            "gltf_detailedDescription" : "When not defined, the parameter is not an array.  When defined, the parameter is an array of count elements of the specified type.  When defined, value will be an array with length equal to sizeof(type) * count, where each sizeof(type) defines the value of one element."
+            "gltf_detailedDescription" : "When defined, the parameter is an array of count elements of the specified type.  Otherwise, the parameter is not an array.  When defined, `value` is array with length equal to count times the number of components in the type, e.g., `3` for `FLOAT_VEC3`."
         },
         "type" : {
             "type" : "integer",
             "description" : "The datatype.",
             "enum" : [5120, 5121, 5122, 5123, 5124, 5125, 5126, 35664, 35665, 35666, 35667, 35668, 35669, 35670, 35671, 35672, 35673, 35674, 35675, 35676, 35678],
             "required" : true,
-            "gltf_detailedDescription" : "The datatype.  Allowed values are 5120 (BYTE), 5121 (UNSIGNED_BYTE), 5122 (SHORT), 5123 (UNSIGNED_SHORT), 5124 (INT), 5125 (UNSIGNED_INT), 5126 (FLOAT), 35664 (FLOAT_VEC2), 35665 (FLOAT_VEC3), 35666 (FLOAT_VEC4), 35667 (INT_VEC2), 35668 (INT_VEC3), 35669 (INT_VEC4), 35670 (BOOL), 35671 (BOOL_VEC2), 35672 (BOOL_VEC3), 35673 (BOOL_VEC4), 35674 (FLOAT_MAT2), 35675 (FLOAT_MAT3), 35676 (FLOAT_MAT4), and 35678 (SAMPLER_2D)."
+            "gltf_detailedDescription" : "The datatype.  Allowed values are `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), `5124` (INT), `5125` (UNSIGNED_INT), `5126` (FLOAT), `35664` (FLOAT_VEC2), `35665` (FLOAT_VEC3), `35666` (FLOAT_VEC4), `35667` (INT_VEC2), `35668` (INT_VEC3), `35669` (INT_VEC4), `35670` (BOOL), `35671` (BOOL_VEC2), `35672` (BOOL_VEC3), `35673` (BOOL_VEC4), `35674` (FLOAT_MAT2), `35675` (FLOAT_MAT3), `35676` (FLOAT_MAT4), and `35678` (SAMPLER_2D)."
         },
         "semantic" : {
             "type" : "string",
-            "description" : "Identifies a parameter with special meaning.",
-            "gltf_detailedDescription" : "Identifies a parameter with special meaning.  Uniform semantics include LOCAL (FLOAT_MAT4), MODEL (FLOAT_MAT4), VIEW (FLOAT_MAT4), PROJECTION (FLOAT_MAT4), MODELVIEW (FLOAT_MAT4), MODELVIEWPROJECTION (FLOAT_MAT4), MODELINVERSE (FLOAT_MAT4), VIEWINVERSE (FLOAT_MAT4), PROJECTIONINVERSE (FLOAT_MAT4), MODELVIEWINVERSE (FLOAT_MAT4), MODELVIEWPROJECTIONINVERSE (FLOAT_MAT4), MODELINVERSETRANSPOSE (FLOAT_MAT3), MODELVIEWINVERSETRANSPOSE (FLOAT_MAT3), VIEWPORT (FLOAT_VEC4).  Attribute semantics include POSITION, NORMAL, TEXCOORD, COLOR, JOINT, JOINTMATRIX, and WEIGHT.  Attribute semantics can be of the form [semantic]_[set_index], e.g, TEXCOORD_0, TEXCOORD_1, etc."
+            "description" : "Identifies a parameter with a well-known meaning.",
+            "gltf_detailedDescription" : "Identifies a parameter with a well-known meaning.  Uniform semantics include `\"LOCAL\"` (FLOAT_MAT4), `\"MODEL\"` (FLOAT_MAT4), `\"VIEW\"` (FLOAT_MAT4), `\"PROJECTION\"` (FLOAT_MAT4), `\"MODELVIEW\"` (FLOAT_MAT4), `\"MODELVIEWPROJECTION\"` (FLOAT_MAT4), `\"MODELINVERSE\"` (FLOAT_MAT4), `\"VIEWINVERSE\"` (FLOAT_MAT4), `\"PROJECTIONINVERSE\"` (FLOAT_MAT4), `\"MODELVIEWINVERSE\"` (FLOAT_MAT4), `\"MODELVIEWPROJECTIONINVERSE\"` (FLOAT_MAT4), `\"MODELINVERSETRANSPOSE\"` (FLOAT_MAT3), `\"MODELVIEWINVERSETRANSPOSE\"` (FLOAT_MAT3), `\"VIEWPORT\"` (FLOAT_VEC4).  Attribute semantics include `\"POSITION\"`, `\"NORMAL\"`, `\"TEXCOORD\"`, `\"COLOR\"`, `\"JOINT\"`, `\"JOINTMATRIX\"`, and `\"WEIGHT\"`.  Attribute semantics can be of the form `[semantic]_[set_index]`, e.g, `\"TEXCOORD_0\"`."
         },
         "value" : {
             "type" : ["number", "boolean", "string", { "$ref" : "arrayValues.schema.json" }],

--- a/specification/schema/technique.schema.json
+++ b/specification/schema/technique.schema.json
@@ -6,14 +6,19 @@
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties": {
         "parameters" : {
+            "type" : "object",
+            "description" : "A dictionary object of parameter technique.parameters objects.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "technique.parameters.schema.json"
             },
-            "default" : {}
+            "default" : {},
+            "gltf_detailedDescription" : "A dictionary object of parameter technique.parameters objects.  Each parameter defines an attribute or uniform input, and an optional semantic and value."
         },
         "attributes" : {
+            "type" : "object",
+            "description" : "A dictionary object of strings that maps GLSL attribute names to technique parameter ids.",
             "properties" : {
             },
             "additionalProperties" : {
@@ -27,6 +32,8 @@
             "required" : true
         },
         "uniforms" : {
+            "type" : "object",
+            "description" : "A dictionary object of strings that maps GLSL uniform names to technique parameter ids.",
             "properties" : {
             },
             "additionalProperties" : {

--- a/specification/schema/technique.schema.json
+++ b/specification/schema/technique.schema.json
@@ -7,14 +7,14 @@
     "properties": {
         "parameters" : {
             "type" : "object",
-            "description" : "A dictionary object of parameter technique.parameters objects.",
+            "description" : "A dictionary object of technique.parameters objects.",
             "properties" : {
             },
             "additionalProperties" : {
                 "$ref" : "technique.parameters.schema.json"
             },
             "default" : {},
-            "gltf_detailedDescription" : "A dictionary object of parameter technique.parameters objects.  Each parameter defines an attribute or uniform input, and an optional semantic and value."
+            "gltf_detailedDescription" : "A dictionary object of technique.parameters objects.  Each parameter defines an attribute or uniform input, and an optional semantic and value."
         },
         "attributes" : {
             "type" : "object",

--- a/specification/schema/technique.schema.json
+++ b/specification/schema/technique.schema.json
@@ -2,7 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "technique",
     "type" : "object",
-    "description" : "Specifies shading and its inputs.",
+    "description" : "A template for a material appearances.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties": {
         "parameters" : {

--- a/specification/schema/technique.states.functions.schema.json
+++ b/specification/schema/technique.states.functions.schema.json
@@ -1,13 +1,13 @@
 {
     "$schema" : "http://json-schema.org/draft-03/schema",
-    "title" : "states",
+    "title" : "functions",
     "type" : "object",
     "description" : "Arguments for fixed-function rendering state functions other than `enable()`/`disable()`.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
         "blendColor" : {
             "type" : "array",
-            "description" : "Floating-point values passed to blendColor(). [red, green, blue, alpha]",
+            "description" : "Floating-point values passed to `blendColor()`. [red, green, blue, alpha]",
             "items" : {
                 "type" : "number"
             },
@@ -18,7 +18,7 @@
         },
         "blendEquationSeparate" : {
             "type" : "array",
-            "description" : "Integer values passed to blendEquationSeparate().",
+            "description" : "Integer values passed to `blendEquationSeparate()`.",
             "items" : {
                 "type" : "integer",
                 "enum" : [32774, 32778, 32779]
@@ -26,12 +26,12 @@
             "minItems" : 2,
             "maxItems" : 2,
             "default" : [32774, 32774],
-            "gltf_detailedDescription" : "Integer values passed to blendEquationSeparate(). [rgb, alpha]. Valid values correspond to WebGL enums: `32774` (FUNC_ADD), `32778` (FUNC_SUBTRACT), and `32779` (FUNC_REVERSE_SUBTRACT).",
+            "gltf_detailedDescription" : "Integer values passed to `blendEquationSeparate()`. [rgb, alpha]. Valid values correspond to WebGL enums: `32774` (FUNC_ADD), `32778` (FUNC_SUBTRACT), and `32779` (FUNC_REVERSE_SUBTRACT).",
             "gltf_webgl" : "`blendEquationSeparate()`"
         },
         "blendFuncSeparate" : {
             "type" : "array",
-            "description" : "Integer values passed to blendFuncSeparate().",
+            "description" : "Integer values passed to `blendFuncSeparate()`.",
             "items" : {
                 "type" : "integer",
                 "enum" : [0, 1, 768, 769, 774, 775, 770, 771, 772, 773, 32769, 32770, 32771, 32772, 776]
@@ -39,12 +39,12 @@
             "minItems" : 4,
             "maxItems" : 4,
             "default" : [1, 1, 0, 0],
-            "gltf_detailedDescription" : "Integer values passed to blendFuncSeparate(). [srcRGB, srcAlpha, dstRGB, dstAlpha]. Valid values correspond to WebGL enums: `0` (ZERO), `1` (ONE), `768` (SRC_COLOR), `769` (ONE_MINUS_SRC_COLOR), `774` (DST_COLOR), `775` (ONE_MINUS_DST_COLOR), `770` (SRC_ALPHA), `771` (ONE_MINUS_SRC_ALPHA), `772` (DST_ALPHA), `773` (ONE_MINUS_DST_ALPHA), `32769` (CONSTANT_COLOR), `32770` (ONE_MINUS_CONSTANT_COLOR), `32771` (CONSTANT_ALPHA), `32772` (ONE_MINUS_CONSTANT_ALPHA), and `776` (SRC_ALPHA_SATURATE).",
+            "gltf_detailedDescription" : "Integer values passed to `blendFuncSeparate()`. [srcRGB, srcAlpha, dstRGB, dstAlpha]. Valid values correspond to WebGL enums: `0` (ZERO), `1` (ONE), `768` (SRC_COLOR), `769` (ONE_MINUS_SRC_COLOR), `774` (DST_COLOR), `775` (ONE_MINUS_DST_COLOR), `770` (SRC_ALPHA), `771` (ONE_MINUS_SRC_ALPHA), `772` (DST_ALPHA), `773` (ONE_MINUS_DST_ALPHA), `32769` (CONSTANT_COLOR), `32770` (ONE_MINUS_CONSTANT_COLOR), `32771` (CONSTANT_ALPHA), `32772` (ONE_MINUS_CONSTANT_ALPHA), and `776` (SRC_ALPHA_SATURATE).",
             "gltf_webgl" : "`blendFuncSeparate()`"
         },
         "colorMask" : {
             "type" : "array",
-            "description" : "Boolean values passed to colorMask(). [red, green, blue, alpha].",
+            "description" : "Boolean values passed to `colorMask()`. [red, green, blue, alpha].",
             "items" : {
                 "type" : "boolean"
             },
@@ -55,7 +55,7 @@
         },
         "cullFace" : {
             "type" : "array",
-            "description" : "Integer value passed to cullFace().",
+            "description" : "Integer value passed to `cullFace()`.",
             "items" : {
                 "type" : "integer",
                 "enum" : [1028, 1029, 1032]
@@ -63,7 +63,7 @@
             "minItems" : 1,
             "maxItems" : 1,
             "default" : [1029],
-            "gltf_detailedDescription" : "Integer value passed to cullFace(). Valid values correspond to WebGL enums: `1028` (FRONT), `1029` (BACK), and `1032` (FRONT_AND_BACK).",
+            "gltf_detailedDescription" : "Integer value passed to `cullFace()`. Valid values correspond to WebGL enums: `1028` (FRONT), `1029` (BACK), and `1032` (FRONT_AND_BACK).",
             "gltf_webgl" : "`cullFace()`"
         },
         "depthFunc" : {
@@ -81,7 +81,7 @@
         },
         "depthMask" : {
             "type" : "array",
-            "description" : "Boolean value passed to depthMask().",
+            "description" : "Boolean value passed to `depthMask()`.",
             "items" : {
                 "type" : "boolean"
             },
@@ -92,7 +92,7 @@
         },
         "depthRange" : {
             "type" : "array",
-            "description" : "Floating-point values passed to depthRange(). [zNear, zFar]",
+            "description" : "Floating-point values passed to `depthRange()`. [zNear, zFar]",
             "items" : {
                 "type" : "number"
             },
@@ -103,7 +103,7 @@
         },
         "frontFace" : {
             "type" : "array",
-            "description" : "Integer value passed to frontFace().",
+            "description" : "Integer value passed to `frontFace()`.",
             "items" : {
                 "type" : "integer",
                 "enum" : [2304, 2305]
@@ -116,7 +116,7 @@
         },
         "lineWidth" : {
             "type" : "array",
-            "description" : "Floating-point value passed to lineWidth().",
+            "description" : "Floating-point value passed to `lineWidth()`.",
             "items" : {
                 "type" : "number",
                 "minimum" : 0.0,
@@ -129,7 +129,7 @@
         },
         "polygonOffset" : {
             "type" : "array",
-            "description" : "Floating-point value passed to polygonOffset().  [factor, units]",
+            "description" : "Floating-point value passed to `polygonOffset()`.  [factor, units]",
             "items" : {
                 "type" : "number"
             },
@@ -140,14 +140,14 @@
         },
         "scissor" : {
             "type" : "array",
-            "description" : "Floating-point value passed to scissor().  [x, y, width, height].",
+            "description" : "Floating-point value passed to `scissor()`.  [x, y, width, height].",
             "items" : {
                 "type" : "number"
             },
             "minItems" : 4,
             "maxItems" : 4,
             "default" : [0.0, 0.0, 0.0, 0.0],
-            "gltf_detailedDescription" : "Floating-point value passed to scissor().  [x, y, width, height].  The default is the dimensions of the canvas when the WebGL context is created.  width and height must be greater than zero.",
+            "gltf_detailedDescription" : "Floating-point value passed to `scissor()`.  [x, y, width, height].  The default is the dimensions of the canvas when the WebGL context is created.  width and height must be greater than zero.",
             "gltf_webgl" : "`scissor()`"
         }
     },

--- a/specification/schema/technique.states.functions.schema.json
+++ b/specification/schema/technique.states.functions.schema.json
@@ -1,0 +1,155 @@
+{
+    "$schema" : "http://json-schema.org/draft-03/schema",
+    "title" : "states",
+    "type" : "object",
+    "description" : "Arguments for fixed-function rendering state functions other than `enable()`/`disable()`.",
+    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "properties" : {
+        "blendColor" : {
+            "type" : "array",
+            "description" : "Floating-point values passed to blendColor(). [red, green, blue, alpha]",
+            "items" : {
+                "type" : "number"
+            },
+            "minItems" : 4,
+            "maxItems" : 4,
+            "default" : [0.0, 0.0, 0.0, 0.0],
+            "gltf_webgl" : "`blendColor()`"
+        },
+        "blendEquationSeparate" : {
+            "type" : "array",
+            "description" : "Integer values passed to blendEquationSeparate().",
+            "items" : {
+                "type" : "integer",
+                "enum" : [32774, 32778, 32779]
+            },
+            "minItems" : 2,
+            "maxItems" : 2,
+            "default" : [32774, 32774],
+            "gltf_detailedDescription" : "Integer values passed to blendEquationSeparate(). [rgb, alpha]. Valid values correspond to WebGL enums: `32774` (FUNC_ADD), `32778` (FUNC_SUBTRACT), and `32779` (FUNC_REVERSE_SUBTRACT).",
+            "gltf_webgl" : "`blendEquationSeparate()`"
+        },
+        "blendFuncSeparate" : {
+            "type" : "array",
+            "description" : "Integer values passed to blendFuncSeparate().",
+            "items" : {
+                "type" : "integer",
+                "enum" : [0, 1, 768, 769, 774, 775, 770, 771, 772, 773, 32769, 32770, 32771, 32772, 776]
+            },
+            "minItems" : 4,
+            "maxItems" : 4,
+            "default" : [1, 1, 0, 0],
+            "gltf_detailedDescription" : "Integer values passed to blendFuncSeparate(). [srcRGB, srcAlpha, dstRGB, dstAlpha]. Valid values correspond to WebGL enums: `0` (ZERO), `1` (ONE), `768` (SRC_COLOR), `769` (ONE_MINUS_SRC_COLOR), `774` (DST_COLOR), `775` (ONE_MINUS_DST_COLOR), `770` (SRC_ALPHA), `771` (ONE_MINUS_SRC_ALPHA), `772` (DST_ALPHA), `773` (ONE_MINUS_DST_ALPHA), `32769` (CONSTANT_COLOR), `32770` (ONE_MINUS_CONSTANT_COLOR), `32771` (CONSTANT_ALPHA), `32772` (ONE_MINUS_CONSTANT_ALPHA), and `776` (SRC_ALPHA_SATURATE).",
+            "gltf_webgl" : "`blendFuncSeparate()`"
+        },
+        "colorMask" : {
+            "type" : "array",
+            "description" : "Boolean values passed to colorMask(). [red, green, blue, alpha].",
+            "items" : {
+                "type" : "boolean"
+            },
+            "minItems" : 4,
+            "maxItems" : 4,
+            "default" : [true, true, true, true],
+            "gltf_webgl" : "`colorMask()`"
+        },
+        "cullFace" : {
+            "type" : "array",
+            "description" : "Integer value passed to cullFace().",
+            "items" : {
+                "type" : "integer",
+                "enum" : [1028, 1029, 1032]
+            },
+            "minItems" : 1,
+            "maxItems" : 1,
+            "default" : [1029],
+            "gltf_detailedDescription" : "Integer value passed to cullFace(). Valid values correspond to WebGL enums: `1028` (FRONT), `1029` (BACK), and `1032` (FRONT_AND_BACK).",
+            "gltf_webgl" : "`cullFace()`"
+        },
+        "depthFunc" : {
+            "type" : "array",
+            "description" : "Integer values passed to depthFunc().",
+            "items" : {
+                "type" : "integer",
+                "enum" : [512, 513, 515, 514, 516, 517, 518, 519]
+            },
+            "minItems" : 1,
+            "maxItems" : 1,
+            "default" : [513],
+            "gltf_detailedDescription" : "Integer values passed to depthFunc(). Valid values correspond to WebGL enums: `512` (NEVER), `513` (LESS), `515` (LEQUAL), `514` (EQUAL), `516` (GREATER), `517` (NOTEQUAL), `518` (GEQUAL), and `519` (ALWAYS).",
+            "gltf_webgl" : "`depthFunc()`"
+        },
+        "depthMask" : {
+            "type" : "array",
+            "description" : "Boolean value passed to depthMask().",
+            "items" : {
+                "type" : "boolean"
+            },
+            "minItems" : 1,
+            "maxItems" : 1,
+            "default" : [true],
+            "gltf_webgl" : "`depthMask()`"
+        },
+        "depthRange" : {
+            "type" : "array",
+            "description" : "Floating-point values passed to depthRange(). [zNear, zFar]",
+            "items" : {
+                "type" : "number"
+            },
+            "minItems" : 2,
+            "maxItems" : 2,
+            "default" : [0.0, 1.0],
+            "gltf_webgl" : "`depthRange()`"
+        },
+        "frontFace" : {
+            "type" : "array",
+            "description" : "Integer value passed to frontFace().",
+            "items" : {
+                "type" : "integer",
+                "enum" : [2304, 2305]
+            },
+            "minItems" : 1,
+            "maxItems" : 1,
+            "default" : [2305],
+            "gltf_detailedDescription" : "Integer value passed to frontFace().  Valid values correspond to WebGL enums: `2304` (CW) and `2305` (CCW).",
+            "gltf_webgl" : "`frontFace()`"
+        },
+        "lineWidth" : {
+            "type" : "array",
+            "description" : "Floating-point value passed to lineWidth().",
+            "items" : {
+                "type" : "number",
+                "minimum" : 0.0,
+                "exclusiveMinimum" : true
+            },
+            "minItems" : 1,
+            "maxItems" : 1,
+            "default" : [1.0],
+            "gltf_webgl" : "`lineWidth()`"
+        },
+        "polygonOffset" : {
+            "type" : "array",
+            "description" : "Floating-point value passed to polygonOffset().  [factor, units]",
+            "items" : {
+                "type" : "number"
+            },
+            "minItems" : 2,
+            "maxItems" : 2,
+            "default" : [0.0, 0.0],
+            "gltf_webgl" : "`polygonOffset()`"
+        },
+        "scissor" : {
+            "type" : "array",
+            "description" : "Floating-point value passed to scissor().  [x, y, width, height].",
+            "items" : {
+                "type" : "number"
+            },
+            "minItems" : 4,
+            "maxItems" : 4,
+            "default" : [0.0, 0.0, 0.0, 0.0],
+            "gltf_detailedDescription" : "Floating-point value passed to scissor().  [x, y, width, height].  The default is the dimensions of the canvas when the WebGL context is created.  width and height must be greater than zero.",
+            "gltf_webgl" : "`scissor()`"
+        }
+    },
+    "additionalProperties" : false
+}

--- a/specification/schema/technique.states.schema.json
+++ b/specification/schema/technique.states.schema.json
@@ -13,7 +13,7 @@
             },
             "uniqueItems" : true,
             "default" : [],
-            "gltf_detailedDescription" : "WebGL states to enable.  Valid values are (3042) BLEND, (2884) CULL_FACE, (2929) DEPTH_TEST, (32823) POLYGON_OFFSET_FILL, (32926) SAMPLE_ALPHA_TO_COVERAGE, and (3089) SCISSOR_TEST.",
+            "gltf_detailedDescription" : "WebGL states to enable.  Valid values correspond to WebGL enums: `3042` (BLEND), `2884` (CULL_FACE), `2929` (DEPTH_TEST), `32823` (POLYGON_OFFSET_FILL), `32926` (SAMPLE_ALPHA_TO_COVERAGE), and `3089` (SCISSOR_TEST).",
             "gltf_webgl" : "`enable()` and `disable()`"
         },
         "functions" : {
@@ -44,7 +44,7 @@
                     "minItems" : 2,
                     "maxItems" : 2,
                     "default" : [32774, 32774],
-                    "gltf_detailedDescription" : "Integer values passed to blendEquationSeparate(). [rgb, alpha]. Valid values are (32774) FUNC_ADD, (32778) FUNC_SUBTRACT, and (32779) FUNC_REVERSE_SUBTRACT.",
+                    "gltf_detailedDescription" : "Integer values passed to blendEquationSeparate(). [rgb, alpha]. Valid values correspond to WebGL enums: `32774` (FUNC_ADD), `32778` (FUNC_SUBTRACT), and `32779` (FUNC_REVERSE_SUBTRACT).",
                     "gltf_webgl" : "`blendEquationSeparate()`"
                 },
                 "blendFuncSeparate" : {
@@ -57,7 +57,7 @@
                     "minItems" : 4,
                     "maxItems" : 4,
                     "default" : [1, 1, 0, 0],
-                    "gltf_detailedDescription" : "Integer values passed to blendFuncSeparate(). [srcRGB, srcAlpha, dstRGB, dstAlpha]. Valid values are (0) ZERO, (1) ONE, (768) SRC_COLOR, (769) ONE_MINUS_SRC_COLOR, (774) DST_COLOR, (775) ONE_MINUS_DST_COLOR, (770) SRC_ALPHA, (771) ONE_MINUS_SRC_ALPHA, (772) DST_ALPHA, (773) ONE_MINUS_DST_ALPHA, (32769) CONSTANT_COLOR, (32770) ONE_MINUS_CONSTANT_COLOR, (32771) CONSTANT_ALPHA, (32772) ONE_MINUS_CONSTANT_ALPHA, and (776) SRC_ALPHA_SATURATE.",
+                    "gltf_detailedDescription" : "Integer values passed to blendFuncSeparate(). [srcRGB, srcAlpha, dstRGB, dstAlpha]. Valid values correspond to WebGL enums: `0` (ZERO), `1` (ONE), `768` (SRC_COLOR), `769` (ONE_MINUS_SRC_COLOR), `774` (DST_COLOR), `775` (ONE_MINUS_DST_COLOR), `770` (SRC_ALPHA), `771` (ONE_MINUS_SRC_ALPHA), `772` (DST_ALPHA), `773` (ONE_MINUS_DST_ALPHA), `32769` (CONSTANT_COLOR), `32770` (ONE_MINUS_CONSTANT_COLOR), `32771` (CONSTANT_ALPHA), `32772` (ONE_MINUS_CONSTANT_ALPHA), and `776` (SRC_ALPHA_SATURATE).",
                     "gltf_webgl" : "`blendFuncSeparate()`"
                 },
                 "colorMask" : {
@@ -81,7 +81,7 @@
                     "minItems" : 1,
                     "maxItems" : 1,
                     "default" : [1029],
-                    "gltf_detailedDescription" : "Integer value passed to cullFace(). Valid values are (1028) FRONT, (1029) BACK, and (1032) FRONT_AND_BACK.",
+                    "gltf_detailedDescription" : "Integer value passed to cullFace(). Valid values correspond to WebGL enums: `1028` (FRONT), `1029` (BACK), and `1032` (FRONT_AND_BACK).",
                     "gltf_webgl" : "`cullFace()`"
                 },
                 "depthFunc" : {
@@ -94,7 +94,7 @@
                     "minItems" : 1,
                     "maxItems" : 1,
                     "default" : [513],
-                    "gltf_detailedDescription" : "Integer values passed to depthFunc(). Valid values are (512) NEVER, (513) LESS, (515) LEQUAL, (514) EQUAL, (516) GREATER, (517) NOTEQUAL, (518) GEQUAL, and (519) ALWAYS.",
+                    "gltf_detailedDescription" : "Integer values passed to depthFunc(). Valid values correspond to WebGL enums: `512` (NEVER), `513` (LESS), `515` (LEQUAL), `514` (EQUAL), `516` (GREATER), `517` (NOTEQUAL), `518` (GEQUAL), and `519` (ALWAYS).",
                     "gltf_webgl" : "`depthFunc()`"
                 },
                 "depthMask" : {
@@ -129,7 +129,7 @@
                     "minItems" : 1,
                     "maxItems" : 1,
                     "default" : [2305],
-                    "gltf_detailedDescription" : "Integer value passed to frontFace().  Valid values are (2304) CW and (2305) CCW.",
+                    "gltf_detailedDescription" : "Integer value passed to frontFace().  Valid values correspond to WebGL enums: `2304` (CW) and `2305` (CCW).",
                     "gltf_webgl" : "`frontFace()`"
                 },
                 "lineWidth" : {

--- a/specification/schema/technique.states.schema.json
+++ b/specification/schema/technique.states.schema.json
@@ -2,6 +2,7 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "states",
     "type" : "object",
+    "description" : "Fixed-function rendering states.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
         "enable" : {
@@ -13,163 +14,11 @@
             },
             "uniqueItems" : true,
             "default" : [],
-            "gltf_detailedDescription" : "WebGL states to enable.  Valid values correspond to WebGL enums: `3042` (BLEND), `2884` (CULL_FACE), `2929` (DEPTH_TEST), `32823` (POLYGON_OFFSET_FILL), `32926` (SAMPLE_ALPHA_TO_COVERAGE), and `3089` (SCISSOR_TEST).",
+            "gltf_detailedDescription" : "WebGL states to enable.  States not in the array are disabled.  Valid values for each element correspond to WebGL enums: `3042` (BLEND), `2884` (CULL_FACE), `2929` (DEPTH_TEST), `32823` (POLYGON_OFFSET_FILL), `32926` (SAMPLE_ALPHA_TO_COVERAGE), and `3089` (SCISSOR_TEST).",
             "gltf_webgl" : "`enable()` and `disable()`"
         },
         "functions" : {
-            "$schema" : "http://json-schema.org/draft-03/schema",
-            "title" : "states functions",
-            "type" : "object",
-            "description" : "Arguments for state functions.",
-            "extends" : { "$ref" : "glTFProperty.schema.json" },
-            "properties" : {
-                "blendColor" : {
-                    "type" : "array",
-                    "description" : "Floating-point values passed to blendColor(). [red, green, blue, alpha]",
-                    "items" : {
-                        "type" : "number"
-                    },
-                    "minItems" : 4,
-                    "maxItems" : 4,
-                    "default" : [0.0, 0.0, 0.0, 0.0],
-                    "gltf_webgl" : "`blendColor()`"
-                },
-                "blendEquationSeparate" : {
-                    "type" : "array",
-                    "description" : "Integer values passed to blendEquationSeparate().",
-                    "items" : {
-                        "type" : "integer",
-                        "enum" : [32774, 32778, 32779]
-                    },
-                    "minItems" : 2,
-                    "maxItems" : 2,
-                    "default" : [32774, 32774],
-                    "gltf_detailedDescription" : "Integer values passed to blendEquationSeparate(). [rgb, alpha]. Valid values correspond to WebGL enums: `32774` (FUNC_ADD), `32778` (FUNC_SUBTRACT), and `32779` (FUNC_REVERSE_SUBTRACT).",
-                    "gltf_webgl" : "`blendEquationSeparate()`"
-                },
-                "blendFuncSeparate" : {
-                    "type" : "array",
-                    "description" : "Integer values passed to blendFuncSeparate().",
-                    "items" : {
-                        "type" : "integer",
-                        "enum" : [0, 1, 768, 769, 774, 775, 770, 771, 772, 773, 32769, 32770, 32771, 32772, 776]
-                    },
-                    "minItems" : 4,
-                    "maxItems" : 4,
-                    "default" : [1, 1, 0, 0],
-                    "gltf_detailedDescription" : "Integer values passed to blendFuncSeparate(). [srcRGB, srcAlpha, dstRGB, dstAlpha]. Valid values correspond to WebGL enums: `0` (ZERO), `1` (ONE), `768` (SRC_COLOR), `769` (ONE_MINUS_SRC_COLOR), `774` (DST_COLOR), `775` (ONE_MINUS_DST_COLOR), `770` (SRC_ALPHA), `771` (ONE_MINUS_SRC_ALPHA), `772` (DST_ALPHA), `773` (ONE_MINUS_DST_ALPHA), `32769` (CONSTANT_COLOR), `32770` (ONE_MINUS_CONSTANT_COLOR), `32771` (CONSTANT_ALPHA), `32772` (ONE_MINUS_CONSTANT_ALPHA), and `776` (SRC_ALPHA_SATURATE).",
-                    "gltf_webgl" : "`blendFuncSeparate()`"
-                },
-                "colorMask" : {
-                    "type" : "array",
-                    "description" : "Boolean values passed to colorMask(). [red, green, blue, alpha].",
-                    "items" : {
-                        "type" : "boolean"
-                    },
-                    "minItems" : 4,
-                    "maxItems" : 4,
-                    "default" : [true, true, true, true],
-                    "gltf_webgl" : "`colorMask()`"
-                },
-                "cullFace" : {
-                    "type" : "array",
-                    "description" : "Integer value passed to cullFace().",
-                    "items" : {
-                        "type" : "integer",
-                        "enum" : [1028, 1029, 1032]
-                    },
-                    "minItems" : 1,
-                    "maxItems" : 1,
-                    "default" : [1029],
-                    "gltf_detailedDescription" : "Integer value passed to cullFace(). Valid values correspond to WebGL enums: `1028` (FRONT), `1029` (BACK), and `1032` (FRONT_AND_BACK).",
-                    "gltf_webgl" : "`cullFace()`"
-                },
-                "depthFunc" : {
-                    "type" : "array",
-                    "description" : "Integer values passed to depthFunc().",
-                    "items" : {
-                        "type" : "integer",
-                        "enum" : [512, 513, 515, 514, 516, 517, 518, 519]
-                    },
-                    "minItems" : 1,
-                    "maxItems" : 1,
-                    "default" : [513],
-                    "gltf_detailedDescription" : "Integer values passed to depthFunc(). Valid values correspond to WebGL enums: `512` (NEVER), `513` (LESS), `515` (LEQUAL), `514` (EQUAL), `516` (GREATER), `517` (NOTEQUAL), `518` (GEQUAL), and `519` (ALWAYS).",
-                    "gltf_webgl" : "`depthFunc()`"
-                },
-                "depthMask" : {
-                    "type" : "array",
-                    "description" : "Boolean value passed to depthMask().",
-                    "items" : {
-                        "type" : "boolean"
-                    },
-                    "minItems" : 1,
-                    "maxItems" : 1,
-                    "default" : [true],
-                    "gltf_webgl" : "`depthMask()`"
-                },
-                "depthRange" : {
-                    "type" : "array",
-                    "description" : "Floating-point values passed to depthRange(). [zNear, zFar]",
-                    "items" : {
-                        "type" : "number"
-                    },
-                    "minItems" : 2,
-                    "maxItems" : 2,
-                    "default" : [0.0, 1.0],
-                    "gltf_webgl" : "`depthRange()`"
-                },
-                "frontFace" : {
-                    "type" : "array",
-                    "description" : "Integer value passed to frontFace().",
-                    "items" : {
-                        "type" : "integer",
-                        "enum" : [2304, 2305]
-                    },
-                    "minItems" : 1,
-                    "maxItems" : 1,
-                    "default" : [2305],
-                    "gltf_detailedDescription" : "Integer value passed to frontFace().  Valid values correspond to WebGL enums: `2304` (CW) and `2305` (CCW).",
-                    "gltf_webgl" : "`frontFace()`"
-                },
-                "lineWidth" : {
-                    "type" : "array",
-                    "description" : "Floating-point value passed to lineWidth().",
-                    "items" : {
-                        "type" : "number",
-                        "minimum" : 0.0,
-                        "exclusiveMinimum" : true
-                    },
-                    "minItems" : 1,
-                    "maxItems" : 1,
-                    "default" : [1.0],
-                    "gltf_webgl" : "`lineWidth()`"
-                },
-                "polygonOffset" : {
-                    "type" : "array",
-                    "description" : "Floating-point value passed to polygonOffset().  [factor, units]",
-                    "items" : {
-                        "type" : "number"
-                    },
-                    "minItems" : 2,
-                    "maxItems" : 2,
-                    "default" : [0.0, 0.0],
-                    "gltf_webgl" : "`polygonOffset()`"
-                },
-                "scissor" : {
-                    "type" : "array",
-                    "description" : "Floating-point value passed to scissor().  [x, y, width, height].",
-                    "items" : {
-                        "type" : "number"
-                    },
-                    "minItems" : 4,
-                    "maxItems" : 4,
-                    "default" : [0.0, 0.0, 0.0, 0.0],
-                    "gltf_detailedDescription" : "Floating-point value passed to scissor().  [x, y, width, height].  The default is the dimensions of the canvas when the WebGL context is created.  width and height must be greater than zero.",
-                    "gltf_webgl" : "`scissor()`"
-                }
-            },
-            "additionalProperties" : false
+            "$ref" : "technique.states.functions.schema.json"
         }
     },
     "additionalProperties" : false

--- a/specification/schema/technique.uniform.schema.json
+++ b/specification/schema/technique.uniform.schema.json
@@ -2,5 +2,5 @@
     "$schema" : "http://json-schema.org/draft-03/schema",
     "title" : "uniform",
     "extends" : { "$ref" : "glTFid.schema.json" },
-    "description" : "Maps GLSL uniform names to technique parameter ids."
+    "description" : "A dictionary object of strings that maps GLSL uniform names to technique parameter ids."
 }

--- a/specification/schema/texture.schema.json
+++ b/specification/schema/texture.schema.json
@@ -10,7 +10,7 @@
             "description" : "The texture's format.",
             "enum" : [6406, 6407, 6408, 6409, 6410],
             "default" : 6408,
-            "gltf_detailedDescription" : "The texture's format.  Valid values are 6406 (ALPHA), 6407 (RGB), 6408 (RGBA), 6409 (LUMINANCE), and 6410 (LUMINANCE_ALPHA).",
+            "gltf_detailedDescription" : "The texture's format.  Valid values correspond to WebGL enums: `6406` (ALPHA), `6407` (RGB), `6408` (RGBA), `6409` (LUMINANCE), and `6410` (LUMINANCE_ALPHA).",
             "gltf_webgl" : "`texImage2D()` format parameter"
         },
         "internalFormat": {
@@ -18,7 +18,7 @@
             "description" : "The texture's internal format.",
             "enum" : [6406, 6407, 6408, 6409, 6410],
             "default" : 6408,
-            "gltf_detailedDescription" : "The texture's internal format.  Valid values are 6406 (ALPHA), 6407 (RGB), 6408 (RGBA), 6409 (LUMINANCE), and 6410 (LUMINANCE_ALPHA).  Defaults to same value as format.",
+            "gltf_detailedDescription" : "The texture's internal format.  Valid values correspond to WebGL enums: `6406` (ALPHA), `6407` (RGB), `6408` (RGBA), `6409` (LUMINANCE), and `6410` (LUMINANCE_ALPHA).  Defaults to same value as format.",
             "gltf_webgl" : "`texImage2D()` internalFormat parameter"
         },
         "sampler" : {
@@ -36,7 +36,7 @@
             "description" : "The target that the WebGL texture should be bound to.",
             "enum" : [3553],
             "default" : 3553,
-            "gltf_detailedDescription" : "The target that the WebGL texture should be bound to.  Valid values are 3553 (TEXTURE_2D).",
+            "gltf_detailedDescription" : "The target that the WebGL texture should be bound to.  Valid values correspond to WebGL enums: `3553` (TEXTURE_2D).",
             "gltf_webgl" : "`bindTexture()`"
         },
         "type": {
@@ -44,7 +44,7 @@
             "description" : "Texel datatype.",
             "enum" : [5121, 33635, 32819, 32820],
             "default" : 5121,
-            "gltf_detailedDescription" : "Texel datatype.  Valid values are 5121 (UNSIGNED_BYTE), 33635 (UNSIGNED_SHORT_5_6_5), 32819 (UNSIGNED_SHORT_4_4_4_4), and 32820 (UNSIGNED_SHORT_5_5_5_1).",
+            "gltf_detailedDescription" : "Texel datatype.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `33635` (UNSIGNED_SHORT_5_6_5), `32819` (UNSIGNED_SHORT_4_4_4_4), and `32820` (UNSIGNED_SHORT_5_5_5_1).",
             "gltf_webgl" : "`texImage2D()` type parameter"
         }
     },


### PR DESCRIPTION
This is a pull request into `spec-1.0`.  Do not merge this yet.  This is for feedback on a preview of what the reference doc will look like.  For example, see the [accessor](https://github.com/KhronosGroup/glTF/blob/1.0-reference/specification/README.md#reference-accessor).

Note that any edits to the text of the schema reference doc should also be made to the schema itself (the `*.schema.json` files in the `schema` sub-directory) since we are auto-generating (then tweaking) the doc from the schema with [wetzel](https://github.com/AnalyticalGraphicsInc/wetzel).
