### PR TITLE
Fixed ordering of blendFuncSeparate

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -3166,7 +3166,7 @@ Integer values passed to `blendEquationSeparate()`. [rgb, alpha]. Valid values c
 
 ### functions.blendFuncSeparate
 
-Integer values passed to `blendFuncSeparate()`. [srcRGB, srcAlpha, dstRGB, dstAlpha]. Valid values correspond to WebGL enums: `0` (ZERO), `1` (ONE), `768` (SRC_COLOR), `769` (ONE_MINUS_SRC_COLOR), `774` (DST_COLOR), `775` (ONE_MINUS_DST_COLOR), `770` (SRC_ALPHA), `771` (ONE_MINUS_SRC_ALPHA), `772` (DST_ALPHA), `773` (ONE_MINUS_DST_ALPHA), `32769` (CONSTANT_COLOR), `32770` (ONE_MINUS_CONSTANT_COLOR), `32771` (CONSTANT_ALPHA), `32772` (ONE_MINUS_CONSTANT_ALPHA), and `776` (SRC_ALPHA_SATURATE).
+Integer values passed to `blendFuncSeparate()`. [srcRGB, dstRGB, srcAlpha, dstAlpha]. Valid values correspond to WebGL enums: `0` (ZERO), `1` (ONE), `768` (SRC_COLOR), `769` (ONE_MINUS_SRC_COLOR), `774` (DST_COLOR), `775` (ONE_MINUS_DST_COLOR), `770` (SRC_ALPHA), `771` (ONE_MINUS_SRC_ALPHA), `772` (DST_ALPHA), `773` (ONE_MINUS_DST_ALPHA), `32769` (CONSTANT_COLOR), `32770` (ONE_MINUS_CONSTANT_COLOR), `32771` (CONSTANT_ALPHA), `32772` (ONE_MINUS_CONSTANT_ALPHA), and `776` (SRC_ALPHA_SATURATE).
 
 * **Type**: `integer[4]`
    * Each element in the array must be one of the following values: `0`, `1`, `768`, `769`, `774`, `775`, `770`, `771`, `772`, `773`, `32769`, `32770`, `32771`, `32772`, `776`.

--- a/specification/schema/examples/techniques.json
+++ b/specification/schema/examples/techniques.json
@@ -91,7 +91,7 @@
                 "functions" : {
                     "blendColor": [0.0, 0.0, 0.0, 0.0],
                     "blendEquationSeparate" : [32774, 32774],
-                    "blendFuncSeparate" : [1, 1, 0, 0],
+                    "blendFuncSeparate" : [1, 0, 1, 0],
                     "colorMask" : [true, true, true, true],
                     "cullFace" : [1029],
                     "depthFunc" : [513],

--- a/specification/schema/technique.states.functions.schema.json
+++ b/specification/schema/technique.states.functions.schema.json
@@ -40,8 +40,8 @@
             },
             "minItems" : 4,
             "maxItems" : 4,
-            "default" : [1, 1, 0, 0],
-            "gltf_detailedDescription" : "Integer values passed to `blendFuncSeparate()`. [srcRGB, srcAlpha, dstRGB, dstAlpha]. All valid values correspond to WebGL enums.",
+            "default" : [1, 0, 1, 0],
+            "gltf_detailedDescription" : "Integer values passed to `blendFuncSeparate()`. [srcRGB, dstRGB, srcAlpha, dstAlpha]. All valid values correspond to WebGL enums.",
             "gltf_webgl" : "`blendFuncSeparate()`"
         },
         "colorMask" : {


### PR DESCRIPTION
The ordering was incorrect in this area. Uncovered through this post on the Cesium forum: https://groups.google.com/forum/#!msg/cesium-dev/BP_fs8K19ww/n2SBwzEsBAAJ