### PR TITLE
Pull the data about integer enum names from the detailed description into a new property.

### DIFF
--- a/specification/schema/accessor.schema.json
+++ b/specification/schema/accessor.schema.json
@@ -33,7 +33,7 @@
             "enum" : [5120, 5121, 5122, 5123, 5126],
             "gltf_enumNames" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "FLOAT"],
             "required" : true,
-            "gltf_detailedDescription" : "The datatype of components in the attribute.  Valid values correspond to WebGL enums: `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), and `5126` (FLOAT).  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, and `Float32Array`, respectively."
+            "gltf_detailedDescription" : "The datatype of components in the attribute.  All valid values correspond to WebGL enums.  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, and `Float32Array`, respectively."
         },
         "count" : {
             "type" : "integer",

--- a/specification/schema/accessor.schema.json
+++ b/specification/schema/accessor.schema.json
@@ -31,6 +31,7 @@
             "type" : "integer",
             "description" : "The datatype of components in the attribute.",
             "enum" : [5120, 5121, 5122, 5123, 5126],
+            "gltf_enumNames" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "FLOAT"],
             "required" : true,
             "gltf_detailedDescription" : "The datatype of components in the attribute.  Valid values correspond to WebGL enums: `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), and `5126` (FLOAT).  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, and `Float32Array`, respectively."
         },

--- a/specification/schema/bufferView.schema.json
+++ b/specification/schema/bufferView.schema.json
@@ -26,6 +26,7 @@
             "type" : "integer",
             "description" : "The target that the WebGL buffer should be bound to.",
             "enum" : [34962, 34963],
+            "gltf_enumNames" : ["ARRAY_BUFFER", "ELEMENT_ARRAY_BUFFER"],
             "gltf_detailedDescription" : "The target that the WebGL buffer should be bound to.  Valid values correspond to WebGL enums: `34962` (ARRAY_BUFFER) and `34963` (ELEMENT_ARRAY_BUFFER).  When this is not provided, the bufferView contains animation or skin data.",
             "gltf_webgl" : "`bindBuffer()`"
         }

--- a/specification/schema/bufferView.schema.json
+++ b/specification/schema/bufferView.schema.json
@@ -27,7 +27,7 @@
             "description" : "The target that the WebGL buffer should be bound to.",
             "enum" : [34962, 34963],
             "gltf_enumNames" : ["ARRAY_BUFFER", "ELEMENT_ARRAY_BUFFER"],
-            "gltf_detailedDescription" : "The target that the WebGL buffer should be bound to.  Valid values correspond to WebGL enums: `34962` (ARRAY_BUFFER) and `34963` (ELEMENT_ARRAY_BUFFER).  When this is not provided, the bufferView contains animation or skin data.",
+            "gltf_detailedDescription" : "The target that the WebGL buffer should be bound to.  All valid values correspond to WebGL enums.  When this is not provided, the bufferView contains animation or skin data.",
             "gltf_webgl" : "`bindBuffer()`"
         }
     },

--- a/specification/schema/mesh.primitive.schema.json
+++ b/specification/schema/mesh.primitive.schema.json
@@ -29,6 +29,7 @@
             "type" : "integer",
             "description" : "The type of primitives to render.",
             "enum" : [0, 1, 2, 3, 4, 5, 6],
+            "gltf_enumNames" : ["POINTS", "LINES", "LINE_LOOP", "LINE_STRIP", "TRIANGLES", "TRIANGLE_STRIP", "TRIANGLE_FAN"],
             "default" : 4,
             "gltf_detailedDescription" : "The type of primitives to render.  Allowed values are 0 (`POINTS`), 1 (`LINES`), 2 (`LINE_LOOP`), 3 (`LINE_STRIP`), 4 (`TRIANGLES`), 5 (`TRIANGLE_STRIP`), and 6 (`TRIANGLE_FAN`)."
         }

--- a/specification/schema/mesh.primitive.schema.json
+++ b/specification/schema/mesh.primitive.schema.json
@@ -31,7 +31,7 @@
             "enum" : [0, 1, 2, 3, 4, 5, 6],
             "gltf_enumNames" : ["POINTS", "LINES", "LINE_LOOP", "LINE_STRIP", "TRIANGLES", "TRIANGLE_STRIP", "TRIANGLE_FAN"],
             "default" : 4,
