### PR TITLE
Fixes blank textures

### DIFF
--- a/COLLADA2GLTF/COLLADA2GLTFWriter.cpp
+++ b/COLLADA2GLTF/COLLADA2GLTFWriter.cpp
@@ -219,32 +219,29 @@ namespace GLTF
         
         opaqueMode = effectCommon->getOpaqueMode();
 
+        ColorOrTexture transparent = effectCommon->getTransparent();
+        double transparentAlpha = (transparent.getType() == ColorOrTexture::COLOR) ? transparent.getColor().getAlpha() : 1.0;
+
         switch (opaqueMode) {
             
             case COLLADAFW::EffectCommon::OpaqueMode::RGB_ZERO:
-            case COLLADAFW::EffectCommon::OpaqueMode::A_ZERO: {
-                ColorOrTexture transparent = effectCommon->getTransparent();
-                transparency = static_cast<float>(1.0 - transparent.getColor().getAlpha() * effectCommon->getTransparency().getFloatValue());
+            case COLLADAFW::EffectCommon::OpaqueMode::A_ZERO:
+                transparency = static_cast<float>(1.0 - transparentAlpha * effectCommon->getTransparency().getFloatValue());
                 if (!loggedOnce) {
                     this->_asset->log("WARNING: unsupported opaque mode:%s fallback to A_ONE\n", opaqueModeToString(opaqueMode).c_str() );
                     loggedOnce = true;
                 }
-            }
                 break;
-            case COLLADAFW::EffectCommon::OpaqueMode::RGB_ONE: {
-                ColorOrTexture transparent = effectCommon->getTransparent();
-                transparency = static_cast<float>(transparent.getColor().getAlpha() * effectCommon->getTransparency().getFloatValue());
+            case COLLADAFW::EffectCommon::OpaqueMode::RGB_ONE:
+                transparency = static_cast<float>(transparentAlpha * effectCommon->getTransparency().getFloatValue());
                 if (!loggedOnce) {
                     this->_asset->log("WARNING: unsupported opaque mode:%s fallback to A_ONE\n", opaqueModeToString(opaqueMode).c_str() );
                     loggedOnce = true;
                 }
-            }
                 break;
             
-            case COLLADAFW::EffectCommon::OpaqueMode::A_ONE: {
-                ColorOrTexture transparent = effectCommon->getTransparent();
-                transparency = static_cast<float>(transparent.getColor().getAlpha() * effectCommon->getTransparency().getFloatValue());
-            }
+            case COLLADAFW::EffectCommon::OpaqueMode::A_ONE: 
+                transparency = static_cast<float>(transparentAlpha * effectCommon->getTransparency().getFloatValue());
                 break;
             case COLLADAFW::EffectCommon::OpaqueMode::UNSPECIFIED_OPAQUE:
             default:


### PR DESCRIPTION
We didn't check whether transparent was a color or texture and we just use the alpha value which was in its initial state of -1. This caused meshes to be transparent when they weren't suppose to be. The real fix would be to handle a transparency map, but that is a decent undertaking. This fix ignores the transparent texture like before, it just doesn't introduce a -1 into the equation.

Its a band aid for #530