### PR TITLE
Clarification on min/max float precision

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -1256,12 +1256,16 @@ Specifies if the attribute is a scalar, vector, or matrix, and the number of ele
 
 Maximum value of each component in this attribute.  Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be `1`, `2`, `3`, `4`, `9`, or `16`.
 
+When `componentType` is `5126` (FLOAT) each array value must be precise enough, so its binary representation equals to the maximum stored value of a corresponding component.
+
 * **Type**: `number[1-16]`
 * **Required**: Yes
 
 ### accessor.min :white_check_mark:
 
 Minimum value of each component in this attribute.  Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be `1`, `2`, `3`, `4`, `9`, or `16`.
+
+When `componentType` is `5126` (FLOAT) each array value must be precise enough, so its binary representation equals to the minimum stored value of a corresponding component.
 
 * **Type**: `number[1-16]`
 * **Required**: Yes

--- a/specification/README.md
+++ b/specification/README.md
@@ -1256,7 +1256,7 @@ Specifies if the attribute is a scalar, vector, or matrix, and the number of ele
 
 Maximum value of each component in this attribute.  Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be `1`, `2`, `3`, `4`, `9`, or `16`.
 
-When `componentType` is `5126` (FLOAT) each array value must be precise enough, so its binary representation equals to the maximum stored value of a corresponding component.
+When `componentType` is `5126` (FLOAT) each array value must be stored as double-precision JSON number with numerical value which is equal to buffer-stored single-precision value to avoid extra runtime conversions.
 
 * **Type**: `number[1-16]`
 * **Required**: Yes
@@ -1265,7 +1265,7 @@ When `componentType` is `5126` (FLOAT) each array value must be precise enough, 
 
 Minimum value of each component in this attribute.  Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be `1`, `2`, `3`, `4`, `9`, or `16`.
 
-When `componentType` is `5126` (FLOAT) each array value must be precise enough, so its binary representation equals to the minimum stored value of a corresponding component.
+When `componentType` is `5126` (FLOAT) each array value must be stored as double-precision JSON number with numerical value which is equal to buffer-stored single-precision value to avoid extra runtime conversions.
 
 * **Type**: `number[1-16]`
 * **Required**: Yes

--- a/specification/schema/accessor.schema.json
+++ b/specification/schema/accessor.schema.json
@@ -58,7 +58,7 @@
             "minItems" : 1,
             "maxItems" : 16,
             "required" : true,
-            "gltf_detailedDescription" : "Maximum value of each component in this attribute.  Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be 1, 2, 3, 4, 9, or 16."
+            "gltf_detailedDescription" : "Maximum value of each component in this attribute.  Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be 1, 2, 3, 4, 9, or 16.\n\nWhen `componentType` is `5126` (FLOAT) each array value must be stored as double-precision JSON number with numerical value which is equal to buffer-stored single-precision value to avoid extra runtime conversions."
         },
         "min" : {
             "type" : "array",
@@ -69,7 +69,7 @@
             "minItems" : 1,
             "maxItems" : 16,
             "required" : true,
-            "gltf_detailedDescription" : "Minimum value of each component in this attribute.  Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be 1, 2, 3, 4, 9, or 16."
+            "gltf_detailedDescription" : "Minimum value of each component in this attribute.  Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be 1, 2, 3, 4, 9, or 16.\n\nWhen `componentType` is `5126` (FLOAT) each array value must be stored as double-precision JSON number with numerical value which is equal to buffer-stored single-precision value to avoid extra runtime conversions."
         }
     },
     "additionalProperties" : false


### PR DESCRIPTION
I've put it in accessor's definitions, because it's the only case of direct comparison between buffer-stored and json-stored floats.