### PR TITLE
Specify that GLBoost supports both glTF 1.0 and 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Diagram by [Marco Hutter](http://marco-hutter.de/) ([repo](https://github.com/ja
 * Initial [glTF loader](https://github.com/xeolabs/xeogl/tree/master/src/importing/gltf) in [xeogl](http://xeogl.org/) (geometry and materials)
    * [Importing glTF](https://github.com/xeolabs/xeogl/wiki/Importing-glTF) tutorial
 * [glTF loader](https://github.com/xirvr/aframe-gltf) in [A-Frame](https://aframe.io/)
-* [glTF loader](https://github.com/emadurandal/GLBoost/blob/master/src/js/middle_level/loader/GLTFLoader.js) in [GLBoost](https://github.com/emadurandal/GLBoost) ([examples](https://gitcdn.xyz/repo/emadurandal/GLBoost/master/examples/index.html))
+* [glTF loader](https://github.com/emadurandal/GLBoost/blob/master/src/js/middle_level/loader/GLTFLoader.js) in [GLBoost](https://github.com/emadurandal/GLBoost) ([examples](https://gitcdn.xyz/repo/emadurandal/GLBoost/master/examples/index.html)) (Both glTF 1.0 & 1.1 supported)
 * [glTF plug-in](https://github.com/xml3d/xml3d-gltf-plugin) for [xml3d.js](http://xml3d.org)  (geometry and materials)
 * [glTF reader/writer](https://github.com/cedricpinson/osgjs/blob/master/sources/osgPlugins/ReaderWriterGLTF.js) in [OSG.JS](http://osgjs.org/)
 


### PR DESCRIPTION
Hi,

I made GLBoost compatible with glTF 1.1, so I requested the pull request.
https://github.com/cx20/gltf-test

Since it is just a notation issue, I'll leave it up to your judgment to decide whether to accept this pull request.
(However, in terms of promoting the movement of 1.1 support, this notation may be good.)

BTW, I'm also writing a new article about glTF for Japanese developers.
It's about Tips for developing your own glTF loader in Javascript and details of glTF 1.1.
The draft is here.
http://qiita.com/emadurandal/private/06df649ad5e9715dbe9c

Recently, I feel that interest in glTF is increasing in Japan at long last. :relaxed: