### PR TITLE
Remove TEXCOORD vertexAttribute when it is unnecessary

### DIFF
--- a/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -67,12 +67,6 @@ namespace GLTF
         asset->convertionResults()->setUnsignedInt32("verticesCount", totalVerticesCount);
 
         GLTF::JSONValueVector primitives = mesh->getPrimitives()->values();
-
-        bool isCompressed = false;
-        if (mesh->contains(kExtensions)) {
-            isCompressed = mesh->getExtensions()->contains("Open3DGC-compression");
-        }
-
         unsigned int primitivesCount = (unsigned int)primitives.size();
         for (unsigned int j = 0; j < primitivesCount; j++) {
             shared_ptr<GLTF::GLTFPrimitive> primitive = static_pointer_cast<GLTFPrimitive>(primitives[j]);

--- a/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -63,7 +63,7 @@ namespace GLTF
         shared_ptr<GLTFAccessor> positionAttribute = mesh->getMeshAttribute(GLTF::POSITION, 0);
         size_t vertexCount = positionAttribute->getCount();
         unsigned int totalVerticesCount = asset->convertionResults()->getUnsignedInt32("verticesCount");
-		totalVerticesCount += (unsigned int)vertexCount;
+        totalVerticesCount += (unsigned int)vertexCount;
         asset->convertionResults()->setUnsignedInt32("verticesCount", totalVerticesCount);
 
         for (unsigned int j = 0 ; j < allMeshAttributes->size() ; j++) {
@@ -90,7 +90,7 @@ namespace GLTF
         GLTFOutputStream* compressionOutputStream = asset->createOutputStreamIfNeeded(kCompressionOutputStream).get();
         
         shared_ptr <JSONObject> floatAttributeIndexMapping(new JSONObject());
-		unsigned compressedBufferStart = (unsigned int)compressionOutputStream->length();
+        unsigned compressedBufferStart = (unsigned int)compressionOutputStream->length();
         encodeOpen3DGCMesh(mesh, floatAttributeIndexMapping, asset);
         typedef std::map<std::string , shared_ptr<GLTF::GLTFBuffer> > IDToBufferDef;
         IDToBufferDef IDToBuffer;
@@ -114,12 +114,12 @@ namespace GLTF
                 asset->convertionResults()->setUnsignedInt32("trianglesCount", trianglesCount);
                 size_t indicesLength = sizeof(unsigned short) * indicesCount;
                 uniqueIndices->setByteOffset(compressedBufferStart);
-				compressedBufferStart += (unsigned int)indicesLength; //we simulate how will be the uncompressed data here, so this is the length in short *on purpose*
+                compressedBufferStart += (unsigned int)indicesLength; //we simulate how will be the uncompressed data here, so this is the length in short *on purpose*
             }
         }
         
         shared_ptr<GLTFAccessor> positionAttribute = mesh->getMeshAttribute(GLTF::POSITION, 0);
-		vertexCount = (unsigned int)positionAttribute->getCount();
+        vertexCount = (unsigned int)positionAttribute->getCount();
         unsigned int totalVerticesCount = asset->convertionResults()->getUnsignedInt32("verticesCount");
         totalVerticesCount += vertexCount;
         asset->convertionResults()->setUnsignedInt32("verticesCount", totalVerticesCount);
@@ -134,7 +134,7 @@ namespace GLTF
             if (!IDToBuffer[bufferView->getBuffer()->getID()].get()) {
                 meshAttribute->exposeMinMax();
                 meshAttribute->setByteOffset(compressedBufferStart);
-				compressedBufferStart += (unsigned int)buffer->getByteLength();
+                compressedBufferStart += (unsigned int)buffer->getByteLength();
                 IDToBuffer[bufferView->getBuffer()->getID()] = buffer;
             }
         }
@@ -200,20 +200,20 @@ namespace GLTF
     shared_ptr<GLTFOutputStream> GLTFAsset::createOutputStreamIfNeeded(const std::string& streamName) {
 
         if (this->_nameToOutputStream.count(streamName) == 0)
-		{
-			shared_ptr<GLTFOutputStream> outputStream;
+        {
+            shared_ptr<GLTFOutputStream> outputStream;
             if (CONFIG_BOOL(this, "embedResources"))
-			{
-				outputStream = std::make_shared<GLTFOutputStream>();
-			}
-			else
-			{
-				COLLADABU::URI outputURI(this->getOutputFilePath().c_str());
+            {
+                outputStream = std::make_shared<GLTFOutputStream>();
+            }
+            else
+            {
+                COLLADABU::URI outputURI(this->getOutputFilePath().c_str());
 
                 std::string folder = getPathDir(outputURI);
 
-				outputStream = std::make_shared<GLTFOutputStream>(folder, streamName, "");
-			}
+                outputStream = std::make_shared<GLTFOutputStream>(folder, streamName, "");
+            }
             this->_nameToOutputStream[streamName] = outputStream;
         }
         
@@ -226,7 +226,7 @@ namespace GLTF
             shared_ptr<GLTFOutputStream> outputStream = this->_nameToOutputStream[streamName];
             
             outputStream->close();
-			if (removeFile) {
+            if (removeFile) {
                 outputStream->remove();
             }
             
@@ -941,7 +941,7 @@ namespace GLTF
         }
         
         meshesUIDs = meshes->getAllKeys();
-		shared_ptr <GLTF::JSONObject> materials = this->_root->createObjectIfNeeded(kMaterials);
+        shared_ptr <GLTF::JSONObject> materials = this->_root->createObjectIfNeeded(kMaterials);
         
         for (size_t i = 0 ; i < meshesUIDs.size() ; i++) {
             shared_ptr<GLTFMesh> mesh = static_pointer_cast<GLTFMesh>(meshes->getObject(meshesUIDs[i]));
@@ -950,38 +950,38 @@ namespace GLTF
 
             for (unsigned int j = 0 ; j < primitivesCount ; j++) {
                 shared_ptr<GLTFPrimitive> primitive = static_pointer_cast<GLTFPrimitive>(primitives[j]);
-				//WORK-AROUND: we don't want meshes without material, which can happen if a mesh is not associated with a node.
-				//In this case, the material binding - isn't resolved.
+                //WORK-AROUND: we don't want meshes without material, which can happen if a mesh is not associated with a node.
+                //In this case, the material binding - isn't resolved.
                 if (primitive->contains(kMaterial) ==  false) {
                     meshes->removeValue(mesh->getID());
                     break;
                 }
-				//WORK-AROUND: TEXCOORD from the Collada model is an unnecessary field if the material doesn't use textures
-				else {
-					GLTF::VertexAttributeVector vertexAttributes = primitive->getVertexAttributes();
-					for (unsigned int k = 0; k < vertexAttributes.size(); k++) {
-						shared_ptr <JSONVertexAttribute> vertexAttribute = static_pointer_cast<JSONVertexAttribute>(vertexAttributes[k]);
-						if (vertexAttribute->getSemantic() == GLTF::TEXCOORD) {
-							std::string materialId = primitive->getMaterialID();
-							shared_ptr <GLTF::GLTFEffect> material = static_pointer_cast<GLTF::GLTFEffect>(materials->getObject(materialId));
-							shared_ptr <JSONObject> values = material->getValues();
-							bool usesTexture = false;
-							std::vector<std::string> keys = values->getAllKeys();
-							for (unsigned int m = 0; m < values->getKeysCount(); m++) {
-								shared_ptr <JSONValue> value = values->getValue(keys.at(m))->valueForKeyPath("value");
-								if (value->valueType() == kJSONString) {
-									usesTexture = true;
-									break;
-								}
-							}
-							if (!usesTexture) {
-								primitive->removeVertexAttribute(k);
-							}
-						}
-					}
-				}
+                //WORK-AROUND: TEXCOORD from the Collada model is an unnecessary field if the material doesn't use textures
+                else {
+                    GLTF::VertexAttributeVector vertexAttributes = primitive->getVertexAttributes();
+                    for (unsigned int k = 0; k < vertexAttributes.size(); k++) {
+                        shared_ptr <JSONVertexAttribute> vertexAttribute = static_pointer_cast<JSONVertexAttribute>(vertexAttributes[k]);
+                        if (vertexAttribute->getSemantic() == GLTF::TEXCOORD) {
+                            std::string materialId = primitive->getMaterialID();
+                            shared_ptr <GLTF::GLTFEffect> material = static_pointer_cast<GLTF::GLTFEffect>(materials->getObject(materialId));
+                            shared_ptr <JSONObject> values = material->getValues();
+                            bool usesTexture = false;
+                            std::vector<std::string> keys = values->getAllKeys();
+                            for (unsigned int m = 0; m < values->getKeysCount(); m++) {
+                                shared_ptr <JSONValue> value = values->getValue(keys.at(m))->valueForKeyPath("value");
+                                if (value->valueType() == kJSONString) {
+                                    usesTexture = true;
+                                    break;
+                                }
+                            }
+                            if (!usesTexture) {
+                                primitive->removeVertexAttribute(k);
+                            }
+                        }
+                    }
+                }
             }
-			mesh->resolveAttributes();
+            mesh->resolveAttributes();
         }
         
         //Meshes may have changed ids here, get keys again.
@@ -1067,30 +1067,26 @@ namespace GLTF
                 isCompressed = mesh->getExtensions()->contains("Open3DGC-compression");
             }
             
-            //serialize attributes
-            vector <GLTF::Semantic> allSemantics = mesh->allSemantics();
-            for (size_t k = 0 ; k < allSemantics.size() ; k++) {
-                GLTF::Semantic semantic = allSemantics[k];
-                size_t attributesCount = mesh->getMeshAttributesCountForSemantic(semantic);
-                
-                for (size_t j = 0 ; j < attributesCount ; j++) {
-                    shared_ptr <GLTF::GLTFAccessor> meshAttribute = mesh->getMeshAttribute(semantic, j);
-                    
-                    meshAttribute->setBufferView(isCompressed ? compressionBufferView : verticesBufferView);
-                    accessors->setValue(meshAttribute->getID(), meshAttribute);
-                }
-            }
-            
-            //serialize indices
+            //serialize indices and attributes
             unsigned int primitivesCount =  (unsigned int)primitives.size();
-            for (size_t k = 0 ; k < primitivesCount ; k++) {
-                shared_ptr<GLTF::GLTFPrimitive> primitive = static_pointer_cast<GLTFPrimitive>(primitives[k]);
+            for (size_t j = 0 ; j < primitivesCount ; j++) {
+                shared_ptr<GLTF::GLTFPrimitive> primitive = static_pointer_cast<GLTFPrimitive>(primitives[j]);
                 shared_ptr <GLTF::GLTFAccessor> uniqueIndices =  primitive->getIndices();
                 
                 GLTFBufferView *bufferView = isCompressed ? (GLTFBufferView*)compressionBufferView.get() : (GLTFBufferView*)indicesBufferView.get();
                 
                 uniqueIndices->setString(kBufferView, bufferView->getID());
                 accessors->setValue(uniqueIndices->getID(), uniqueIndices);
+
+                GLTF::VertexAttributeVector vertexAttributes = primitive->getVertexAttributes();
+                for (unsigned int k = 0; k < vertexAttributes.size(); k++) {
+                    shared_ptr <JSONVertexAttribute> vertexAttribute = static_pointer_cast<JSONVertexAttribute>(vertexAttributes[k]);
+                    GLTF::Semantic semantic = vertexAttribute->getSemantic();
+                    shared_ptr <GLTF::GLTFAccessor> meshAttribute = mesh->getMeshAttribute(semantic, j);
+
+                    meshAttribute->setBufferView(isCompressed ? compressionBufferView : verticesBufferView);
+                    accessors->setValue(meshAttribute->getID(), meshAttribute);
+                }
             }
             
             //set the compression buffer view
@@ -1151,9 +1147,8 @@ namespace GLTF
                 parameterObject->setString(kBufferView, genericBufferView->getID());
             }            
         }
-        
+
         shared_ptr <JSONObject> buffersObject(new JSONObject());
-        
         this->_root->setValue("buffers", buffersObject);
         
         if (sharedBuffer->getByteLength() > 0) {
@@ -1206,11 +1201,11 @@ namespace GLTF
             this->closeOutputStream(kCompressionOutputStream, true);
         }
         
-		if (sharedBuffer->getByteLength() == 0)
+        if (sharedBuffer->getByteLength() == 0)
             rawOutputStream->remove();
                 
-		this->convertionResults()->setUnsignedInt32(kGeometry, (unsigned int)this->getGeometryByteLength());
-		this->convertionResults()->setUnsignedInt32(kAnimation, (unsigned int)this->getAnimationByteLength());
+        this->convertionResults()->setUnsignedInt32(kGeometry, (unsigned int)this->getGeometryByteLength());
+        this->convertionResults()->setUnsignedInt32(kAnimation, (unsigned int)this->getAnimationByteLength());
         this->convertionResults()->setUnsignedInt32(kScene, (int) (verticesLength + indicesLength + animationLength + compressionLength) );
         
         this->log("[geometry] %d bytes\n", (int)this->getGeometryByteLength());

--- a/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -76,19 +76,21 @@ namespace GLTF
                 GLTF::Semantic semantic = vertexAttribute->getSemantic();
                 shared_ptr <GLTF::GLTFAccessor> meshAttribute = mesh->getMeshAttribute(semantic, j);
 
