### PR TITLE
glTF schema v4 upgrade and inheritance issue fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Diagram by [Marco Hutter](http://marco-hutter.de/) ([repo](https://github.com/ja
 
 #### WebGL Engines
 
-* [glTF loader](https://github.com/mrdoob/three.js/tree/master/examples/js/loaders/gltf) in [Three.js](http://threejs.org/)
+* [glTF loader](https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/GLTFLoader.js) in [Three.js](https://threejs.org/)
 * [glTF loader](https://github.com/BabylonJS/Babylon.js/tree/master/loaders/glTF) in [BabylonJS](http://babylonjs.com/)
 * [glTF loader](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/Model.js) in [Cesium](http://cesiumjs.org/)
    * The [COLLADA to glTF](http://cesiumjs.org/convertmodel.html) converter also supports drag-and-drop viewing of glTF assets

--- a/README.md
+++ b/README.md
@@ -110,12 +110,13 @@ Diagram by [Marco Hutter](http://marco-hutter.de/) ([repo](https://github.com/ja
 
 ## Presentations and Articles
 
-* [glTF: The Runtime Asset Format for GL-based Applications](https://www.khronos.org/assets/uploads/developers/library/2016-siggraph/glTF-Background-Briefing_Jul16.pdf). July 2016
+* [glTF Brief](https://docs.google.com/presentation/d/1BRdEGqJFIWk3QOehOxJqM9dIE4kIBNQhIm7UeBaVse0/edit#slide=id.g185e245559_2_28) by Tony Parisi, FormVR and Amanda Watson, Oculus. October 2016
 * [Bringing 3D to everyone through open standards](https://blogs.windows.com/buildingapps/2016/10/28/bringing-3d-to-everyone-through-open-standards/) by Forest W. Gouin and Jean Paoli. October 2016
 * [Using Quantization with 3D Models](http://cesiumjs.org/2016/08/08/Cesium-web3d-quantized-attributes/) by Rob Taglang. August 2016
 * [glTF and Mobile VR: Inclusive standards for a 3D world](https://www.khronos.org/assets/uploads/developers/library/2016-siggraph/glTF-MobileVR-Oculus-BOF-Update-SIGGRAPH_Jul16.pdf). Amanda Watson, Oculus, WebGL + glTF BOF. July 2016
 * [glTF Update and Roadmap](https://www.khronos.org/assets/uploads/developers/library/2016-siggraph/glTF-BOF-Update-SIGGRAPH_Jul16.pdf). Tony Parisi, WebGL + glTF BOF. July 2016
 * [PBR in glTF: Current State](https://www.khronos.org/webgl/wiki_1_15/images/2016-07-28_WebGL_BOF_PBR.pdf). Max Limper, Johannes Behr, and Timo Sturm, WebGL + glTF BOF. July 2016
+* [glTF: The Runtime Asset Format for GL-based Applications](https://www.khronos.org/assets/uploads/developers/library/2016-siggraph/glTF-Background-Briefing_Jul16.pdf). July 2016
 * [glTF working group updates](https://www.khronos.org/assets/uploads/developers/library/2016-gdc/glTF-GDC_Mar16.pdf) ([slides](https://www.khronos.org/assets/uploads/developers/library/2016-gdc/glTF-GDC_Mar16.pdf), [video](https://www.youtube.com/watch?v=qAjWiVfR5Nw&t=43m40s)). Patrick Cozzi and Tony Parisi, WebGL + glTF BOF. March 2016
 * [FBX to/from glTF](https://www.khronos.org/assets/uploads/developers/library/2016-gdc/Autodesk-FBX-glTF-WebGL_Mar16.pdf) ([slides](https://www.khronos.org/assets/uploads/developers/library/2016-gdc/Autodesk-FBX-glTF-WebGL_Mar16.pdf), [video](https://www.youtube.com/watch?v=qAjWiVfR5Nw&t=59m08s)). Cyrille Fauvel, WebGL + glTF BOF. March 2016
 * [Khronos Group glTF Webinar](https://www.youtube.com/watch?v=YXPeh2hy6Tc). Neil Trevett, Virtual AR Community meeting. October 2015

--- a/extensions/Khronos/KHR_binary_glTF/schema/image.KHR_binary_glTF.schema.json
+++ b/extensions/Khronos/KHR_binary_glTF/schema/image.KHR_binary_glTF.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "KHR_binary_glTF image extension",
     "type" : "object",
     "properties" : {

--- a/extensions/Khronos/KHR_binary_glTF/schema/image.KHR_binary_glTF.schema.json
+++ b/extensions/Khronos/KHR_binary_glTF/schema/image.KHR_binary_glTF.schema.json
@@ -6,27 +6,24 @@
         "bufferView" : {
             "type" : "string",
             "description" : "The id (JSON property name) of the buffer-view that references the image. Use this instead of the image's uri property.",
-            "minLength" : 1,
-            "required" : true
+            "minLength" : 1
         },
         "mimeType" : {
             "type" : "string",
             "description" : "The image's MIME type.",
-            "minLength" : 1,
-            "required" : true
+            "minLength" : 1
         },
         "width" : {
             "type" : "integer",
             "description" : "The width of the image in pixels.",
-            "minimum" : 0,
-            "required" : true
+            "minimum" : 0
         },
         "height" : {
             "type" : "integer",
             "description" : "The height of the image in pixels.",
-            "minimum" : 0,
-            "required" : true
+            "minimum" : 0
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required" : ["bufferView", "mimeType", "width", "height"]
 }

--- a/extensions/Khronos/KHR_binary_glTF/schema/shader.KHR_binary_glTF.schema.json
+++ b/extensions/Khronos/KHR_binary_glTF/schema/shader.KHR_binary_glTF.schema.json
@@ -6,9 +6,9 @@
         "bufferView" : {
             "type" : "string",
             "description" : "The id (JSON property name) of the buffer-view that references the shader source. Use this instead of the shader's uri property.",
-            "minLength" : 1,
-            "required" : true
+            "minLength" : 1
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required" : ["bufferView"]
 }

--- a/extensions/Khronos/KHR_binary_glTF/schema/shader.KHR_binary_glTF.schema.json
+++ b/extensions/Khronos/KHR_binary_glTF/schema/shader.KHR_binary_glTF.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "KHR_binary_glTF shader extension",
     "type" : "object",
     "properties" : {

--- a/extensions/Khronos/KHR_materials_common/schema/glTF.KHR_materials_common.schema.json
+++ b/extensions/Khronos/KHR_materials_common/schema/glTF.KHR_materials_common.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "KHR_materials_common glTF extension",
     "type" : "object",
     "properties" : {

--- a/extensions/Khronos/KHR_materials_common/schema/light.ambient.schema.json
+++ b/extensions/Khronos/KHR_materials_common/schema/light.ambient.schema.json
@@ -1,8 +1,8 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "light/ambient",
     "type" : "object",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "color" : {
             "type" : "array",

--- a/extensions/Khronos/KHR_materials_common/schema/light.directional.schema.json
+++ b/extensions/Khronos/KHR_materials_common/schema/light.directional.schema.json
@@ -1,8 +1,8 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "light/directional",
     "type" : "object",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "color" : {
             "type" : "array",

--- a/extensions/Khronos/KHR_materials_common/schema/light.point.schema.json
+++ b/extensions/Khronos/KHR_materials_common/schema/light.point.schema.json
@@ -1,8 +1,8 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "light/point",
     "type" : "object",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "color" : {
             "type" : "array",

--- a/extensions/Khronos/KHR_materials_common/schema/light.schema.json
+++ b/extensions/Khronos/KHR_materials_common/schema/light.schema.json
@@ -24,9 +24,9 @@
         "type" : {
             "type" : "string",
             "description" : "Specifies the light type.",
-            "enum" : ["ambient", "directional", "point", "spot"],
-            "required" : true
+            "enum" : ["ambient", "directional", "point", "spot"]
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required" : ["type"]
 }

--- a/extensions/Khronos/KHR_materials_common/schema/light.schema.json
+++ b/extensions/Khronos/KHR_materials_common/schema/light.schema.json
@@ -1,24 +1,24 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "light",
     "type" : "object",
     "description" : "An ambient, directional, point, or spot light.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "ambient" : {
-            "extends" : { "$ref" : "light.ambient.schema.json" },
+            "allOf" : [ { "$ref" : "light.ambient.schema.json" } ],
             "description" : "Ambient light source."
         },
         "directional" : {
-            "extends" : { "$ref" : "light.directional.schema.json" },
+            "allOf" : [ { "$ref" : "light.directional.schema.json" } ],
             "description" : "Directional light source."
         },
         "point" : {
-            "extends" : { "$ref" : "light.point.schema.json" },
+            "allOf" : [ { "$ref" : "light.point.schema.json" } ],
             "description" : "Point light source."
         },
         "spot" : {
-            "extends" : { "$ref" : "light.spot.schema.json" },
+            "allOf" : [ { "$ref" : "light.spot.schema.json" } ],
             "description" : "Spot light source."
         },
         "type" : {

--- a/extensions/Khronos/KHR_materials_common/schema/light.spot.schema.json
+++ b/extensions/Khronos/KHR_materials_common/schema/light.spot.schema.json
@@ -1,8 +1,8 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "light/spot",
     "type" : "object",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "color" : {
             "type" : "array",

--- a/extensions/Khronos/KHR_materials_common/schema/node.KHR_materials_common.schema.json
+++ b/extensions/Khronos/KHR_materials_common/schema/node.KHR_materials_common.schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "KHR_materials_common node extension",
     "type" : "object",
     "properties" : {
         "light" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The id of the light referenced by this node."
         }
     },

--- a/extensions/Vendor/CESIUM_RTC/CESIUM_RTC.schema.json
+++ b/extensions/Vendor/CESIUM_RTC/CESIUM_RTC.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "CESIUM_RTC",
     "type" : "object",
     "description" : "glTF CESIUM_RTC extension.",

--- a/extensions/Vendor/CESIUM_RTC/CESIUM_RTC.schema.json
+++ b/extensions/Vendor/CESIUM_RTC/CESIUM_RTC.schema.json
@@ -11,9 +11,9 @@
                 "type" : "number"
             },
             "minItems" : 3,
-            "maxItems" : 3,
-            "required" : true
+            "maxItems" : 3
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required" : ["center"]
 }

--- a/extensions/Vendor/WEB3D_quantized_attributes/schema/WEB3D_quantized_attributes.accessor.schema.json
+++ b/extensions/Vendor/WEB3D_quantized_attributes/schema/WEB3D_quantized_attributes.accessor.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "WEB3D_quantized_attributes accessor extension",
     "type" : "object",
     "properties" : {

--- a/extensions/Vendor/WEB3D_quantized_attributes/schema/WEB3D_quantized_attributes.accessor.schema.json
+++ b/extensions/Vendor/WEB3D_quantized_attributes/schema/WEB3D_quantized_attributes.accessor.schema.json
@@ -10,8 +10,7 @@
                 "type": "number"
             },
             "minItems" : 4,
-            "maxItems" : 25,
-            "required" : true
+            "maxItems" : 25
         },
         "decodedMax" : {
             "type" : "array",
@@ -20,8 +19,7 @@
                 "type" : "number"
             },
             "minItems" : 1,
-            "maxItems" : 4,
-            "required" : true
+            "maxItems" : 4
         },
         "decodedMin" : {
             "type" : "array",
@@ -30,9 +28,9 @@
                 "type" : "number"
             },
             "minItems" : 1,
-            "maxItems" : 4,
-            "required" : true
+            "maxItems" : 4
         }    
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required" : ["decodeMatrix", "decodedMax", "decodedMin"]
 }

--- a/specification/schema/accessor.schema.json
+++ b/specification/schema/accessor.schema.json
@@ -1,15 +1,15 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "accessor",
     "type" : "object",
     "description" : "A typed view into a bufferView.  A bufferView contains raw binary data.  An accessor provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name" : {},
         "extensions" : {},
         "extras" : {},
         "bufferView" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the bufferView.",
             "required" : true
         },

--- a/specification/schema/accessor.schema.json
+++ b/specification/schema/accessor.schema.json
@@ -5,6 +5,9 @@
     "description" : "A typed view into a bufferView.  A bufferView contains raw binary data.  An accessor provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "bufferView" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
             "description" : "The ID of the bufferView.",

--- a/specification/schema/accessor.schema.json
+++ b/specification/schema/accessor.schema.json
@@ -10,14 +10,12 @@
         "extras" : {},
         "bufferView" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
-            "description" : "The ID of the bufferView.",
-            "required" : true
+            "description" : "The ID of the bufferView."
         },
         "byteOffset" : {
             "type" : "integer",
             "description" : "The offset relative to the start of the bufferView in bytes.",
             "minimum" : 0,
-            "required" : true,
             "gltf_detailedDescription" : "The offset relative to the start of the bufferView in bytes.  This must be a multiple of the size of the data type.",
             "gltf_webgl" : "`vertexAttribPointer()` offset parameter"
         },
@@ -35,21 +33,18 @@
             "description" : "The datatype of components in the attribute.",
             "enum" : [5120, 5121, 5122, 5123, 5126],
             "gltf_enumNames" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "FLOAT"],
-            "required" : true,
             "gltf_detailedDescription" : "The datatype of components in the attribute.  All valid values correspond to WebGL enums.  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, and `Float32Array`, respectively."
         },
         "count" : {
             "type" : "integer",
             "description" : "The number of attributes referenced by this accessor.",
             "minimum" : 1,
-            "required" : true,
             "gltf_detailedDescription" : "The number of attributes referenced by this accessor, not to be confused with the number of bytes or number of components."
         },
         "type" : {
             "type" : "string",
             "description" : "Specifies if the attribute is a scalar, vector, or matrix.",
             "enum" : ["SCALAR", "VEC2", "VEC3", "VEC4", "MAT2", "MAT3", "MAT4"],
-            "required" : true,
             "gltf_detailedDescription" : "Specifies if the attribute is a scalar, vector, or matrix, and the number of elements in the vector or matrix."
         },        
         "max" : {
@@ -73,5 +68,6 @@
             "gltf_detailedDescription" : "Minimum value of each component in this attribute.  When both min and max arrays are defined, they have the same length.  The length is determined by the value of the type property; it can be 1, 2, 3, 4, 9, or 16."
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required": ["bufferView", "byteOffset", "componentType", "count", "type"]
 }

--- a/specification/schema/animation.channel.schema.json
+++ b/specification/schema/animation.channel.schema.json
@@ -10,14 +10,13 @@
         "sampler" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of a sampler in this animation used to compute the value for the target.",
-            "required" : true,
             "gltf_detailedDescription" : "The ID of a sampler in this animation used to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS)."
         },
         "target" : {
             "allOf" : [ { "$ref" : "animation.channel.target.schema.json" } ],
-            "description" : "The ID of the node and TRS property to target.",
-            "required" : true
+            "description" : "The ID of the node and TRS property to target."
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required": ["sampler", "target"]
 }

--- a/specification/schema/animation.channel.schema.json
+++ b/specification/schema/animation.channel.schema.json
@@ -1,20 +1,20 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "channel",
     "type" : "object",
     "description" : "Targets an animation's sampler at a node's property.",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},
         "sampler" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of a sampler in this animation used to compute the value for the target.",
             "required" : true,
             "gltf_detailedDescription" : "The ID of a sampler in this animation used to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS)."
         },
         "target" : {
-            "extends" : { "$ref" : "animation.channel.target.schema.json" },
+            "allOf" : [ { "$ref" : "animation.channel.target.schema.json" } ],
             "description" : "The ID of the node and TRS property to target.",
             "required" : true
         }

--- a/specification/schema/animation.channel.schema.json
+++ b/specification/schema/animation.channel.schema.json
@@ -5,6 +5,8 @@
     "description" : "Targets an animation's sampler at a node's property.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "sampler" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
             "description" : "The ID of a sampler in this animation used to compute the value for the target.",

--- a/specification/schema/animation.channel.target.schema.json
+++ b/specification/schema/animation.channel.target.schema.json
@@ -1,14 +1,14 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "target",
     "type" : "object",
     "description" : "The ID of the node and TRS property that an animation channel targets.",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},
         "id" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the node to target.",
             "required" : true
         },

--- a/specification/schema/animation.channel.target.schema.json
+++ b/specification/schema/animation.channel.target.schema.json
@@ -5,6 +5,8 @@
     "description" : "The ID of the node and TRS property that an animation channel targets.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "id" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
             "description" : "The ID of the node to target.",

--- a/specification/schema/animation.channel.target.schema.json
+++ b/specification/schema/animation.channel.target.schema.json
@@ -9,15 +9,14 @@
         "extras" : {},
         "id" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
-            "description" : "The ID of the node to target.",
-            "required" : true
+            "description" : "The ID of the node to target."
         },
         "path" : {
             "type" : "string",
             "description" : "The name of the node's TRS property to modify.",
-            "enum" : ["translation", "rotation", "scale"],
-            "required" : true
+            "enum" : ["translation", "rotation", "scale"]
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required": ["id", "path"]
 }

--- a/specification/schema/animation.parameter.schema.json
+++ b/specification/schema/animation.parameter.schema.json
@@ -1,7 +1,7 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "parameter",
-    "extends" : { "$ref" : "glTFid.schema.json" },
+    "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
     "description" : "The ID of the accessor containing keyframes for this parameter.",
     "additionalProperties" : false
 }

--- a/specification/schema/animation.sampler.schema.json
+++ b/specification/schema/animation.sampler.schema.json
@@ -5,6 +5,8 @@
     "description" : "Combines input and output parameters with an interpolation algorithm to define a keyframe graph (but not its target).",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "input" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
             "description" : "The ID of a parameter in this animation to use as keyframe input, e.g., time.",

--- a/specification/schema/animation.sampler.schema.json
+++ b/specification/schema/animation.sampler.schema.json
@@ -10,7 +10,6 @@
         "input" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of a parameter in this animation to use as keyframe input, e.g., time.",
-            "required" : true,
             "gltf_detailedDescription" : "The ID of a parameter in this animation to use as keyframe input.  This parameter must have type `FLOAT`.  The values represent time in seconds with `time[0] >= 0.0`, and monotonically increasing values, i.e., `time[n + 1] >= time[n]`."
         },
         "interpolation" : {
@@ -22,9 +21,9 @@
         },
         "output" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
-            "description" : "The ID of a parameter in this animation to use as keyframe output.",
-            "required" : true
+            "description" : "The ID of a parameter in this animation to use as keyframe output."
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required": ["input", "output"]
 }

--- a/specification/schema/animation.sampler.schema.json
+++ b/specification/schema/animation.sampler.schema.json
@@ -1,14 +1,14 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "animation sampler",
     "type" : "object",
     "description" : "Combines input and output parameters with an interpolation algorithm to define a keyframe graph (but not its target).",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},
         "input" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of a parameter in this animation to use as keyframe input, e.g., time.",
             "required" : true,
             "gltf_detailedDescription" : "The ID of a parameter in this animation to use as keyframe input.  This parameter must have type `FLOAT`.  The values represent time in seconds with `time[0] >= 0.0`, and monotonically increasing values, i.e., `time[n + 1] >= time[n]`."
@@ -21,7 +21,7 @@
             "gltf_detailedDescription" : "Interpolation algorithm.  When an animation targets a node's rotation, and the animation's interpolation is `\"LINEAR\"`, spherical linear interpolation (slerp) should be used to interpolate quaternions."
         },
         "output" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of a parameter in this animation to use as keyframe output.",
             "required" : true
         }

--- a/specification/schema/animation.schema.json
+++ b/specification/schema/animation.schema.json
@@ -5,6 +5,9 @@
     "description" : "A keyframe animation.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name": {},
+        "extensions" : {},
+        "extras" : {},
         "channels" : {
             "type" : "array",
             "description" : "An array of channels, each of which targets an animation's sampler at a node's property.",

--- a/specification/schema/animation.schema.json
+++ b/specification/schema/animation.schema.json
@@ -38,8 +38,8 @@
         }
     },
     "dependencies" : {
-        "channels" : "samplers",
-        "samplers" : "parameters"
+        "channels" : ["samplers"],
+        "samplers" : ["parameters"]
     },
     "additionalProperties" : false
 }

