### PR TITLE
Add alpha coverage details

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -62,6 +62,7 @@ Copyright (C) 2013-2017 The Khronos Group Inc. All Rights Reserved. glTF is a tr
     * [Metallic-Roughness Material](#metallic-roughness-material)
     * [Additional Maps](#additional-maps)
     * [Alpha Coverage](#alpha-coverage)
+    * [Double Sided](#double-sided)
   * [Cameras](#cameras)
     * [Projection Matrices](#projection-matrices)
   * [Animations](#animations)
@@ -1015,12 +1016,14 @@ The `alphaMode` property defines how the alpha value of the main factor and text
 
  When `alphaMode` is set to `MASK` the `alphaCutoff` property specifies the cutoff threshold. If the alpha value is greater than or equal to the `alphaCutoff` value then it is rendered as fully opaque, otherwise, it is rendered as fully transparent. `alphaCutoff` value is ignored for other modes.
 
-The `doubleSided` property specified whether the material is double sided.
-
 >**Implementation Note for Real-Time Rasterizers:** Real-time rasterizers typically use depth buffers and mesh sorting to support alpha modes. The following describe the expected behavior for these types of renderers.
 >* `OPAQUE` - A depth value is written for every pixel and mesh sorting is not required for correct output.
 >* `MASK` - A depth value is not written for a pixel that is discarded after the alpha test. A depth value is written for all other pixels. Mesh sorting is not required for correct output.
 >* `BLEND` - Support for this mode varies. There is no perfect and fast solution that works for all cases. Implementations should try to achieve the correct blending output for as many situations as possible. Whether depth value is written or whether to sort is up to the implementation. For example, implementations can discard pixels which have zero or close to zero alpha value to avoid sorting issues.
+
+### Double Sided
+
+The `doubleSided` property specified whether the material is double sided. When this value is false, back-face culling is enabled. When this value is true, back-face culling is disabled and double sided lighting is enabled. The back-face must have its normals reversed before the lighting equation is evaluated.
 
 ## Cameras
 

--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -61,6 +61,7 @@ Copyright (C) 2013-2017 The Khronos Group Inc. All Rights Reserved. glTF is a tr
   * [Materials](#materials)
     * [Metallic-Roughness Material](#metallic-roughness-material)
     * [Additional Maps](#additional-maps)
+    * [Alpha Coverage](#alpha-coverage)
   * [Cameras](#cameras)
     * [Projection Matrices](#projection-matrices)
   * [Animations](#animations)
@@ -1002,6 +1003,24 @@ The following examples shows a material that is defined using `pbrMetallicRoughn
 >| Normal    | Geometry will appear less detailed than authored. |
 >| Occlusion | Model will appear brighter in areas that should be darker. |
 >| Emissive  | Model with lights will not be lit. For example, the headlights of a car model will be off instead of on. |
+
+### Alpha Coverage
+
+The `alphaMode` property defines how the alpha value of the main factor and texture should be interpreted. The alpha value is defined in the `baseColor` for metallic-roughness material model. 
+
+`alphaMode` can be one of the following values:
+* `OPAQUE` - The rendered output is fully opaque and any alpha value is ignored.
+* `MASK` - The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value. This mode is used to simulate geometry such as tree leaves or wire fences.
+* `BLEND` - The rendered output is combined with the background using the normal painting operation (i.e. the Porter and Duff over operator). This mode is used to simulate geometry such as guaze cloth or animal fur. 
+
+ When `alphaMode` is set to `MASK` the `alphaCutoff` property specifies the cutoff threshold. If the alpha value is greater than or equal to the `alphaCutoff` value then it is rendered as fully opaque, otherwise, it is rendered as fully transparent. `alphaCutoff` value is ignored for other modes.
+
+The `doubleSided` property specified whether the material is double sided.
+
+>**Implementation Note for Real-Time Rasterizers:** Real-time rasterizers typically use depth buffers and mesh sorting to support alpha modes. The following describe the expected behavior for these types of renderers.
+>* `OPAQUE` - A depth value is written for every pixel and mesh sorting is not required for correct output.
+>* `MASK` - A depth value is not written for a pixel that is discarded after the alpha test. A depth value is written for all other pixels. Mesh sorting is not required for correct output.
+>* `BLEND` - Support for this mode varies. There is no perfect and fast solution that works for all cases. Implementations should try to achieve the correct blending output for as many situations as possible. Whether depth value is written or whether to sort is up to the implementation. For example, implementations can discard pixels which have zero or close to zero alpha value to avoid sorting issues.
 
 ## Cameras
 

--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -1023,7 +1023,7 @@ The `alphaMode` property defines how the alpha value of the main factor and text
 
 ### Double Sided
 
-The `doubleSided` property specified whether the material is double sided. When this value is false, back-face culling is enabled. When this value is true, back-face culling is disabled and double sided lighting is enabled. The back-face must have its normals reversed before the lighting equation is evaluated.
+The `doubleSided` property specifies whether the material is double sided. When this value is false, back-face culling is enabled. When this value is true, back-face culling is disabled and double sided lighting is enabled. The back-face must have its normals reversed before the lighting equation is evaluated.
 
 ## Cameras
 

--- a/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
+++ b/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
@@ -15,12 +15,12 @@
             "default": [ 1.0, 1.0, 1.0, 1.0 ],
             "minItems": 4,
             "maxItems": 4,
-            "gltf_detailedDescription": "The RGBA components of the base color of the material. The fourth component (A) is the opacity of the material. These values are linear."
+            "gltf_detailedDescription": "The RGBA components of the base color of the material. The fourth component (A) is the alpha coverage of the material. The `alphaMode` property specifies how alpha is interpreted. These values are linear."
         },
         "baseColorTexture": {
             "allOf": [ { "$ref": "textureInfo.schema.json" } ],
             "description": "The base color texture.",
-            "gltf_detailedDescription": "The base color texture. This texture contains RGB(A) components in sRGB color space. The first three components (RGB) specify the base color of the material. If the fourth component (A) is present, it represents the opacity of the material. Otherwise, an opacity of 1.0 is assumed."
+            "gltf_detailedDescription": "The base color texture. This texture contains RGB(A) components in sRGB color space. The first three components (RGB) specify the base color of the material. If the fourth component (A) is present, it represents the alpha coverage of the material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property specifies how alpha is interpreted. The stored texels must not be premultiplied."
         },
         "metallicFactor": {
             "type": "number",

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -5,9 +5,9 @@
     "description": "The material appearance of a primitive.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
-        "name": {},
-        "extensions": {},
-        "extras": {},
+        "name": { },
+        "extensions": { },
+        "extras": { },
         "pbrMetallicRoughness": {
             "allOf": [ { "$ref": "material.pbrMetallicRoughness.schema.json" } ],
             "description": "A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology."
@@ -39,7 +39,30 @@
             "default": [ 0.0, 0.0, 0.0 ],
             "description": "The emissive color of the material.",
             "gltf_detailedDescription": "The RGB components of the emissive color of the material. If an emissiveTexture is specified, this value is multiplied with the texel values."
+        },
+        "alphaMode": {
+            "type": "string",
+            "enum": [ "OPAQUE", "MASK", "BLEND" ],
+            "default": "OPAQUE",
+            "description": "The alpha rendering mode of the material.",
+            "gltf_detailedDescription": "The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture. If the alpha mode is not specified, it defaults to `OPAQUE` where the alpha value is ignored and the rendered output is fully opaque. In `MASK` mode, the rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value. In `BLEND` mode, the alpha value is used to composite the source and destination areas. The rendered output is combined with the background using the normal painting operation (i.e. the Porter and Duff over operator)."
+        },
+        "alphaCutoff": {
+            "type": "number",
+            "minimum": 0.0,
+            "default": 0.5,
+            "description": "The alpha cutoff value of the material.",
+            "gltf_detailedDescription": "This value specifies the cutoff threshold when in `MASK` mode. If the alpha value is greater than or equal to this value then it is rendered as fully opaque, otherwise, it is rendered as fully transparent. This value is ignored for other modes."
+        },
+        "doubleSided": {
+            "type": "boolean",
+            "default": false,
+            "description": "Indicates whether a material is double sided.",
+            "gltf_detailedDescription": "Declares whether back-face culling should be disabled for this material."
         }
+    },
+     "dependencies" : {
+        "alphaCutoff" : ["alphaMode"]
     },
     "additionalProperties": false
 }

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -52,13 +52,13 @@
             "minimum": 0.0,
             "default": 0.5,
             "description": "The alpha cutoff value of the material.",
-            "gltf_detailedDescription": "This value specifies the cutoff threshold when in `MASK` mode. If the alpha value is greater than or equal to this value then it is rendered as fully opaque, otherwise, it is rendered as fully transparent. This value is ignored for other modes."
+            "gltf_detailedDescription": "Specifies the cutoff threshold when in `MASK` mode. If the alpha value is greater than or equal to this value then it is rendered as fully opaque, otherwise, it is rendered as fully transparent. This value is ignored for other modes."
         },
         "doubleSided": {
             "type": "boolean",
             "default": false,
-            "description": "Indicates whether a material is double sided.",
-            "gltf_detailedDescription": "Declares whether back-face culling should be disabled for this material."
+            "description": "Specifies whether the material is double sided.",
+            "gltf_detailedDescription": "Specifies whether the material is double sided. When this value is false, back-face culling is enabled. When this value is true, back-face culling is disabled and double sided lighting is enabled. The back-face must have its normals reversed before the lighting equation is evaluated."
         }
     },
      "dependencies" : {


### PR DESCRIPTION
Adding details on alpha coverage as per #822 
Also added doubleSided property from common materials extension to core spec since it can be used across multiple material models.

Doc: https://github.com/sbtron/glTF/tree/2.0Transparency/specification/2.0#alpha-coverage
Schemas:
https://github.com/sbtron/glTF/blob/2.0Transparency/specification/2.0/schema/material.schema.json
https://github.com/sbtron/glTF/blob/2.0Transparency/specification/2.0/schema/material.pbrMetallicRoughness.schema.json 

@AurL @cedricpinson could you review and ensure this meets your needs so you no longer have to use the extras field.

