### PR TITLE
Fill in missing includes #656

### DIFF
--- a/COLLADA2GLTF/JSON/JSONNumber.cpp
+++ b/COLLADA2GLTF/JSON/JSONNumber.cpp
@@ -25,6 +25,7 @@
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "GLTF.h"
+#include <cstring>
 
 #if __cplusplus <= 199711L
 using namespace std::tr1;

--- a/COLLADA2GLTF/helpers/geometryHelpers.cpp
+++ b/COLLADA2GLTF/helpers/geometryHelpers.cpp
@@ -24,6 +24,7 @@
 #include "GLTF.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <cstring>
 #include "geometryHelpers.h"
 
 #if __cplusplus <= 199711L


### PR DESCRIPTION
This solves the build issue on Linux (I had it on latest Arch, @timknip on Ubuntu)