--- a/specification/schema/animation.schema.json
+++ b/specification/schema/animation.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "animation",
     "type" : "object",
     "description" : "A keyframe animation.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name": {},
         "extensions" : {},

--- a/specification/schema/arrayValues.schema.json
+++ b/specification/schema/arrayValues.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "type" : "array",
     "items" : {
         "type" : ["number", "boolean", "string"]

--- a/specification/schema/asset.profile.schema.json
+++ b/specification/schema/asset.profile.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "profile",
     "type" : "object",
     "description" : "Specifies the target rendering API and version, e.g., WebGL 1.0.3.",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},

--- a/specification/schema/asset.profile.schema.json
+++ b/specification/schema/asset.profile.schema.json
@@ -5,6 +5,8 @@
     "description" : "Specifies the target rendering API and version, e.g., WebGL 1.0.3.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "api" : {
             "type" : "string",
             "description" : "Specifies the target rendering API.",

--- a/specification/schema/asset.schema.json
+++ b/specification/schema/asset.schema.json
@@ -5,6 +5,8 @@
     "description" : "Metadata about the glTF asset.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "copyright" : {
             "type" : "string",
             "description" : "A copyright message suitable for display to credit the content creator."

--- a/specification/schema/asset.schema.json
+++ b/specification/schema/asset.schema.json
@@ -27,9 +27,9 @@
         },
         "version" : {
             "type" : "string",
-            "description" : "The glTF version.",
-            "required" : true
+            "description" : "The glTF version."
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required": ["version"]
 }