-            "gltf_detailedDescription" : "The type of primitives to render.  Allowed values are 0 (`POINTS`), 1 (`LINES`), 2 (`LINE_LOOP`), 3 (`LINE_STRIP`), 4 (`TRIANGLES`), 5 (`TRIANGLE_STRIP`), and 6 (`TRIANGLE_FAN`)."
+            "gltf_detailedDescription" : "The type of primitives to render. All valid values correspond to WebGL enums."
         }
     },
     "additionalProperties" : false,

--- a/specification/schema/sampler.schema.json
+++ b/specification/schema/sampler.schema.json
@@ -20,7 +20,7 @@
             "enum" : [9728, 9729, 9984, 9985, 9986, 9987],
             "gltf_enumNames" : ["NEAREST", "LINEAR", "NEAREST_MIPMAP_NEAREST", "LINEAR_MIPMAP_NEAREST", "NEAREST_MIPMAP_LINEAR", "LINEAR_MIPMAP_LINEAR"],
             "default" : 9986,
-            "gltf_detailedDescription" : "Minification filter.  Valid values correspond to WebGL enums: `9728` (NEAREST), `9729` (LINEAR), `9984` (NEAREST_MIPMAP_NEAREST), `9985` (LINEAR_MIPMAP_NEAREST), `9986` (NEAREST_MIPMAP_LINEAR), and `9987` (LINEAR_MIPMAP_LINEAR).",
+            "gltf_detailedDescription" : "Minification filter.  All valid values correspond to WebGL enums.",
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_MIN_FILTER"
         },
         "wrapS": {
@@ -29,7 +29,7 @@
             "enum" : [33071, 33648, 10497],
             "gltf_enumNames" : ["CLAMP_TO_EDGE", "MIRRORED_REPEAT", "REPEAT"],
             "default" : 10497,
-            "gltf_detailedDescription" : "s wrapping mode.  Valid values correspond to WebGL enums: `33071` (CLAMP_TO_EDGE), `33648` (MIRRORED_REPEAT), and `10497` (REPEAT).",
+            "gltf_detailedDescription" : "s wrapping mode.  All valid values correspond to WebGL enums.",
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_WRAP_S"
         },
         "wrapT": {
@@ -38,7 +38,7 @@
             "enum" : [33071, 33648, 10497],
             "gltf_enumNames" : ["CLAMP_TO_EDGE", "MIRRORED_REPEAT", "REPEAT"],
             "default" : 10497,
-            "gltf_detailedDescription" : "t wrapping mode.  Valid values correspond to WebGL enums: `33071` (CLAMP_TO_EDGE), `33648` (MIRRORED_REPEAT), and `10497` (REPEAT).",
+            "gltf_detailedDescription" : "t wrapping mode.  All valid values correspond to WebGL enums.",
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_WRAP_T"
         }
     },

--- a/specification/schema/sampler.schema.json
+++ b/specification/schema/sampler.schema.json
@@ -9,6 +9,7 @@
             "type" : "integer",
             "description" : "Magnification filter.",
             "enum" : [9728, 9729],
+            "gltf_enumNames" : ["NEAREST", "LINEAR"],
             "default" : 9729,
             "gltf_detailedDescription" : "Magnification filter.  Valid values correspond to WebGL enums: `9728` (NEAREST) and `9729` (LINEAR).",
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_MAG_FILTER"
@@ -17,6 +18,7 @@
             "type" : "integer",
             "description" : "Minification filter.",
             "enum" : [9728, 9729, 9984, 9985, 9986, 9987],
+            "gltf_enumNames" : ["NEAREST", "LINEAR", "NEAREST_MIPMAP_NEAREST", "LINEAR_MIPMAP_NEAREST", "NEAREST_MIPMAP_LINEAR", "LINEAR_MIPMAP_LINEAR"],
             "default" : 9986,
             "gltf_detailedDescription" : "Minification filter.  Valid values correspond to WebGL enums: `9728` (NEAREST), `9729` (LINEAR), `9984` (NEAREST_MIPMAP_NEAREST), `9985` (LINEAR_MIPMAP_NEAREST), `9986` (NEAREST_MIPMAP_LINEAR), and `9987` (LINEAR_MIPMAP_LINEAR).",
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_MIN_FILTER"
@@ -25,6 +27,7 @@
             "type" : "integer",
             "description" : "s wrapping mode.",
             "enum" : [33071, 33648, 10497],
