### PR TITLE
Link to current (KHR) binary extension spec.

### DIFF
--- a/extensions/Vendor/CESIUM_binary_glTF/README.md
+++ b/extensions/Vendor/CESIUM_binary_glTF/README.md
@@ -8,7 +8,7 @@
 
 ## Status
 
-Do not use this extension; instead, use [EXT_binary_glTF](../../MultiVendor/EXT_binary_glTF).  This extension was used in Cesium 1.10 to 1.14.  This spec is for historic context.
+Do not use this extension; instead, use [KHR_binary_glTF](../../Khronos/KHR_binary_glTF).  This extension was used in Cesium 1.10 to 1.14.  This spec is for historic context.
 
 ## Dependencies
 


### PR DESCRIPTION
I assume EXT should now be KHR? The current link is broken, if not.