--- a/specification/schema/asset.schema.json
+++ b/specification/schema/asset.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "asset",
     "type" : "object",
     "description" : "Metadata about the glTF asset.",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},

--- a/specification/schema/buffer.schema.json
+++ b/specification/schema/buffer.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "buffer",
     "type" : "object",
     "description" : "A buffer points to binary geometry, animation, or skins.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name" : {},
         "extensions" : {},

--- a/specification/schema/buffer.schema.json
+++ b/specification/schema/buffer.schema.json
@@ -12,7 +12,6 @@
             "type" : "string",
             "description" : "The uri of the buffer.",
             "format" : "uri",
-            "required" : true,
             "gltf_detailedDescription" : "The uri of the buffer.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.",
             "gltf_uriType" : "application"
         },
@@ -29,5 +28,6 @@
             "default" : "arraybuffer"
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required": ["uri"]
 }

--- a/specification/schema/buffer.schema.json
+++ b/specification/schema/buffer.schema.json
@@ -5,6 +5,9 @@
     "description" : "A buffer points to binary geometry, animation, or skins.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "uri" : {
             "type" : "string",
             "description" : "The uri of the buffer.",

--- a/specification/schema/bufferView.schema.json
+++ b/specification/schema/bufferView.schema.json
@@ -10,14 +10,12 @@
         "extras" : {},
         "buffer" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
