### PR TITLE
Fixed issue when FIFO PopFirst call resurns incorrect value; it was h…

### DIFF
--- a/COLLADA2GLTF/dependencies/o3dgc/src/o3dgc_common_lib/inc/o3dgcFIFO.h
+++ b/COLLADA2GLTF/dependencies/o3dgc/src/o3dgc_common_lib/inc/o3dgcFIFO.h
@@ -66,7 +66,7 @@ namespace o3dgc
                                     unsigned long current = m_start++;
                                     if (m_start == m_allocated) 
                                     {
-                                        m_end = 0;
+                                        m_start = 0;
                                     }
                                     return m_buffer[current];
                                 };


### PR DESCRIPTION
…appening when number of PopFirst call exceeds allocated FIFO size.

I'm not sure that it's right repo for PR but I hope to get some help here.

I tried to convert my 3d models with `collada2gltf -f model.dae -o compressed -k -c Open3DGC -m binary` . And faced with problem when compression for some models caused errors like this:

`collada2gltf: /home/vagrant/dev/glTF/COLLADA2GLTF/dependencies/o3dgc/src/o3dgc_common_lib/inc/o3dgcAdjacencyInfo.h:123: long int o3dgc::AdjacencyInfo::Begin(long int) const: Assertion 'element < m_numElements' failed.`

I figured out the reasons of that error and fix it (see 3f58ffc) after that I checked my models but there was second error: `Segmentation fault`.

After some time of my research I found the main reason of error it was `const long O3DGC_MAX_TFAN_SIZE = 256;` limitation see code: [link#1](https://github.com/KhronosGroup/glTF/blob/master/COLLADA2GLTF/dependencies/o3dgc/src/o3dgc_common_lib/inc/o3dgcCommon.h#L44) and [link#2](https://github.com/KhronosGroup/glTF/blob/master/COLLADA2GLTF/dependencies/o3dgc/src/o3dgc_encode_lib/inc/o3dgcTriangleListEncoder.inl#L575-L576). But `TFAN` size for my models could reach 4k.

So my question is whtat is thre right way to fix it? I suppose to compute `O3DGC_MAX_TFAN_SIZE` value for particular case.

Thanks for attention. 
