### PR TITLE
Add optional property mesh.closed specifying that mesh is closed (watertight)

### DIFF
--- a/specification/2.0/schema/mesh.schema.json
+++ b/specification/2.0/schema/mesh.schema.json
@@ -23,6 +23,12 @@
                 "type": "number"
             },
             "minItems": 0
+        },
+        "closed": {
+            "type": "boolean",
+            "default": false,
+            "description": "Specifies whether the mesh is closed (watertight).",
+            "gltf_detailedDescription": "Specifies whether the mesh is closed (watertight).  Application can use this property within rendering techniques where it is important to consider - e.g. when applying clipping planes capped with material or just to enable back-face culling (regardless of doubleSided property of material)."
         }
     },
     "required": [ "primitives" ]


### PR DESCRIPTION
Application (3D viewer) can use closed (watertight) flag of the mesh within rendering techniques where it is important to consider - e.g. when applying clipping planes capped with material or just to enable back-face culling (regardless of doubleSided property of material).

This flag applies to the full list of primitive sets as whole, not for each one individually. E.g. closed mesh can be also declared for several primitive sets with each one defining only an open Shell, but forming a closed mesh as whole through sharing vertex positions (via duplicated vertices).

This property can be easily declared for models exported from CAD application (where it is well-known if mesh forms closed Solid or open Shell), but also can be computed from mesh itself (this operation is however is not cheap). Other applications generating glTF model that don't care might omit this property (considering the mesh is not closed in this case).