### PR TITLE
Fixed compile issue when linking into another exe

### DIFF
--- a/COLLADA2GLTF/GLTF/GLTF.h
+++ b/COLLADA2GLTF/GLTF/GLTF.h
@@ -41,6 +41,7 @@
 #include "assert.h"
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 #if (defined(WIN32) || defined(_LIBCPP_VERSION) || __cplusplus > 199711L)
 #include <memory>


### PR DESCRIPTION
I get a few compile errors about missing `memcpy` and `memcmp`.