### PR TITLE
Add Grimoire.js as Javascript library supporting glTF

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Diagram by [Marco Hutter](http://marco-hutter.de/) ([repo](https://github.com/ja
 * [glTF plug-in](https://github.com/xml3d/xml3d-gltf-plugin) for [xml3d.js](http://xml3d.org)  (geometry and materials)
 * [glTF reader/writer](https://github.com/cedricpinson/osgjs/blob/master/sources/osgPlugins/ReaderWriterGLTF.js) in [OSG.JS](http://osgjs.org/)
 * [glTF loader](https://github.com/x3dom/x3dom/blob/master/src/util/glTF/glTFLoader.js) in [X3DOM](http://x3dom.org/)
+* [grimoirejs-gltf](https://github.com/GrimoireGL/grimoirejs-gltf) in [Grimoire.js](https://github.com/GrimoireGL/GrimoireJS)
 
 [Compare WebGL-based glTF loaders](https://github.com/cx20/gltf-test) from various engines
 


### PR DESCRIPTION
Add my tag-based Web3D library(Grimoire.js) to the list on README.md.

My WebGL library (Grimoire.js(https://github.com/GrimoireGL/GrimoireJS)) supports glTF 1.0 completely.(See https://github.com/cx20/gltf-test)
I haven't add English document on official site(https://grimoire.gl). But, it will be fully translated into English soon and it will contains some glTF samples also.

Could be my libraries added to the list?