### PR TITLE
Made default falloffAngle in KHR_materials_common consistent

### DIFF
--- a/extensions/Khronos/KHR_materials_common/README.md
+++ b/extensions/Khronos/KHR_materials_common/README.md
@@ -380,7 +380,7 @@ Table 3. Spot Light Properties
 
 | Property                     | Type         | Description | Default Value |
 |:----------------------------:|:------------:|:-----------:|:-------------:|
-| `falloffAngle`              | `FLOAT` | Falloff angle for the spot light, in radians.| PI / 2 |
+| `falloffAngle`              | `FLOAT` | Falloff angle for the spot light, in radians.| PI |
 | `falloffExponent`           | `FLOAT` | Falloff exponent for the spotlight. | 0 |
 
 


### PR DESCRIPTION
@tparisi making this `PI` is consistent with the COLLADA spec.  What do you think?

From #563:

> Default value for falloffAngle is PI/2 in spec but PI in light.spot.schema.json.