-            "description" : "The ID of the buffer.",
-            "required" : true
+            "description" : "The ID of the buffer."
         },
         "byteOffset" : {
             "type" : "integer",
             "description" : "The offset into the buffer in bytes.",
-            "minimum" : 0,
-            "required" : true
+            "minimum" : 0
         },
         "byteLength" : {
             "type" : "integer",
@@ -34,5 +32,6 @@
             "gltf_webgl" : "`bindBuffer()`"
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required": ["buffer", "byteOffset"]
 }

--- a/specification/schema/bufferView.schema.json
+++ b/specification/schema/bufferView.schema.json
@@ -1,15 +1,15 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "bufferView",
     "type" : "object",
     "description" : "A view into a buffer generally representing a subset of the buffer.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name" : {},
         "extensions" : {},
         "extras" : {},
         "buffer" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the buffer.",
             "required" : true
         },

--- a/specification/schema/bufferView.schema.json
+++ b/specification/schema/bufferView.schema.json
@@ -5,6 +5,9 @@
     "description" : "A view into a buffer generally representing a subset of the buffer.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "buffer" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
             "description" : "The ID of the buffer.",

--- a/specification/schema/camera.orthographic.schema.json
+++ b/specification/schema/camera.orthographic.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "orthographic",
     "type" : "object",
     "description" : "An orthographic camera containing properties to create an orthographic projection matrix.",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},

--- a/specification/schema/camera.orthographic.schema.json
+++ b/specification/schema/camera.orthographic.schema.json
@@ -9,26 +9,23 @@
         "extras" : {},
         "xmag" : {
             "type" : "number",
-            "description" : "The floating-point horizontal magnification of the view.",
-            "required" : true
+            "description" : "The floating-point horizontal magnification of the view."
         },
         "ymag" : {
             "type" : "number",
-            "description" : "The floating-point vertical magnification of the view.",
-            "required" : true
+            "description" : "The floating-point vertical magnification of the view."
         },
         "zfar" : {
             "type" : "number",
             "description" : "The floating-point distance to the far clipping plane.",
-            "required" : true,
             "minimum" : 0.0
         },
         "znear" : {
             "type" : "number",
             "description" : "The floating-point distance to the near clipping plane.",
-            "required" : true,
             "minimum" : 0.0
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required": ["xmag", "ymag", "zfar", "znear"]
 }

--- a/specification/schema/camera.orthographic.schema.json
+++ b/specification/schema/camera.orthographic.schema.json
@@ -5,6 +5,8 @@
     "description" : "An orthographic camera containing properties to create an orthographic projection matrix.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "xmag" : {
             "type" : "number",
             "description" : "The floating-point horizontal magnification of the view.",

--- a/specification/schema/camera.perspective.schema.json
+++ b/specification/schema/camera.perspective.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "perspective",
     "type" : "object",
     "description" : "A perspective camera containing properties to create a perspective projection matrix.",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},

