### PR TITLE
Update affiliations in acknowledgments

### DIFF
--- a/specification/1.0/README.md
+++ b/specification/1.0/README.md
@@ -3381,11 +3381,11 @@ Application-specific data.
 * Ed Mackey, Analytical Graphics, Inc.
 * Matthew McMullan,
 * Darryl Gough, 
-* Alex Wood,
+* Alex Wood, Analytical Graphics, Inc.
 * Rob Taglang, Cesium
 * Marco Hutter,
 * Alexey Knyazev,
-* Sean Lilley,
+* Sean Lilley, Cesium
 * Corentin Wallez,
 * Yu Chen Hou
 


### PR DESCRIPTION
@lexaknyazev this updates the affiliations that I know for sure.  In general, we should not just add folk's affiliations even if we think we know them because they might have done the work on their own, not for their employer.  We really need to ask everyone else.

My original approach was to only acknowledge significant contributions (with no real definition of that) and rely on GitHub history for everything else.  Are you changing this because the history is now different with all the repo movement?