-                shared_ptr <GLTFBufferView> bufferView = meshAttribute->getBufferView();
-                shared_ptr <GLTFBuffer> buffer = bufferView->getBuffer();
+                if (meshAttribute != NULL) {
+                    shared_ptr <GLTFBufferView> bufferView = meshAttribute->getBufferView();
+                    shared_ptr <GLTFBuffer> buffer = bufferView->getBuffer();
 
-                if (!bufferView.get()) {
-                    return false;
-                }
+                    if (!bufferView.get()) {
+                        return false;
+                    }
 
-                if (IDToBuffer.count(bufferView->getBuffer()->getID()) == 0) {
-                    meshAttribute->exposeMinMax();
-                    meshAttribute->setByteOffset(vertexOutputStream->length() - startOffset);
-                    vertexOutputStream->write(buffer);
-                    IDToBuffer[bufferView->getBuffer()->getID()] = buffer;
-                    asset->setGeometryByteLength(asset->getGeometryByteLength() + buffer->getByteLength());
+                    if (IDToBuffer.count(bufferView->getBuffer()->getID()) == 0) {
+                        meshAttribute->exposeMinMax();
+                        meshAttribute->setByteOffset(vertexOutputStream->length() - startOffset);
+                        vertexOutputStream->write(buffer);
+                        IDToBuffer[bufferView->getBuffer()->getID()] = buffer;
+                        asset->setGeometryByteLength(asset->getGeometryByteLength() + buffer->getByteLength());
+                    }
                 }
             }
         }
@@ -977,10 +979,14 @@ namespace GLTF
                             bool usesTexture = false;
                             std::vector<std::string> keys = values->getAllKeys();
                             for (unsigned int m = 0; m < values->getKeysCount(); m++) {
-                                shared_ptr <JSONValue> value = values->getValue(keys.at(m))->valueForKeyPath("value");
-                                if (value->valueType() == kJSONString) {
-                                    usesTexture = true;
-                                    break;
+                                std::string key = keys.at(m);
+                                //As-in commonProfileShaders.cpp, exclude the reflective slot
+                                if (key != "reflective") {
+                                    shared_ptr <JSONValue> value = values->getValue(keys.at(m))->valueForKeyPath("value");
+                                    if (value->valueType() == kJSONString) {
+                                        usesTexture = true;
+                                        break;
+                                    }
                                 }
                             }
                             if (!usesTexture) {
@@ -1093,8 +1099,10 @@ namespace GLTF
                     GLTF::Semantic semantic = vertexAttribute->getSemantic();
                     shared_ptr <GLTF::GLTFAccessor> meshAttribute = mesh->getMeshAttribute(semantic, j);
 
-                    meshAttribute->setBufferView(isCompressed ? compressionBufferView : verticesBufferView);
-                    accessors->setValue(meshAttribute->getID(), meshAttribute);
+                    if (meshAttribute != NULL) {
+                        meshAttribute->setBufferView(isCompressed ? compressionBufferView : verticesBufferView);
+                        accessors->setValue(meshAttribute->getID(), meshAttribute);
+                    }
                 }
             }
             