--- a/specification/schema/camera.perspective.schema.json
+++ b/specification/schema/camera.perspective.schema.json
@@ -16,13 +16,11 @@
         "yfov" : {
             "type" : "number",
             "description" : "The floating-point vertical field of view in radians.",
-            "required" : true,
             "minimum" : 0.0
         },
         "zfar" : {
             "type" : "number",
             "description" : "The floating-point distance to the far clipping plane.",
-            "required" : true,
             "minimum" : 0.0,
             "exclusiveMinimum" : true,
             "gltf_detailedDescription" : "The floating-point distance to the far clipping plane.  zfar must be greater than znear."
@@ -30,11 +28,11 @@
         "znear" : {
             "type" : "number",
             "description" : "The floating-point distance to the near clipping plane.",
-            "required" : true,
             "minimum" : 0.0,
             "exclusiveMinimum" : true,
             "gltf_detailedDescription" : "The floating-point distance to the near clipping plane.  zfar must be greater than znear."
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required": ["yfov", "zfar", "znear"]
 }

--- a/specification/schema/camera.perspective.schema.json
+++ b/specification/schema/camera.perspective.schema.json
@@ -5,6 +5,8 @@
     "description" : "A perspective camera containing properties to create a perspective projection matrix.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "aspectRatio" : {
             "type" : "number",
             "description" : "The floating-point aspect ratio of the field of view.",

--- a/specification/schema/camera.schema.json
+++ b/specification/schema/camera.schema.json
@@ -5,6 +5,9 @@
     "description" : "A camera's projection.  A node can reference a camera ID to apply a transform to place the camera in the scene.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "orthographic" : {
             "extends" : { "$ref" : "camera.orthographic.schema.json" },
             "description" : "An orthographic camera containing properties to create an orthographic projection matrix."

--- a/specification/schema/camera.schema.json
+++ b/specification/schema/camera.schema.json
@@ -1,19 +1,19 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "camera",
     "type" : "object",
     "description" : "A camera's projection.  A node can reference a camera ID to apply a transform to place the camera in the scene.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name" : {},
         "extensions" : {},
         "extras" : {},
         "orthographic" : {
-            "extends" : { "$ref" : "camera.orthographic.schema.json" },
+            "allOf" : [ { "$ref" : "camera.orthographic.schema.json" } ],
             "description" : "An orthographic camera containing properties to create an orthographic projection matrix."
         },
         "perspective" : {
-            "extends" : { "$ref" : "camera.perspective.schema.json" },
+            "allOf" : [ { "$ref" : "camera.perspective.schema.json" } ],
             "description" : "A perspective camera containing properties to create a perspective projection matrix."
         },
         "type" : {

--- a/specification/schema/camera.schema.json
+++ b/specification/schema/camera.schema.json
@@ -20,9 +20,9 @@
             "type" : "string",
             "description" : "Specifies if the camera uses a perspective or orthographic projection.",
             "enum" : ["perspective", "orthographic"],
-            "required" : true,
             "gltf_detailedDescription" : "Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's `perspective` or `orthographic` property will be defined."
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required": ["type"]
 }

--- a/specification/schema/extension.schema.json
+++ b/specification/schema/extension.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "extension",
     "type" : "object",
     "description" : "Dictionary object with extension-specific objects.",

--- a/specification/schema/extras.schema.json
+++ b/specification/schema/extras.schema.json
@@ -1,6 +1,5 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "extras",
-    "type" : "any",
     "description" : "Application-specific data."
 }

--- a/specification/schema/glTF.schema.json
+++ b/specification/schema/glTF.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "glTF",
     "type" : "object",
     "description" : "The root object for a glTF asset.",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},
@@ -40,7 +40,7 @@
             "gltf_detailedDescription" : "A dictionary object of keyframe animations.  The name of each animation is an ID in the global glTF namespace that is used to reference the animation."
         },
         "asset" : {
-            "extends" : { "$ref" : "asset.schema.json" },
+            "allOf" : [ { "$ref" : "asset.schema.json" } ],
             "description" : "Metadata about the glTF asset.",
             "default" : {}
         },
@@ -144,7 +144,7 @@
             "gltf_detailedDescription" : "A dictionary object of samplers.  The name of each sampler is an ID in the global glTF namespace that is used to reference the sampler.  A sampler contains properties for texture filtering and wrapping modes."
         },
         "scene" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the default scene."
         },
         "scenes" : {

--- a/specification/schema/glTF.schema.json
+++ b/specification/schema/glTF.schema.json
@@ -204,7 +204,7 @@
         }
     },
     "dependencies" : {
-        "scene" : "scenes"
+        "scene" : ["scenes"]
     },
     "additionalProperties" : false
 }

--- a/specification/schema/glTF.schema.json
+++ b/specification/schema/glTF.schema.json
@@ -5,6 +5,8 @@
     "description" : "The root object for a glTF asset.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "extensionsUsed" : {
             "type" : "array",
             "description" : "Names of extensions used somewhere in this asset.",

--- a/specification/schema/glTFChildOfRootProperty.schema.json
+++ b/specification/schema/glTFChildOfRootProperty.schema.json
@@ -1,8 +1,8 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "Child of a glTF root property",
     "type" : "object",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "name" : {
             "type" : "string",

--- a/specification/schema/glTFProperty.schema.json
+++ b/specification/schema/glTFProperty.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "glTF property",
     "type" : "object",
     "properties" : {

--- a/specification/schema/glTFid.schema.json
+++ b/specification/schema/glTFid.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "glTF id",
     "type" : "string",
     "minLength" : 1

--- a/specification/schema/image.schema.json
+++ b/specification/schema/image.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "image",
     "type" : "object",
     "description" : "Image data used to create a texture.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "uri" : {
             "type" : "string",

--- a/specification/schema/image.schema.json
+++ b/specification/schema/image.schema.json
@@ -9,10 +9,10 @@
             "type" : "string",
             "description" : "The uri of the image.",
             "format" : "uri",
-            "required" : true,
             "gltf_detailedDescription" : "The uri of the image.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.  The image format must be jpg, png, bmp, or gif.",
             "gltf_uriType" : "image"
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required": ["uri"]
 }

--- a/specification/schema/material.schema.json
+++ b/specification/schema/material.schema.json
@@ -1,15 +1,15 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "material",
     "type" : "object",
     "description" : "The material appearance of a primitive.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "name" : {},
         "extensions" : {},
         "extras" : {},
         "technique" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the technique.",
             "gltf_detailedDescription" : "The ID of the technique.  If this is not supplied, and no extension is present that defines material properties, then the primitive should be rendered using a default material with 50% gray emissive color."
         },

--- a/specification/schema/material.schema.json
+++ b/specification/schema/material.schema.json
@@ -5,6 +5,9 @@
     "description" : "The material appearance of a primitive.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties": {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "technique" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
             "description" : "The ID of the technique.",

--- a/specification/schema/material.values.schema.json
+++ b/specification/schema/material.values.schema.json
@@ -1,6 +1,6 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "values",
-    "type" : ["number", "boolean", "string", { "$ref" : "arrayValues.schema.json" }],
+    "anyOf" : [ {"type": ["number", "boolean", "string"]} , { "$ref" : "arrayValues.schema.json" }],
     "description" : "A dictionary object of parameter values.  Parameters with the same name as the technique's parameter override the technique's parameter value."
 }

--- a/specification/schema/mesh.primitive.attribute.schema.json
+++ b/specification/schema/mesh.primitive.attribute.schema.json
@@ -1,6 +1,6 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "attribute",
-    "extends" : { "$ref" : "glTFid.schema.json" },
+    "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
     "description" : "A dictionary object of strings, where each string is the ID of the accessor containing an attribute."
 }

--- a/specification/schema/mesh.primitive.schema.json
+++ b/specification/schema/mesh.primitive.schema.json
@@ -24,8 +24,7 @@
         },
         "material" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
-            "description" : "The ID of the material to apply to this primitive when rendering.",
-            "required" : true
+            "description" : "The ID of the material to apply to this primitive when rendering."
         },
         "mode" : {
             "type" : "integer",
@@ -37,5 +36,6 @@
         }
     },
     "additionalProperties" : false,
-    "gltf_webgl" : "`drawElements()` and `drawArrays()`"
+    "gltf_webgl" : "`drawElements()` and `drawArrays()`",
+    "required": ["material"]
 }

--- a/specification/schema/mesh.primitive.schema.json
+++ b/specification/schema/mesh.primitive.schema.json
@@ -5,6 +5,8 @@
     "description" : "Geometry to be rendered with the given material.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "attributes" : {
             "type" : "object",
             "description" : "A dictionary object of strings, where each string is the ID of the accessor containing an attribute.",

