### PR TITLE
Fixed CG_profile effect. Default material applied in this case

### DIFF
--- a/COLLADA2GLTF/GLTF/GLTFAsset.h
+++ b/COLLADA2GLTF/GLTF/GLTFAsset.h
@@ -143,6 +143,8 @@ namespace GLTF
             std::shared_ptr <MaterialBindingsPrimitiveMap> materialBindingPrimitiveMap,
             std::shared_ptr <JSONArray> meshesArray,
             std::shared_ptr<JSONObject> meshExtras);
+		void _applyDefaultMaterial(std::shared_ptr<GLTFMesh>& mesh, std::shared_ptr <GLTF::GLTFPrimitive>& primitive, std::shared_ptr<JSONObject>& materials, int j);
+
         void _writeJSONResource(const std::string &resourcePath, std::shared_ptr<JSONObject> obj);
     public:
         MaterialUIDToEffectUID          _materialUIDToEffectUID;


### PR DESCRIPTION
openCOLLADA, which is the core library used by glTF converter, does not seem capable to load the profile_CG data from the COLLADA file, which in turns makes it very difficult for the glTF converter to not behave correctly. 

To have the gltf converter not to crash, this fix will create a defaultMaterial in this case. 
