### PR TITLE
Draft of uint32 support

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -1132,7 +1132,7 @@ All extensions used in a model are listed in the top-level `extensionsUsed` dict
 ]
 ```
 
-_TODO: add note on how this is different than `webglExtensionsUsed` property._
+_TODO: add note on how this is different than `glExtensionsUsed` property._
 
 For more information on glTF extensions, consult the [extensions registry specification](../extensions/README.md).
 
@@ -1230,7 +1230,7 @@ The stride, in bytes, between attributes referenced by this accessor.  When this
 
 The datatype of components in the attribute.  Valid values correspond to WebGL enums: `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), `5125` (UNSIGNED_INT) and `5126` (FLOAT).  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, `Uint32Array`, and `Float32Array`, respectively.
 
-`5125` (UNSIGNED_INT) is only allowed when the accessor contains indices and the OES_element_index_uint extension is used, i.e., the accessor is only referenced by [`primitive.indices`](#reference-primitive.indices) and [`webglExtensionsUsed`](#reference-webglExtensionsUsed) contains `"OES_element_index_uint"`.
+`5125` (UNSIGNED_INT) is only allowed when the accessor contains indices and the OES_element_index_uint extension is used, i.e., the accessor is only referenced by [`primitive.indices`](#reference-primitive.indices) and [`glExtensionsUsed`](#reference-glExtensionsUsed) contains `"OES_element_index_uint"`.
 
 * **Type**: `integer`
 * **Required**: Yes
@@ -2022,7 +2022,7 @@ The root object for a glTF asset.
 |**techniques**|`object`|A dictionary object of [`technique`](#reference-technique) objects.|No, default: `{}`|
 |**textures**|`object`|A dictionary object of [`texture`](#reference-texture) objects.|No, default: `{}`|
 |**extensionsUsed**|`string[]`|Names of glTF extensions used somewhere in this asset.|No, default: `[]`|
-|**webglExtensionsUsed**|`string[]`|Names of WebGL extensions required to render this asset.|No, default: `[]`|
+|**glExtensionsUsed**|`string[]`|Names of WebGL extensions required to render this asset.|No, default: `[]`|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
 
@@ -2189,7 +2189,7 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: `object`
 
-### glTF.webglExtensionsUsed
+### glTF.glExtensionsUsed
 
 Names of WebGL extensions required to render this asset.  WebGL extensions must be enabled by calling `getExtension()` for each extension.
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -1132,6 +1132,8 @@ All extensions used in a model are listed in the top-level `extensionsUsed` dict
 ]
 ```
 
+_TODO: add note on how this is different than `webglExtensionsUsed` property._
+
 For more information on glTF extensions, consult the [extensions registry specification](../extensions/README.md).
 
 <a name="properties"></a>
@@ -1226,11 +1228,13 @@ The stride, in bytes, between attributes referenced by this accessor.  When this
 
 ### accessor.componentType :white_check_mark:
 
-The datatype of components in the attribute.  Valid values correspond to WebGL enums: `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), and `5126` (FLOAT).  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, and `Float32Array`, respectively.
+The datatype of components in the attribute.  Valid values correspond to WebGL enums: `5120` (BYTE), `5121` (UNSIGNED_BYTE), `5122` (SHORT), `5123` (UNSIGNED_SHORT), `5125` (UNSIGNED_INT) and `5126` (FLOAT).  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, `Uint32Array`, and `Float32Array`, respectively.
+
+`5125` (UNSIGNED_INT) is only allowed when the accessor contains indices and the OES_element_index_uint extension is used, i.e., the accessor is only referenced by [`primitive.indices`](#reference-primitive.indices) and [`webglExtensionsUsed`](#reference-webglExtensionsUsed) contains `"OES_element_index_uint"`.
 
 * **Type**: `integer`
 * **Required**: Yes
-* **Allowed values**: `5120`, `5121`, `5122`, `5123`, `5126`
+* **Allowed values**: `5120`, `5121`, `5122`, `5123`, `5125`, `5126`
 
 ### accessor.count :white_check_mark:
 
@@ -2017,7 +2021,8 @@ The root object for a glTF asset.
 |**skins**|`object`|A dictionary object of [`skin`](#reference-skin) objects.|No, default: `{}`|
 |**techniques**|`object`|A dictionary object of [`technique`](#reference-technique) objects.|No, default: `{}`|
 |**textures**|`object`|A dictionary object of [`texture`](#reference-texture) objects.|No, default: `{}`|
-|**extensionsUsed**|`string[]`|Names of extensions used somewhere in this asset.|No, default: `[]`|
+|**extensionsUsed**|`string[]`|Names of glTF extensions used somewhere in this asset.|No, default: `[]`|
+|**webglExtensionsUsed**|`string[]`|Names of WebGL extensions required to render this asset.|No, default: `[]`|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
 
@@ -2175,7 +2180,6 @@ Names of extensions used somewhere in this asset.
 * **Type**: `string[]`
    * Each element in the array must be unique.
 * **Required**: No, default: `[]`
-* **Related WebGL functions**: `getSupportedExtensions()` and `getExtension()`
 
 ### glTF.extensions
 
@@ -2184,6 +2188,17 @@ Dictionary object with extension-specific objects.
 * **Type**: `object`
 * **Required**: No
 * **Type of each property**: `object`
+
+### glTF.webglExtensionsUsed
+
+Names of WebGL extensions required to render this asset.  WebGL extensions must be enabled by calling `getExtension()` for each extension.
+
+* **Type**: `string[]`
+   * Each element in the array must be unique.
+* **Required**: No, default: `[]`
+* **Allowed values**: `"OES_element_index_uint"`
+* **Related WebGL functions**: `getSupportedExtensions()` and `getExtension()`
+
 
 ### glTF.extras
 

--- a/specification/schema/accessor.schema.json
+++ b/specification/schema/accessor.schema.json
@@ -30,10 +30,10 @@
         "componentType" : {
             "type" : "integer",
             "description" : "The datatype of components in the attribute.",
-            "enum" : [5120, 5121, 5122, 5123, 5126],
-            "gltf_enumNames" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "FLOAT"],
+            "enum" : [5120, 5121, 5122, 5123, 5125, 5126],
+            "gltf_enumNames" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "UNSIGNED_INT", "FLOAT"],
             "required" : true,
-            "gltf_detailedDescription" : "The datatype of components in the attribute.  All valid values correspond to WebGL enums.  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, and `Float32Array`, respectively."
+            "gltf_detailedDescription" : "The datatype of components in the attribute.  All valid values correspond to WebGL enums.  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, `Uint32Array`, and `Float32Array`, respectively.  5125 (UNSIGNED_INT) is only allowed when the accessor contains indices and the OES_element_index_uint extension is used, i.e., the accessor is only referenced by `primitive.indices` and `webglExtensionsUsed` contains `\"OES_element_index_uint\"`."
         },
         "count" : {
             "type" : "integer",

--- a/specification/schema/accessor.schema.json
+++ b/specification/schema/accessor.schema.json
@@ -33,7 +33,7 @@
             "enum" : [5120, 5121, 5122, 5123, 5125, 5126],
             "gltf_enumNames" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "UNSIGNED_INT", "FLOAT"],
             "required" : true,
-            "gltf_detailedDescription" : "The datatype of components in the attribute.  All valid values correspond to WebGL enums.  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, `Uint32Array`, and `Float32Array`, respectively.  5125 (UNSIGNED_INT) is only allowed when the accessor contains indices and the OES_element_index_uint extension is used, i.e., the accessor is only referenced by `primitive.indices` and `webglExtensionsUsed` contains `\"OES_element_index_uint\"`."
+            "gltf_detailedDescription" : "The datatype of components in the attribute.  All valid values correspond to WebGL enums.  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, `Uint32Array`, and `Float32Array`, respectively.  5125 (UNSIGNED_INT) is only allowed when the accessor contains indices and the OES_element_index_uint extension is used, i.e., the accessor is only referenced by `primitive.indices` and `glExtensionsUsed` contains `\"OES_element_index_uint\"`."
         },
         "count" : {
             "type" : "integer",

--- a/specification/schema/examples/glExtensionsUsed.json
+++ b/specification/schema/examples/glExtensionsUsed.json
@@ -1,5 +1,5 @@
 {
-    "webglExtensionsUsed " : ["OES_element_index_uint"],
+    "glExtensionsUsed " : ["OES_element_index_uint"],
     "accessor_id": {
         "bufferView": "bufferView_id",
         "byteOffset": 0,

--- a/specification/schema/examples/webglExtensionsUsed.json
+++ b/specification/schema/examples/webglExtensionsUsed.json
@@ -1,0 +1,11 @@
+{
+    "webglExtensionsUsed " : ["OES_element_index_uint"],
+    "accessor_id": {
+        "bufferView": "bufferView_id",
+        "byteOffset": 0,
+        "byteStride": 0,
+        "componentType": 5125,
+        "count": 36,
+        "type": "SCALAR"
+    }
+}

--- a/specification/schema/glTF.schema.json
+++ b/specification/schema/glTF.schema.json
@@ -199,7 +199,7 @@
             "default" : {},
             "gltf_detailedDescription" : "A dictionary object of textures.  The name of each texture is an ID in the global glTF namespace that is used to reference the texture."
         },
-        "webglExtensionsUsed" : {
+        "glExtensionsUsed" : {
             "type" : "array",
             "description" : "Names of WebGL extensions required to render this asset.",
             "items" : {

--- a/specification/schema/glTF.schema.json
+++ b/specification/schema/glTF.schema.json
@@ -7,13 +7,12 @@
     "properties" : {
         "extensionsUsed" : {
             "type" : "array",
-            "description" : "Names of extensions used somewhere in this asset.",
+            "description" : "Names of glTF extensions used somewhere in this asset.",
             "items" : {
                 "type" : "string"
             },
             "uniqueItems" : true,
-            "default" : [],
-            "gltf_webgl" : "`getSupportedExtensions()` and `getExtension()`"
+            "default" : []
         },
         "accessors" : {
             "type" : "object",
@@ -199,6 +198,18 @@
             },
             "default" : {},
             "gltf_detailedDescription" : "A dictionary object of textures.  The name of each texture is an ID in the global glTF namespace that is used to reference the texture."
+        },
+        "webglExtensionsUsed" : {
+            "type" : "array",
+            "description" : "Names of WebGL extensions required to render this asset.",
+            "items" : {
+                "type" : "string"
+            },
+            "enum" : ["OES_element_index_uint"],
+            "uniqueItems" : true,
+            "default" : [],
+            "gltf_detailedDescription" : "Names of WebGL extensions required to render this asset.  WebGL extensions must be enabled by calling `getExtension()` for each extension.",
+            "gltf_webgl" : "`getSupportedExtensions()` and `getExtension()`"
         }
     },
     "dependencies" : {


### PR DESCRIPTION
PR into `1.0.1` branch for #570.

Adds `webglExtensionsUsed` property and `5125` (UNSIGNED_INT) `accessor.componentType` value.

For example:
```json
{
    "webglExtensionsUsed " : ["OES_element_index_uint"],
    "accessor_id": {
        "bufferView": "bufferView_id",
        "byteOffset": 0,
        "byteStride": 0,
        "componentType": 5125,
        "count": 36,
        "type": "SCALAR"
    }
}
```