--- a/specification/schema/mesh.primitive.schema.json
+++ b/specification/schema/mesh.primitive.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "primitive",
     "type" : "object",
     "description" : "Geometry to be rendered with the given material.",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},
@@ -18,12 +18,12 @@
             "default" : {}
         },
         "indices" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the accessor that contains the indices.",
             "gltf_detailedDescription" : "The ID of the accessor that contains the indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.  When defined, the accessor must contain indices: the bufferView referenced by the accessor must have a target equal to 34963 (ELEMENT_ARRAY_BUFFER); a byteStride that is tightly packed, i.e., 0 or the byte size of componentType in bytes; componentType must be 5121 (UNSIGNED_BYTE) or 5123 (UNSIGNED_SHORT); and type must be \"SCALAR\"."
         },
         "material" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the material to apply to this primitive when rendering.",
             "required" : true
         },

--- a/specification/schema/mesh.schema.json
+++ b/specification/schema/mesh.schema.json
@@ -5,6 +5,9 @@
     "description" : "A set of primitives to be rendered.  A node can contain one or more meshes.  A node's transform places the mesh in the scene.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "primitives" : {
             "type" : "array",
             "description" : "An array of primitives, each defining geometry to be rendered with a material.",

--- a/specification/schema/mesh.schema.json
+++ b/specification/schema/mesh.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "mesh",
     "type" : "object",
     "description" : "A set of primitives to be rendered.  A node can contain one or more meshes.  A node's transform places the mesh in the scene.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name" : {},
         "extensions" : {},

--- a/specification/schema/node.schema.json
+++ b/specification/schema/node.schema.json
@@ -5,6 +5,9 @@
     "description" : "A node in the node hierarchy.  A node can have either the `camera`, `meshes`, or `skeletons`/`skin`/`meshes` properties defined.  In the later case, all `primitives` in the referenced `meshes` contain `JOINT` and `WEIGHT` attributes and the referenced `material`/`technique` from each `primitive` has parameters with `JOINT` and `WEIGHT` semantics.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "camera" : {
             "extends" : { "$ref" : "glTFid.schema.json" },
             "description" : "The ID of the camera referenced by this node."

--- a/specification/schema/node.schema.json
+++ b/specification/schema/node.schema.json
@@ -1,15 +1,15 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "node",
     "type" : "object",
     "description" : "A node in the node hierarchy.  A node can have either the `camera`, `meshes`, or `skeletons`/`skin`/`meshes` properties defined.  In the later case, all `primitives` in the referenced `meshes` contain `JOINT` and `WEIGHT` attributes and the referenced `material`/`technique` from each `primitive` has parameters with `JOINT` and `WEIGHT` semantics.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name" : {},
         "extensions" : {},
         "extras" : {},
         "camera" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the camera referenced by this node."
         },
         "children" : {
@@ -31,11 +31,11 @@
             "gltf_detailedDescription" : "The ID of skeleton nodes.  Each node defines a subtree, which has a `jointName` of the corresponding element in the referenced `skin.jointNames`."
         },
         "skin" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the skin referenced by this node."
         },
         "jointName" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "Name used when this node is a joint in a skin."
         },
         "matrix" : {

--- a/specification/schema/node.schema.json
+++ b/specification/schema/node.schema.json
@@ -91,10 +91,8 @@
         }
     },
     "dependencies" : {
-        "skeletons" : "skin",
-        "skeletons" : "meshes",
-        "skin" : "skeletons",
-        "skin" : "meshes"
+        "skeletons" : ["skin", "meshes"],
+        "skin" : ["skeletons", "meshes"]
     },
     "additionalProperties" : false
 }

--- a/specification/schema/program.schema.json
+++ b/specification/schema/program.schema.json
@@ -5,6 +5,9 @@
     "description" : "A shader program, including its vertex and fragment shader, and names of vertex shader attributes.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties": {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "attributes" : {
             "type" : "array",
             "description" : "Names of GLSL vertex shader attributes.",

--- a/specification/schema/program.schema.json
+++ b/specification/schema/program.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "program",
     "type" : "object",
     "description" : "A shader program, including its vertex and fragment shader, and names of vertex shader attributes.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "name" : {},
         "extensions" : {},
@@ -20,12 +20,12 @@
             "gltf_webgl" : "`bindAttribLocation()`"
         },
         "fragmentShader" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the fragment shader.",
             "required" : true
         },
         "vertexShader" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the vertex shader.",
             "required" : true
         }

--- a/specification/schema/program.schema.json
+++ b/specification/schema/program.schema.json
@@ -21,15 +21,14 @@
         },
         "fragmentShader" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
-            "description" : "The ID of the fragment shader.",
-            "required" : true
+            "description" : "The ID of the fragment shader."
         },
         "vertexShader" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
-            "description" : "The ID of the vertex shader.",
-            "required" : true
+            "description" : "The ID of the vertex shader."
         }
     },
     "additionalProperties" : false,
+    "required": ["fragmentShader", "vertexShader"],
     "gltf_webgl" : "`attachShader()`, `bindAttribLocation()`, `createProgram()`, `deleteProgram()`, `getProgramParameter()`, `getProgramInfoLog()`, `linkProgram()`, `useProgram()`, and `validateProgram()`"
 }

--- a/specification/schema/program.schema.json
+++ b/specification/schema/program.schema.json
@@ -13,8 +13,8 @@
             "description" : "Names of GLSL vertex shader attributes.",
             "items" : {
                 "type" : "string",
-                "minLength" : "1",
-                "maxLength" : "256"
+                "minLength" : 1,
+                "maxLength" : 256
             },
             "default" : [],
             "gltf_webgl" : "`bindAttribLocation()`"

--- a/specification/schema/sampler.schema.json
+++ b/specification/schema/sampler.schema.json
@@ -5,6 +5,9 @@
     "description" : "Texture sampler properties for filtering and wrapping modes.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "magFilter": {
             "type" : "integer",
             "description" : "Magnification filter.",

--- a/specification/schema/sampler.schema.json
+++ b/specification/schema/sampler.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "sampler",
     "type" : "object",
     "description" : "Texture sampler properties for filtering and wrapping modes.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name" : {},
         "extensions" : {},

--- a/specification/schema/scene.schema.json
+++ b/specification/schema/scene.schema.json
@@ -5,6 +5,9 @@
     "description" : "The root nodes of a scene.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "nodes" : {
             "type" : "array",
             "description" : "The IDs of each root node.",

--- a/specification/schema/scene.schema.json
+++ b/specification/schema/scene.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "scene",
     "type" : "object",
     "description" : "The root nodes of a scene.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name" : {},
         "extensions" : {},

--- a/specification/schema/shader.schema.json
+++ b/specification/schema/shader.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "shader",
     "type" : "object",
     "description" : "A vertex or fragment shader.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name" : {},
         "extensions" : {},