+            "gltf_enumNames" : ["CLAMP_TO_EDGE", "MIRRORED_REPEAT", "REPEAT"],
             "default" : 10497,
             "gltf_detailedDescription" : "s wrapping mode.  Valid values correspond to WebGL enums: `33071` (CLAMP_TO_EDGE), `33648` (MIRRORED_REPEAT), and `10497` (REPEAT).",
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_WRAP_S"
@@ -33,6 +36,7 @@
             "type" : "integer",
             "description" : "t wrapping mode.",
             "enum" : [33071, 33648, 10497],
+            "gltf_enumNames" : ["CLAMP_TO_EDGE", "MIRRORED_REPEAT", "REPEAT"],
             "default" : 10497,
             "gltf_detailedDescription" : "t wrapping mode.  Valid values correspond to WebGL enums: `33071` (CLAMP_TO_EDGE), `33648` (MIRRORED_REPEAT), and `10497` (REPEAT).",
             "gltf_webgl" : "`texParameterf()` with pname equal to TEXTURE_WRAP_T"

--- a/specification/schema/shader.schema.json
+++ b/specification/schema/shader.schema.json
@@ -16,6 +16,7 @@
             "type" : "integer",
             "description" : "The shader stage.",
             "enum" : [35632, 35633],
+            "gltf_enumNames" : ["FRAGMENT_SHADER", "VERTEX_SHADER"],
             "required" : true,
             "gltf_detailedDescription" : "The shader stage.  Allowed values are `35632` (FRAGMENT_SHADER) and `35633` (VERTEX_SHADER)."
         }

--- a/specification/schema/shader.schema.json
+++ b/specification/schema/shader.schema.json
@@ -18,7 +18,7 @@
             "enum" : [35632, 35633],
             "gltf_enumNames" : ["FRAGMENT_SHADER", "VERTEX_SHADER"],
             "required" : true,
-            "gltf_detailedDescription" : "The shader stage.  Allowed values are `35632` (FRAGMENT_SHADER) and `35633` (VERTEX_SHADER)."
+            "gltf_detailedDescription" : "The shader stage.  All valid values correspond to WebGL enums."
         }
     },
     "additionalProperties" : false,

--- a/specification/schema/technique.parameters.schema.json
+++ b/specification/schema/technique.parameters.schema.json
@@ -20,6 +20,7 @@
             "type" : "integer",
             "description" : "The datatype.",
             "enum" : [5120, 5121, 5122, 5123, 5124, 5125, 5126, 35664, 35665, 35666, 35667, 35668, 35669, 35670, 35671, 35672, 35673, 35674, 35675, 35676, 35678],
+            "gltf_enumNames" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "INT", "UNSIGNED_INT", "FLOAT", "FLOAT_VEC2", "FLOAT_VEC3", "FLOAT_VEC4", "INT_VEC2", "INT_VEC3", "INT_VEC4", "BOOL", "BOOL_VEC2", "BOOL_VEC3", "BOOL_VEC4", "FLOAT_MAT2", "FLOAT_MAT3", "FLOAT_MAT4", "SAMPLER_2D"],
             "required" : true,
             "gltf_detailedDescription" : "The datatype.  Allowed values are `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), `5124` (INT), `5125` (UNSIGNED_INT), `5126` (FLOAT), `35664` (FLOAT_VEC2), `35665` (FLOAT_VEC3), `35666` (FLOAT_VEC4), `35667` (INT_VEC2), `35668` (INT_VEC3), `35669` (INT_VEC4), `35670` (BOOL), `35671` (BOOL_VEC2), `35672` (BOOL_VEC3), `35673` (BOOL_VEC4), `35674` (FLOAT_MAT2), `35675` (FLOAT_MAT3), `35676` (FLOAT_MAT4), and `35678` (SAMPLER_2D)."
         },

