### PR TITLE
Changed asset.version to be a string as per the 1.0 spec.

### DIFF
--- a/COLLADA2GLTF/COLLADA2GLTFWriter.cpp
+++ b/COLLADA2GLTF/COLLADA2GLTFWriter.cpp
@@ -168,7 +168,7 @@ namespace GLTF
         assetObject->setString("generator",version);
         assetObject->setBool(kPremultipliedAlpha, CONFIG_BOOL(asset, kPremultipliedAlpha));
         assetObject->setValue(kProfile, asset->profile()->id());
-        assetObject->setDouble(kVersion, glTFVersion);
+        assetObject->setString(kVersion, glTFVersion);
 
         _metersPerUnit = globalAsset->getUnit().getLinearUnitMeter();
         if (globalAsset->getUpAxisType() == COLLADAFW::FileInfo::X_UP ||

--- a/COLLADA2GLTF/GLTF/GLTFTypesAndConstants.h
+++ b/COLLADA2GLTF/GLTF/GLTFTypesAndConstants.h
@@ -29,7 +29,7 @@
 
 #define EXPORT_MATERIALS_AS_EFFECTS 1
 
-const float glTFVersion = 1.0f;
+const std::string glTFVersion = "1.0";
 
 const std::string kCount = "count";
 const std::string kByteOffset = "byteOffset";


### PR DESCRIPTION
The converter was never fixed to make this a string.