--- a/specification/schema/shader.schema.json
+++ b/specification/schema/shader.schema.json
@@ -5,6 +5,9 @@
     "description" : "A vertex or fragment shader.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "uri" : {
             "type" : "string",
             "description" : "The uri of the GLSL source.",

--- a/specification/schema/shader.schema.json
+++ b/specification/schema/shader.schema.json
@@ -12,7 +12,6 @@
             "type" : "string",
             "description" : "The uri of the GLSL source.",
             "format" : "uri",
-            "required" : true,
             "gltf_detailedDescription" : "The uri of the GLSL source.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.",
             "gltf_uriType" : "text"
         },
@@ -21,11 +20,11 @@
             "description" : "The shader stage.",
             "enum" : [35632, 35633],
             "gltf_enumNames" : ["FRAGMENT_SHADER", "VERTEX_SHADER"],
-            "required" : true,
             "gltf_detailedDescription" : "The shader stage.  All valid values correspond to WebGL enums."
         }
     },
     "additionalProperties" : false,
+    "required" : ["uri", "type"],
     "gltf_webgl" : "`createShader()`, `deleteShader()`, `shaderSource()`, `compileShader()`, `getShaderParameter()`, and `getShaderInfoLog()`"
 }
 

--- a/specification/schema/skin.schema.json
+++ b/specification/schema/skin.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "skin",
     "type" : "object",
     "description" : "Joints and matrices defining a skin.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name" : {},
         "extensions" : {},
@@ -19,7 +19,7 @@
             "default" : [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ]
         },
         "inverseBindMatrices" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the accessor containing the floating-point 4x4 inverse-bind matrices.",
             "required" : true        
         },

--- a/specification/schema/skin.schema.json
+++ b/specification/schema/skin.schema.json
@@ -20,8 +20,7 @@
         },
         "inverseBindMatrices" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
-            "description" : "The ID of the accessor containing the floating-point 4x4 inverse-bind matrices.",
-            "required" : true        
+            "description" : "The ID of the accessor containing the floating-point 4x4 inverse-bind matrices."    
         },
         "jointNames" : {
             "type" : "array",
@@ -30,9 +29,9 @@
                 "$ref" : "glTFid.schema.json"
             },
             "uniqueItems" : true,
-            "required" : true,
             "gltf_detailedDescription" : "Joint names of the joints (nodes with a `jointName` property) in this skin.  The array length is the same as the `count` property of the `inverseBindMatrices` accessor, and the same as the total quantity of all skeleton nodes from node-trees referenced by the skinned mesh instance node's `skeletons` array."
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required" : ["inverseBindMatrices", "jointNames"]
 }

--- a/specification/schema/skin.schema.json
+++ b/specification/schema/skin.schema.json
@@ -5,6 +5,9 @@
     "description" : "Joints and matrices defining a skin.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "bindShapeMatrix" : {
             "type" : "array",
             "description" : "Floating-point 4x4 transformation matrix stored in column-major order.",

--- a/specification/schema/technique.attribute.schema.json
+++ b/specification/schema/technique.attribute.schema.json
@@ -1,6 +1,6 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "attribute",
-    "extends" : { "$ref" : "glTFid.schema.json" },
+    "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
     "description" : "A dictionary object of strings that maps GLSL attribute names to technique parameter IDs."
 }

--- a/specification/schema/technique.parameters.schema.json
+++ b/specification/schema/technique.parameters.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "parameter",
     "type" : "object",
     "description" : "An attribute or uniform input to a technique, and an optional semantic and value.",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},
@@ -14,7 +14,7 @@
             "gltf_detailedDescription" : "When defined, the parameter is an array of count elements of the specified type.  Otherwise, the parameter is not an array.  When defined, `value` is an array with length equal to count, times the number of components in the type, e.g., `3` for `FLOAT_VEC3`.  An array parameter of scalar values is not the same as a vector parameter of the same size; for example, when count is 2 and type is 5126 (FLOAT), the parameter is an array of two floating-point values, not a FLOAT_VEC2."
         },
         "node" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The id of the node whose transform is used as the parameter's value.",
             "gltf_detailedDescription" : "The id of the node whose transform is used as the parameter's value.  When this is defined, `type` must be `35676` (FLOAT_MAT4), therefore, when the semantic is \"MODELINVERSETRANSPOSE\", \"MODELVIEWINVERSETRANSPOSE\", or \"VIEWPORT\", the node property can't be defined."
         },
@@ -32,7 +32,7 @@
             "gltf_detailedDescription" : "Identifies a parameter with a well-known meaning.  Uniform semantics include `\"LOCAL\"` (FLOAT_MAT4), `\"MODEL\"` (FLOAT_MAT4), `\"VIEW\"` (FLOAT_MAT4), `\"PROJECTION\"` (FLOAT_MAT4), `\"MODELVIEW\"` (FLOAT_MAT4), `\"MODELVIEWPROJECTION\"` (FLOAT_MAT4), `\"MODELINVERSE\"` (FLOAT_MAT4), `\"VIEWINVERSE\"` (FLOAT_MAT4), `\"PROJECTIONINVERSE\"` (FLOAT_MAT4), `\"MODELVIEWINVERSE\"` (FLOAT_MAT4), `\"MODELVIEWPROJECTIONINVERSE\"` (FLOAT_MAT4), `\"MODELINVERSETRANSPOSE\"` (FLOAT_MAT3), `\"MODELVIEWINVERSETRANSPOSE\"` (FLOAT_MAT3), `\"VIEWPORT\"` (FLOAT_VEC4), `\"JOINTMATRIX\"` (FLOAT_MAT4).  Attribute semantics include `\"POSITION\"`, `\"NORMAL\"`, `\"TEXCOORD\"`, `\"COLOR\"`, `\"JOINT\"`, and `\"WEIGHT\"`.  Attribute semantic property names can be of the form `[semantic]_[set_index]`, e.g., `\"TEXCOORD_0\"`."
         },
         "value" : {
-            "type" : ["number", "boolean", "string", { "$ref" : "arrayValues.schema.json" }],
+            "anyOf" : [{"type" :["number", "boolean", "string"]}, { "$ref" : "arrayValues.schema.json" }],
             "description" : "The value of the parameter.",
             "gltf_detailedDescription" : "The value of the parameter.  A material value with the same name, when specified, overrides this value."
         }

--- a/specification/schema/technique.parameters.schema.json
+++ b/specification/schema/technique.parameters.schema.json
@@ -5,6 +5,8 @@
     "description" : "An attribute or uniform input to a technique, and an optional semantic and value.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "count" : {
             "type" : "integer",
             "description" : "When defined, the parameter is an array of count elements of the specified type.  Otherwise, the parameter is not an array.",