--- a/COLLADA2GLTF/GLTF/GLTFPrimitive.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFPrimitive.cpp
@@ -71,7 +71,7 @@ namespace GLTF
     
     unsigned int GLTFPrimitive::getIndexOfSetAtIndex(unsigned int index)
     {
-		return (unsigned int)this->_allVertexAttributes[index]->getIndexOfSet();
+        return (unsigned int)this->_allVertexAttributes[index]->getIndexOfSet();
     }
 
     size_t GLTFPrimitive::getVertexAttributesCount()
@@ -89,9 +89,9 @@ namespace GLTF
         this->_allVertexAttributes.push_back(VertexAttribute);
     }  
 
-	void GLTFPrimitive::removeVertexAttribute(unsigned int index) {
-		this->_allVertexAttributes.erase(this->_allVertexAttributes.begin() + index);
-	}
+    void GLTFPrimitive::removeVertexAttribute(unsigned int index) {
+        this->_allVertexAttributes.erase(this->_allVertexAttributes.begin() + index);
+    }
         
     unsigned int GLTFPrimitive::getMode() {
         return this->getUnsignedInt32(kMode);

--- a/COLLADA2GLTF/GLTF/GLTFPrimitive.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFPrimitive.cpp
@@ -87,7 +87,11 @@ namespace GLTF
     void GLTFPrimitive::appendVertexAttribute(shared_ptr <JSONVertexAttribute> VertexAttribute)
     {
         this->_allVertexAttributes.push_back(VertexAttribute);
-    }    
+    }  
+
+	void GLTFPrimitive::removeVertexAttribute(unsigned int index) {
+		this->_allVertexAttributes.erase(this->_allVertexAttributes.begin() + index);
+	}
         
     unsigned int GLTFPrimitive::getMode() {
         return this->getUnsignedInt32(kMode);

--- a/COLLADA2GLTF/GLTF/GLTFPrimitive.h
+++ b/COLLADA2GLTF/GLTF/GLTFPrimitive.h
@@ -71,6 +71,7 @@ namespace GLTF
         
         VertexAttributeVector getVertexAttributes();
         void appendVertexAttribute(std::shared_ptr <JSONVertexAttribute> VertexAttribute);
+		void removeVertexAttribute(unsigned int index);
         
         std::shared_ptr <GLTF::GLTFAccessor>  getIndices();
         void setIndices(std::shared_ptr <GLTF::GLTFAccessor> indices);

--- a/COLLADA2GLTF/GLTF/GLTFPrimitive.h
+++ b/COLLADA2GLTF/GLTF/GLTFPrimitive.h
@@ -71,7 +71,7 @@ namespace GLTF
         
         VertexAttributeVector getVertexAttributes();
         void appendVertexAttribute(std::shared_ptr <JSONVertexAttribute> VertexAttribute);
-		void removeVertexAttribute(unsigned int index);
+        void removeVertexAttribute(unsigned int index);
         
         std::shared_ptr <GLTF::GLTFAccessor>  getIndices();
         void setIndices(std::shared_ptr <GLTF::GLTFAccessor> indices);


### PR DESCRIPTION
In reference to #556.

The TEXCOORD field is unnecessary unless the material for the node references a texture.

I've tested this with the box model and it successfully removed unused TEXCOORD fields. I've also tested it with the milk truck model and it correctly identifies that the TEXCOORD fields are used and doesn't remove them.

Also adds the ```removeVertexAttributes``` method to GLTFPrimitive.

Edit: After reviewing a bit, I realized that this still leaves the unused accessor and data for TEXCOORD. While that doesn't break anything, they should be removed to reduce the size of the model. Feel free to comment on what's here already, and I should have a fix in for the aforementioned soon.