--- a/specification/schema/technique.parameters.schema.json
+++ b/specification/schema/technique.parameters.schema.json
@@ -22,7 +22,7 @@
             "enum" : [5120, 5121, 5122, 5123, 5124, 5125, 5126, 35664, 35665, 35666, 35667, 35668, 35669, 35670, 35671, 35672, 35673, 35674, 35675, 35676, 35678],
             "gltf_enumNames" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "INT", "UNSIGNED_INT", "FLOAT", "FLOAT_VEC2", "FLOAT_VEC3", "FLOAT_VEC4", "INT_VEC2", "INT_VEC3", "INT_VEC4", "BOOL", "BOOL_VEC2", "BOOL_VEC3", "BOOL_VEC4", "FLOAT_MAT2", "FLOAT_MAT3", "FLOAT_MAT4", "SAMPLER_2D"],
             "required" : true,
-            "gltf_detailedDescription" : "The datatype.  Allowed values are `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), `5124` (INT), `5125` (UNSIGNED_INT), `5126` (FLOAT), `35664` (FLOAT_VEC2), `35665` (FLOAT_VEC3), `35666` (FLOAT_VEC4), `35667` (INT_VEC2), `35668` (INT_VEC3), `35669` (INT_VEC4), `35670` (BOOL), `35671` (BOOL_VEC2), `35672` (BOOL_VEC3), `35673` (BOOL_VEC4), `35674` (FLOAT_MAT2), `35675` (FLOAT_MAT3), `35676` (FLOAT_MAT4), and `35678` (SAMPLER_2D)."
+            "gltf_detailedDescription" : "The datatype.  All valid values correspond to WebGL enums."
         },
         "semantic" : {
             "type" : "string",

--- a/specification/schema/technique.states.functions.schema.json
+++ b/specification/schema/technique.states.functions.schema.json
@@ -21,7 +21,8 @@
             "description" : "Integer values passed to `blendEquationSeparate()`.",
             "items" : {
                 "type" : "integer",
-                "enum" : [32774, 32778, 32779]
+                "enum" : [32774, 32778, 32779],
+                "gltf_enumNames" : ["FUNC_ADD", "FUNC_SUBTRACT", "FUNC_REVERSE_SUBTRACT"]
             },
             "minItems" : 2,
             "maxItems" : 2,
@@ -34,7 +35,8 @@
             "description" : "Integer values passed to `blendFuncSeparate()`.",
             "items" : {
                 "type" : "integer",
-                "enum" : [0, 1, 768, 769, 774, 775, 770, 771, 772, 773, 32769, 32770, 32771, 32772, 776]
+                "enum" : [0, 1, 768, 769, 774, 775, 770, 771, 772, 773, 32769, 32770, 32771, 32772, 776],
+                "gltf_enumNames" : ["ZERO", "ONE", "SRC_COLOR", "ONE_MINUS_SRC_COLOR", "DST_COLOR", "ONE_MINUS_DST_COLOR", "SRC_ALPHA", "ONE_MINUS_SRC_ALPHA", "DST_ALPHA", "ONE_MINUS_DST_ALPHA", "CONSTANT_COLOR", "ONE_MINUS_CONSTANT_COLOR", "CONSTANT_ALPHA", "ONE_MINUS_CONSTANT_ALPHA", "SRC_ALPHA_SATURATE"]
             },
             "minItems" : 4,
             "maxItems" : 4,
@@ -58,7 +60,8 @@
             "description" : "Integer value passed to `cullFace()`.",
             "items" : {
                 "type" : "integer",
-                "enum" : [1028, 1029, 1032]
+                "enum" : [1028, 1029, 1032],
+                "gltf_enumNames" : ["FRONT", "BACK", "FRONT_AND_BACK"]
             },
             "minItems" : 1,
             "maxItems" : 1,
@@ -71,7 +74,8 @@
             "description" : "Integer values passed to `depthFunc()`.",
             "items" : {
                 "type" : "integer",
-                "enum" : [512, 513, 515, 514, 516, 517, 518, 519]
+                "enum" : [512, 513, 515, 514, 516, 517, 518, 519],
+                "gltf_enumNames" : ["NEVER", "LESS", "LEQUAL", "EQUAL", "GREATER", "NOTEQUAL", "GEQUAL", "ALWAYS"]
             },
             "minItems" : 1,
             "maxItems" : 1,
@@ -106,7 +110,8 @@
             "description" : "Integer value passed to `frontFace()`.",
             "items" : {
                 "type" : "integer",
-                "enum" : [2304, 2305]
+                "enum" : [2304, 2305],
+                "gltf_enumNames" : ["CW", "CCW"]
             },
             "minItems" : 1,
             "maxItems" : 1,

--- a/specification/schema/technique.states.functions.schema.json
+++ b/specification/schema/technique.states.functions.schema.json
@@ -27,7 +27,7 @@
             "minItems" : 2,
             "maxItems" : 2,
             "default" : [32774, 32774],
-            "gltf_detailedDescription" : "Integer values passed to `blendEquationSeparate()`. [rgb, alpha]. Valid values correspond to WebGL enums: `32774` (FUNC_ADD), `32778` (FUNC_SUBTRACT), and `32779` (FUNC_REVERSE_SUBTRACT).",
+            "gltf_detailedDescription" : "Integer values passed to `blendEquationSeparate()`. [rgb, alpha]. All valid values correspond to WebGL enums.",
             "gltf_webgl" : "`blendEquationSeparate()`"
         },
         "blendFuncSeparate" : {
@@ -41,7 +41,7 @@
             "minItems" : 4,
             "maxItems" : 4,
             "default" : [1, 1, 0, 0],
-            "gltf_detailedDescription" : "Integer values passed to `blendFuncSeparate()`. [srcRGB, srcAlpha, dstRGB, dstAlpha]. Valid values correspond to WebGL enums: `0` (ZERO), `1` (ONE), `768` (SRC_COLOR), `769` (ONE_MINUS_SRC_COLOR), `774` (DST_COLOR), `775` (ONE_MINUS_DST_COLOR), `770` (SRC_ALPHA), `771` (ONE_MINUS_SRC_ALPHA), `772` (DST_ALPHA), `773` (ONE_MINUS_DST_ALPHA), `32769` (CONSTANT_COLOR), `32770` (ONE_MINUS_CONSTANT_COLOR), `32771` (CONSTANT_ALPHA), `32772` (ONE_MINUS_CONSTANT_ALPHA), and `776` (SRC_ALPHA_SATURATE).",
+            "gltf_detailedDescription" : "Integer values passed to `blendFuncSeparate()`. [srcRGB, srcAlpha, dstRGB, dstAlpha]. All valid values correspond to WebGL enums.",
             "gltf_webgl" : "`blendFuncSeparate()`"
         },
         "colorMask" : {
@@ -66,7 +66,7 @@
             "minItems" : 1,
             "maxItems" : 1,
             "default" : [1029],
-            "gltf_detailedDescription" : "Integer value passed to `cullFace()`. Valid values correspond to WebGL enums: `1028` (FRONT), `1029` (BACK), and `1032` (FRONT_AND_BACK).",
+            "gltf_detailedDescription" : "Integer value passed to `cullFace()`. All valid values correspond to WebGL enums.",
             "gltf_webgl" : "`cullFace()`"
         },
         "depthFunc" : {
@@ -80,7 +80,7 @@
             "minItems" : 1,
             "maxItems" : 1,
             "default" : [513],
-            "gltf_detailedDescription" : "Integer values passed to `depthFunc()`. Valid values correspond to WebGL enums: `512` (NEVER), `513` (LESS), `515` (LEQUAL), `514` (EQUAL), `516` (GREATER), `517` (NOTEQUAL), `518` (GEQUAL), and `519` (ALWAYS).",
+            "gltf_detailedDescription" : "Integer values passed to `depthFunc()`. All valid values correspond to WebGL enums.",
             "gltf_webgl" : "`depthFunc()`"
         },
         "depthMask" : {
@@ -116,7 +116,7 @@
             "minItems" : 1,
             "maxItems" : 1,
             "default" : [2305],
-            "gltf_detailedDescription" : "Integer value passed to `frontFace()`.  Valid values correspond to WebGL enums: `2304` (CW) and `2305` (CCW).",
+            "gltf_detailedDescription" : "Integer value passed to `frontFace()`.  All valid values correspond to WebGL enums.",
             "gltf_webgl" : "`frontFace()`"
         },
         "lineWidth" : {

--- a/specification/schema/technique.states.schema.json
+++ b/specification/schema/technique.states.schema.json
@@ -15,7 +15,7 @@
             },
             "uniqueItems" : true,
             "default" : [],