--- a/specification/schema/technique.parameters.schema.json
+++ b/specification/schema/technique.parameters.schema.json
@@ -23,7 +23,6 @@
             "description" : "The datatype.",
             "enum" : [5120, 5121, 5122, 5123, 5124, 5125, 5126, 35664, 35665, 35666, 35667, 35668, 35669, 35670, 35671, 35672, 35673, 35674, 35675, 35676, 35678],
             "gltf_enumNames" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "INT", "UNSIGNED_INT", "FLOAT", "FLOAT_VEC2", "FLOAT_VEC3", "FLOAT_VEC4", "INT_VEC2", "INT_VEC3", "INT_VEC4", "BOOL", "BOOL_VEC2", "BOOL_VEC3", "BOOL_VEC4", "FLOAT_MAT2", "FLOAT_MAT3", "FLOAT_MAT4", "SAMPLER_2D"],
-            "required" : true,
             "gltf_detailedDescription" : "The datatype.  All valid values correspond to WebGL enums."
         },
         "semantic" : {
@@ -37,5 +36,6 @@
             "gltf_detailedDescription" : "The value of the parameter.  A material value with the same name, when specified, overrides this value."
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required" : ["type"]
 }

--- a/specification/schema/technique.schema.json
+++ b/specification/schema/technique.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "technique",
     "type" : "object",
     "description" : "A template for material appearances.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "name" : {},
         "extensions" : {},
@@ -30,7 +30,7 @@
             "default" : {}
         },
         "program" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the program.",
             "required" : true
         },
@@ -45,7 +45,7 @@
             "default" : {}
         },
         "states" : {
-            "extends" : { "$ref" : "technique.states.schema.json" },
+            "allOf" : [ { "$ref" : "technique.states.schema.json" } ],
             "description" : "Fixed-function rendering states.",
             "default" : {}
         }

--- a/specification/schema/technique.schema.json
+++ b/specification/schema/technique.schema.json
@@ -31,8 +31,7 @@
         },
         "program" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
-            "description" : "The ID of the program.",
-            "required" : true
+            "description" : "The ID of the program."
         },
         "uniforms" : {
             "type" : "object",
@@ -50,5 +49,6 @@
             "default" : {}
         }
     },
-    "additionalProperties" : false
+    "additionalProperties" : false,
+    "required" : ["program"]
 }

--- a/specification/schema/technique.schema.json
+++ b/specification/schema/technique.schema.json
@@ -5,6 +5,9 @@
     "description" : "A template for material appearances.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties": {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "parameters" : {
             "type" : "object",
             "description" : "A dictionary object of technique.parameters objects.",

--- a/specification/schema/technique.states.functions.schema.json
+++ b/specification/schema/technique.states.functions.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "functions",
     "type" : "object",
     "description" : "Arguments for fixed-function rendering state functions other than `enable()`/`disable()`.",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},

--- a/specification/schema/technique.states.functions.schema.json
+++ b/specification/schema/technique.states.functions.schema.json
@@ -5,6 +5,8 @@
     "description" : "Arguments for fixed-function rendering state functions other than `enable()`/`disable()`.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "blendColor" : {
             "type" : "array",
             "description" : "Floating-point values passed to `blendColor()`. [red, green, blue, alpha]",

--- a/specification/schema/technique.states.schema.json
+++ b/specification/schema/technique.states.schema.json
@@ -5,6 +5,8 @@
     "description" : "Fixed-function rendering states.",
     "extends" : { "$ref" : "glTFProperty.schema.json" },
     "properties" : {
+        "extensions" : {},
+        "extras" : {},
         "enable" : {
             "type" : "array",
             "description" : "WebGL states to enable.",

--- a/specification/schema/technique.states.schema.json
+++ b/specification/schema/technique.states.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "states",
     "type" : "object",
     "description" : "Fixed-function rendering states.",
-    "extends" : { "$ref" : "glTFProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFProperty.schema.json" } ],
     "properties" : {
         "extensions" : {},
         "extras" : {},

--- a/specification/schema/technique.uniform.schema.json
+++ b/specification/schema/technique.uniform.schema.json
@@ -1,6 +1,6 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "uniform",
-    "extends" : { "$ref" : "glTFid.schema.json" },
+    "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
     "description" : "A dictionary object of strings that maps GLSL uniform names to technique parameter IDs."
 }

--- a/specification/schema/texture.schema.json
+++ b/specification/schema/texture.schema.json
@@ -1,9 +1,9 @@
 {
-    "$schema" : "http://json-schema.org/draft-03/schema",
+    "$schema" : "http://json-schema.org/draft-04/schema",
     "title" : "texture",
     "type" : "object",
     "description" : "A texture and its sampler.",
-    "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties" : {
         "name" : {},
         "extensions" : {},
@@ -27,12 +27,12 @@
             "gltf_webgl" : "`texImage2D()` internalFormat parameter"
         },
         "sampler" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the sampler used by this texture.",
             "required" : true
         },
         "source" : {
-            "extends" : { "$ref" : "glTFid.schema.json" },
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
             "description" : "The ID of the image used by this texture.",
             "required" : true
         },

--- a/specification/schema/texture.schema.json
+++ b/specification/schema/texture.schema.json
@@ -28,13 +28,11 @@
         },
         "sampler" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
-            "description" : "The ID of the sampler used by this texture.",
-            "required" : true
+            "description" : "The ID of the sampler used by this texture."
         },
         "source" : {
             "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
-            "description" : "The ID of the image used by this texture.",
-            "required" : true
+            "description" : "The ID of the image used by this texture."
         },
         "target": {
             "type" : "integer",
@@ -56,5 +54,6 @@
         }
     },
     "additionalProperties" : false,
-    "gltf_webgl" : "`createTexture()`, `deleteTexture()`, `bindTexture()`, `texImage2D()`, and `texParameterf()`"
+    "gltf_webgl" : "`createTexture()`, `deleteTexture()`, `bindTexture()`, `texImage2D()`, and `texParameterf()`",
+    "required": ["sampler", "source"]
 }

--- a/specification/schema/texture.schema.json
+++ b/specification/schema/texture.schema.json
@@ -5,6 +5,9 @@
     "description" : "A texture and its sampler.",
     "extends" : { "$ref" : "glTFChildOfRootProperty.schema.json" },
     "properties" : {
+        "name" : {},
+        "extensions" : {},
+        "extras" : {},
         "format": {
             "type" : "integer",
             "description" : "The texture's format.",


### PR DESCRIPTION
There's an issue in the gltf schema related to inheritance that is causing schema validators to fail (I verified this with [rapidjson](https://github.com/miloyip/rapidjson/) and [json-schema-validator](https://github.com/daveclayton/json-schema-validator). A description of the problem can be found [here](http://stackoverflow.com/questions/27410216/json-schema-and-inheritance) and [here](http://stackoverflow.com/questions/22689900/json-schema-allof-with-additionalproperties).

I implemented a workaround that fixes the issue (hopefully a future version of json schema will provide a more elegant solution). The solution consists of passing the name of the fields defined in the "parent" down to the children and define them as empty objects. The advantage of this approach is that there is no duplication involved and the actual schema of the fields in question is only defined in the parent. This way the schema will not fail at additionalProperties and validators seem to behave as expected.

I've also added v4 schema upgrades as well. See https://github.com/json-schema/json-schema/wiki/ChangeLog for changes between schema v3 and v4
