### PR TITLE
Make indices accessor constraints explicit

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -2385,6 +2385,8 @@ A dictionary object of strings, where each string is the ID of the accessor cont
 
 The ID of the accessor that contains the indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.
 
+When defined, the [`accessor`](#accessor) must contain indices: the bufferView referenced by the accessor must have a [`target`](#bufferviewtarget) equal to `34963` (ELEMENT_ARRAY_BUFFER); a `byteStride` that is tightly packed, i.e., `0` or the byte size of `componentType` in bytes; `componentType` must be `5121` (UNSIGNED_BYTE) or `5123` (UNSIGNED_SHORT); and `type` must be `"SCALAR"`.
+
 * **Type**: `string`
 * **Required**: No
 * **Minimum Length**`: >= 1`

--- a/specification/schema/mesh.primitive.schema.json
+++ b/specification/schema/mesh.primitive.schema.json
@@ -18,7 +18,7 @@
         "indices" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
             "description" : "The ID of the accessor that contains the indices.",
-            "gltf_detailedDescription" : "The ID of the accessor that contains the indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`."            
+            "gltf_detailedDescription" : "The ID of the accessor that contains the indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.  When defined, the accessor must contain indices: the bufferView referenced by the accessor must have a target equal to 34963 (ELEMENT_ARRAY_BUFFER); a byteStride that is tightly packed, i.e., 0 or the byte size of componentType in bytes; componentType must be 5121 (UNSIGNED_BYTE) or 5123 (UNSIGNED_SHORT); and type must be \"SCALAR\"."
         },
         "material" : {
             "extends" : { "$ref" : "glTFid.schema.json" },


### PR DESCRIPTION
Part of #563

>  There is no explicit requirement on the mesh.primitive.indices accessor to not to be FLOAT and to reference bufferView with ELEMENT_ARRAY_BUFFER target.

@lexaknyazev what do you think of this word?

Also, I think this is fine for the 1.0 spec since these are the constraints that are needed in practice; this is just a clarification and does not need to wait for 1.0.1