### PR TITLE
Removed requirement of rapidjson

### DIFF
--- a/COLLADA2GLTF/CMakeLists.txt
+++ b/COLLADA2GLTF/CMakeLists.txt
@@ -109,6 +109,7 @@ set(GLTF_SOURCES
     GLTF/GLTFPrimitive.cpp
     GLTF/GLTFUtils.cpp
     GLTF/GLTFWriter.cpp
+    GLTF/GLTFDefaultWriter.cpp
     GLTF/GLTFSkin.cpp
     GLTF/GLTF.h
     GLTF/GLTFTypesAndConstants.h
@@ -122,6 +123,7 @@ set(GLTF_SOURCES
     GLTF/GLTFPrimitive.h
     GLTF/GLTFUtils.h
     GLTF/GLTFWriter.h
+    GLTF/GLTFDefaultWriter.h
     GLTF/GLTFSkin.h
     GLTF/GLTFExtraDataHandler.h
     GLTF/GLTFExtraDataHandler.cpp

--- a/COLLADA2GLTF/COLLADA2GLTFWriter.cpp
+++ b/COLLADA2GLTF/COLLADA2GLTFWriter.cpp
@@ -46,7 +46,6 @@ using namespace std;
 using namespace COLLADAFW;
 using namespace COLLADABU;
 using namespace COLLADASaxFWL;
-using namespace rapidjson;
 
 namespace
 {

--- a/COLLADA2GLTF/GLTF/GLTFAccessor.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFAccessor.cpp
@@ -26,7 +26,6 @@
 
 #include "GLTF.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/GLTF/GLTFAnimation.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFAnimation.cpp
@@ -26,8 +26,6 @@
 #include "animationConverter.h"
 #include "GLTF-Open3DGC.h" //FIXME: setupAndWriteAnimationParameter has to move out from this header
 
-using namespace rapidjson;
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -8,6 +8,7 @@
 #include "geometryHelpers.h"
 #include "../shaders/commonProfileShaders.h"
 #include <GLTFOpenCOLLADAUtils.h>
+#include <GLTFDefaultWriter.h>
 
 #if __cplusplus <= 199711L
 using namespace std::tr1;

--- a/COLLADA2GLTF/GLTF/GLTFBuffer.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFBuffer.cpp
@@ -27,8 +27,6 @@
 #include "GLTF.h"
 #include "GLTFAsset.h"
 
-using namespace rapidjson;
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/GLTF/GLTFConfig.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFConfig.cpp
@@ -23,7 +23,6 @@
 
 #include "GLTF.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/GLTF/GLTFDefaultWriter.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFDefaultWriter.cpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2012, Motorola Mobility, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of the Motorola Mobility, Inc. nor the names of its
+//    contributors may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "GLTF.h"
+#include "../GLTFOpenCOLLADA.h"
+#include "GLTFDefaultWriter.h"
+
+#if __cplusplus <= 199711L
+using namespace std::tr1;
+#endif
+using namespace std;
+
+namespace GLTF 
+{    
+    //-- Default Writer
+    
+    GLTFDefaultWriter::GLTFDefaultWriter() :
+        _writer(0)
+    {
+        _fd = 0;
+    }
+
+    bool GLTFDefaultWriter::initWithPath(const std::string &path) {
+        this->_fd = fopen(path.c_str(), "w");
+        if (this->_fd) {
+            this->_fileStream = new rapidjson::FileStream(this->_fd);
+            if (this->_fileStream) {
+                this->_writer = new rapidjson::PrettyWriter <rapidjson::FileStream>(*this->_fileStream);
+                return this->_writer != 0;
+            }
+        }
+        
+        return false;
+    }
+        
+    GLTFDefaultWriter::~GLTFDefaultWriter() {
+        if (_fd) {
+            delete this->_fileStream;
+            delete this->_writer;
+            fclose(this->_fd);
+        }
+    }
+        
+    //base
+    void GLTFDefaultWriter::writeArray(JSONArray* array, void *context) {
+        this->_writer->StartArray();
+        
+        vector <shared_ptr <JSONValue> > values = array->values();
+        size_t count = values.size();
+        for (size_t i = 0 ; i < count ; i++) {
+            values[i]->write(this, context);
+        }
+        
+        this->_writer->EndArray();
+    }
+    
+    void GLTFDefaultWriter::writeObject(JSONObject* object, void *context) {
+        this->_writer->StartObject(); 
+
+        vector <std::string> keys = object->getAllKeys();
+        size_t count = keys.size();
+        
+        for (size_t i = 0 ; i < count ; i++) {
+            shared_ptr <JSONValue> value = object->getValue(keys[i]);
+            const std::string& key = keys[i];
+            this->_writer->String(key.c_str());
+            if (value)
+                value->write(this, context);
+        }
+        
+        this->_writer->EndObject(); 
+    }
+    
+    void GLTFDefaultWriter::writeNumber(JSONNumber* number, void *context) {
+        JSONNumber::JSONNumberType type = number->getNumberType();
+        
+        switch (type) {
+            case JSONNumber::UNSIGNED_INT32:
+                this->_writer->Uint(number->getUnsignedInt32());
+                break;
+            case JSONNumber::INT32:
+                this->_writer->Int(number->getInt32());
+                break;
+            case JSONNumber::DOUBLE:
+            {   
+                double value = number->getDouble();
+                this->_writer->Double(value);
+                break;
+            }
+            case JSONNumber::BOOL:
+            {   
+                bool value = number->getBool();
+                this->_writer->Bool(value);
+            }
+                break;
+            default:
+                //FIXME: TODO Handle error
+                break;
+        }
+    }
+        
+    void GLTFDefaultWriter::writeString(JSONString* str, void *context) {
+        this->_writer->String(str->getCString());
+    }
+    
+    void GLTFDefaultWriter::write(JSONValue* value, void* context) {
+        JSONType jsonType = value->getJSONType();
+        
+        if (jsonType == kJSONNumber) {
+            this->writeNumber((JSONNumber*)value, context);
+        } else if (jsonType == kJSONObject) {
+            this->writeObject((JSONObject*)value, context);
+        } else if (jsonType == kJSONArray) {
+            this->writeArray((JSONArray*)value, context);
+        } else if (jsonType == kJSONString) {
+            this->writeString((JSONString*)value, context);
+        } 
+        
+    }
+        
+}
+

--- a/COLLADA2GLTF/GLTF/GLTFDefaultWriter.h
+++ b/COLLADA2GLTF/GLTF/GLTFDefaultWriter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, Motorola Mobility, Inc.
+// Copyright (c) 2012, Motorola Mobility, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -24,54 +24,37 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef __GLTF_H__
-#define __GLTF_H__
+#ifndef __JSON_DEFAULT_WRITER_H__
+#define __JSON_DEFAULT_WRITER_H__
 
-// system & STL headers
-#include <algorithm>
-#include <stack>
-#include <list>
-#include <map>
-#include <set>
-#include <string>
-#include <iostream>
-#include <sstream>
-#include <fstream>
-#include <vector>
-#include "assert.h"
-#include <cstddef>
-#include <cstdint>
+#include "GLTFWriter.h"
 
-#if (defined(WIN32) || defined(_LIBCPP_VERSION) || __cplusplus > 199711L)
-#include <memory>
-#include <unordered_map>
-#else 
-#include <tr1/memory>
-#include <tr1/unordered_map>
+#include <prettywriter.h>
+#include <filestream.h>
+
+namespace GLTF
+{
+
+    class GLTFDefaultWriter : public GLTFWriter
+    {
+    public:
+        GLTFDefaultWriter();
+        virtual ~GLTFDefaultWriter();
+
+        bool initWithPath(const std::string &path);
+        void writeArray(JSONArray* array, void *context);
+        void writeObject(JSONObject* object, void *context);
+        void writeNumber(JSONNumber* number, void *context);
+        void writeString(JSONString* str, void *context);
+        void write(JSONValue* value, void *context);
+
+    private:
+        FILE* _fd;
+        rapidjson::PrettyWriter <rapidjson::FileStream> *_writer;
+        rapidjson::FileStream *_fileStream;
+    };
+
+}
+
 #endif
 
-// GLTF headers
-#include "COLLADA2GLTFExport.h"
-#include "GLTFTypesAndConstants.h"
-#include "GLTFProfile.h"
-#include "JSONValue.h"
-#include "JSONNumber.h"
-#include "JSONString.h"
-#include "JSONObject.h"
-#include "JSONArray.h"
-#include "GLTFUtils.h"
-#include "GLTFBuffer.h"
-#include "GLTFAccessor.h"
-#include "GLTFEffect.h"
-#include "GLTFPrimitive.h"
-#include "GLTFMesh.h"
-#include "GLTFSkin.h"
-#include "GLTFAnimation.h"
-#include "GLTFWriter.h"
-#include "GLTFInputStream.h"
-#include "GLTFOutputStream.h"
-#include "GLTFConfig.h"
-#include "GLTFAssetModifier.h"
-#include "GLTFExtras.h"
-
-#endif 

--- a/COLLADA2GLTF/GLTF/GLTFEffect.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFEffect.cpp
@@ -32,7 +32,6 @@
 #define _GL_STR(X) #X
 #define _GL(X) (this->_profile->getGLenumForString(_GL_STR(X)))
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/GLTF/GLTFExtras.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFExtras.cpp
@@ -23,7 +23,6 @@
 
 #include "GLTF.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/GLTF/GLTFMesh.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFMesh.cpp
@@ -28,7 +28,6 @@
 #include "GLTF.h"
 #include "../helpers/geometryHelpers.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/GLTF/GLTFPrimitive.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFPrimitive.cpp
@@ -26,7 +26,6 @@
 
 #include "GLTF.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/GLTF/GLTFSkin.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFSkin.cpp
@@ -23,7 +23,6 @@
 
 #include "GLTF.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/GLTF/GLTFWriter.h
+++ b/COLLADA2GLTF/GLTF/GLTFWriter.h
@@ -45,26 +45,6 @@ namespace GLTF
         virtual void write(JSONValue* value, void *context) = 0;
     };
 
-    class GLTFDefaultWriter : public GLTFWriter
-    {
-    public:
-        GLTFDefaultWriter();
-        virtual ~GLTFDefaultWriter();
-
-        bool initWithPath(const std::string &path);
-        void writeArray(JSONArray* array, void *context);
-        void writeObject(JSONObject* object, void *context);
-        void writeNumber(JSONNumber* number, void *context);
-        void writeString(JSONString* str, void *context);
-        void write(JSONValue* value, void *context);
-
-    private:
-        FILE* _fd;
-        rapidjson::PrettyWriter <rapidjson::FileStream> *_writer;
-        rapidjson::FileStream *_fileStream;
-    };
-
 }
-
 
 #endif

--- a/COLLADA2GLTF/JSON/JSONNumber.cpp
+++ b/COLLADA2GLTF/JSON/JSONNumber.cpp
@@ -26,7 +26,6 @@
 
 #include "GLTF.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/JSON/JSONValue.cpp
+++ b/COLLADA2GLTF/JSON/JSONValue.cpp
@@ -26,7 +26,6 @@
 
 #include "GLTF.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/assetModifiers/GLTFFlipUVModifier.cpp
+++ b/COLLADA2GLTF/assetModifiers/GLTFFlipUVModifier.cpp
@@ -24,7 +24,6 @@
 #include "GLTF.h"
 #include "GLTFFlipUVModifier.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/convert/animationConverter.cpp
+++ b/COLLADA2GLTF/convert/animationConverter.cpp
@@ -8,7 +8,6 @@
 
 #include "GLTF-Open3DGC.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/convert/meshConverter.cpp
+++ b/COLLADA2GLTF/convert/meshConverter.cpp
@@ -22,7 +22,6 @@
 #endif
 //--- X3DGC
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/extensions/o3dgc-compression/GLTF-Open3DGC.cpp
+++ b/COLLADA2GLTF/extensions/o3dgc-compression/GLTF-Open3DGC.cpp
@@ -39,7 +39,6 @@
 #define DUMP_O3DGC_OUTPUT 0
 
 using namespace o3dgc;
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/helpers/encodingHelpers.cpp
+++ b/COLLADA2GLTF/helpers/encodingHelpers.cpp
@@ -24,7 +24,6 @@
 #include "GLTF.h"
 #include "encodingHelpers.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/helpers/geometryHelpers.cpp
+++ b/COLLADA2GLTF/helpers/geometryHelpers.cpp
@@ -26,7 +26,6 @@
 #include <stdlib.h>
 #include "geometryHelpers.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/helpers/mathHelpers.cpp
+++ b/COLLADA2GLTF/helpers/mathHelpers.cpp
@@ -25,7 +25,6 @@
 #include "../GLTFOpenCOLLADA.h"
 #include "mathHelpers.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif

--- a/COLLADA2GLTF/main.cpp
+++ b/COLLADA2GLTF/main.cpp
@@ -41,7 +41,6 @@
 #include "JSONObject.h"
 #include "GLTFOpenCOLLADAUtils.h"
 
-using namespace rapidjson;
 #if __cplusplus <= 199711L
 using namespace std::tr1;
 #endif
@@ -129,8 +128,6 @@ bool fileExists(const char * filename) {
 
 static bool processArgs(int argc, char * const * argv, GLTF::GLTFAsset *asset) {
 	int ch;
-    std::string file;
-    std::string output;
     bool hasOutputPath = false;
     bool hasInputPath = false;
     bool shouldShowHelp = false;
@@ -198,7 +195,7 @@ static bool processArgs(int argc, char * const * argv, GLTF::GLTFAsset *asset) {
                     if (strcmp(optarg, "true") == 0) {
                         useDefaultLight = true;
                     }
-                    if (strcmp(optarg, "false") == 0) {
+                    else if (strcmp(optarg, "false") == 0) {
                         useDefaultLight = false;
                     } else {
                         useDefaultLight = atoi(optarg) != 0;


### PR DESCRIPTION
Removed rapidjson from all public headers. Its now only used for reading the json and as the default writer. This allows us to use a different version or other json library if we specify a custom writer from our own app.