### PR TITLE
Check for unbound textures

### DIFF
--- a/COLLADA2GLTF/GLTF/GLTFAsset.cpp
+++ b/COLLADA2GLTF/GLTF/GLTFAsset.cpp
@@ -984,25 +984,26 @@ namespace GLTF
                     shared_ptr <GLTF::GLTFEffect> material = static_pointer_cast<GLTF::GLTFEffect>(materials->getObject(materialId));
                     shared_ptr <JSONObject> technique = material->getTechniqueGenerator();
                     shared_ptr <JSONObject> texcoordBindings = technique->getObject("texcoordBindings");
-
-                    for (unsigned int k = 0; k < primitive->getVertexAttributes().size(); k++) {
-                        shared_ptr <JSONVertexAttribute> vertexAttribute = static_pointer_cast<JSONVertexAttribute>(primitive->getVertexAttributes()[k]);
-                        if (vertexAttribute->getSemantic() == GLTF::TEXCOORD) {
-                            std::string attribute = "TEXCOORD_" + std::to_string(vertexAttribute->getIndexOfSet());
-                            bool bound = false;
-                            for (unsigned int m = 0; m < texcoordBindings->getKeysCount(); m++) {
-                                std::string key = texcoordBindings->getAllKeys()[m];
-                                std::string binding = texcoordBindings->getString(key);
-
-                                if (attribute == binding) {
-                                    bound = true;
-                                    break;
+                    SemanticArrayPtr unboundTextures = material->getSemanticsForTexcoordName("");
+                    // If there are unbound textures in the model, it is impossible to determine which TEXCOORD semantics are unused
+                    if (unboundTextures == NULL || unboundTextures->size() == 0) {
+                        for (unsigned int k = 0; k < primitive->getVertexAttributes().size(); k++) {
+                            shared_ptr <JSONVertexAttribute> vertexAttribute = static_pointer_cast<JSONVertexAttribute>(primitive->getVertexAttributes()[k]);
+                            if (vertexAttribute->getSemantic() == GLTF::TEXCOORD) {
+                                std::string attribute = "TEXCOORD_" + std::to_string(vertexAttribute->getIndexOfSet());
+                                bool bound = false;
+                                for (unsigned int m = 0; m < texcoordBindings->getKeysCount(); m++) {
+                                    std::string key = texcoordBindings->getAllKeys()[m];
+                                    std::string binding = texcoordBindings->getString(key);
+                                    if (attribute == binding) {
+                                        bound = true;
+                                        break;
+                                    }
                                 }
-                            }
-
-                            if (!bound) {
-                                primitive->removeVertexAttribute(k);
-                                k--;
+                                if (!bound) {
+                                    primitive->removeVertexAttribute(k);
+                                    k--;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #635. CesiumMan converts correctly after this change and CesiumMilkTruck still has its unused TEXCOORD fields removed.

If you look at the collada between these two models the issue is that in CesiumMilkTruck, the texture is bound to a texture coordinate set:

```xml
<diffuse>
    <texture texture="Image0001-sampler" texcoord="Texture" />
</diffuse>
```
while in CesiumMan, it is not:

```xml
<diffuse>
    <texture texture="Cesium_Man_jpg-sampler"/>
 </diffuse>
```

The TEXCOORD removal optimization now jumps ship if a texture is unbound since there's no way to tell what is used and what isn't.