-            "gltf_detailedDescription" : "WebGL states to enable.  States not in the array are disabled.  Valid values for each element correspond to WebGL enums: `3042` (BLEND), `2884` (CULL_FACE), `2929` (DEPTH_TEST), `32823` (POLYGON_OFFSET_FILL), `32926` (SAMPLE_ALPHA_TO_COVERAGE), and `3089` (SCISSOR_TEST).",
+            "gltf_detailedDescription" : "WebGL states to enable.  States not in the array are disabled.  All valid values correspond to WebGL enums.",
             "gltf_webgl" : "`enable()` and `disable()`"
         },
         "functions" : {

--- a/specification/schema/technique.states.schema.json
+++ b/specification/schema/technique.states.schema.json
@@ -10,7 +10,8 @@
             "description" : "WebGL states to enable.",
             "items" : {
                 "type" : "integer",
-                "enum" : [3042, 2884, 2929, 32823, 32926, 3089]
+                "enum" : [3042, 2884, 2929, 32823, 32926, 3089],
+                "gltf_enumNames" : ["BLEND", "CULL_FACE", "DEPTH_TEST", "POLYGON_OFFSET_FILL", "SAMPLE_ALPHA_TO_COVERAGE", "SCISSOR_TEST"]
             },
             "uniqueItems" : true,
             "default" : [],

--- a/specification/schema/texture.schema.json
+++ b/specification/schema/texture.schema.json
@@ -9,6 +9,7 @@
             "type" : "integer",
             "description" : "The texture's format.",
             "enum" : [6406, 6407, 6408, 6409, 6410],
+            "gltf_enumNames" : ["ALPHA", "RGB", "RGBA", "LUMINANCE", "LUMINANCE_ALPHA"],
             "default" : 6408,
             "gltf_detailedDescription" : "The texture's format.  Valid values correspond to WebGL enums: `6406` (ALPHA), `6407` (RGB), `6408` (RGBA), `6409` (LUMINANCE), and `6410` (LUMINANCE_ALPHA).",
             "gltf_webgl" : "`texImage2D()` format parameter"
@@ -17,6 +18,7 @@
             "type" : "integer",
             "description" : "The texture's internal format.",
             "enum" : [6406, 6407, 6408, 6409, 6410],
+            "gltf_enumNames" : ["ALPHA", "RGB", "RGBA", "LUMINANCE", "LUMINANCE_ALPHA"],
             "default" : 6408,
             "gltf_detailedDescription" : "The texture's internal format.  Valid values correspond to WebGL enums: `6406` (ALPHA), `6407` (RGB), `6408` (RGBA), `6409` (LUMINANCE), and `6410` (LUMINANCE_ALPHA).  Defaults to same value as format.",
             "gltf_webgl" : "`texImage2D()` internalFormat parameter"
@@ -35,6 +37,7 @@
             "type" : "integer",
             "description" : "The target that the WebGL texture should be bound to.",
             "enum" : [3553],
+            "gltf_enumNames" : ["TEXTURE_2D"],
             "default" : 3553,
             "gltf_detailedDescription" : "The target that the WebGL texture should be bound to.  Valid values correspond to WebGL enums: `3553` (TEXTURE_2D).",
             "gltf_webgl" : "`bindTexture()`"
@@ -43,6 +46,7 @@
             "type" : "integer",
             "description" : "Texel datatype.",
             "enum" : [5121, 33635, 32819, 32820],
+            "gltf_enumNames" : ["UNSIGNED_BYTE", "UNSIGNED_SHORT_5_6_5", "UNSIGNED_SHORT_4_4_4_4", "UNSIGNED_SHORT_5_5_5_1"],
             "default" : 5121,
             "gltf_detailedDescription" : "Texel datatype.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `33635` (UNSIGNED_SHORT_5_6_5), `32819` (UNSIGNED_SHORT_4_4_4_4), and `32820` (UNSIGNED_SHORT_5_5_5_1).",
             "gltf_webgl" : "`texImage2D()` type parameter"


### PR DESCRIPTION
This is intended to make the enum names more machine parsable for our ongoing C# code-gen work.