### PR TITLE
Fix primitive.targets, remove unneeded schema indirection

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -690,7 +690,9 @@ Valid accessor type and component type for each attribute semantic property are 
 #### Morph Targets
 
 Morph Targets are defined by extending the Mesh concept.
+
 A Morph Target is a morphable Mesh where primitives' attributes are obtained by adding the original attributes to a weighted sum of targets attributes.
+
 For instance, the Morph Target vertices `POSITION` for the primitive at index *i* are computed in this way:
 ```
 primitives[i].attributes.POSITION + 
@@ -698,7 +700,8 @@ primitives[i].attributes.POSITION +
   weights[1] * primitives[i].targets[1].POSITION +
   weights[2] * primitives[i].targets[2].POSITION + ...
 ```
-Morph Targets are implemented via the `targets` property defined in the Mesh `primitives`. Each target in the `targets` array is a dictionary mapping a primitive attribute to an accessor containing Morph Target displacement data, currently only two attributes ('POSITION' and 'NORMAL') are supported. All primitives are required to list the same number of `targets` in the same order.
+Morph Targets are implemented via the `targets` property defined in the Mesh `primitives`. Each target in the `targets` array is a dictionary mapping a primitive attribute to an accessor containing Morph Target displacement data, currently only three attributes (`POSITION`, `NORMAL`, and `TANGENT`) are supported. All primitives are required to list the same number of `targets` in the same order.
+
 The `weights` array is optional, it stores the default targets weights, in the absence of `node.weights` the primitives attributes are resolved using these weights. When this property is missing the default targets weights are assumed to be zero.
 
 The following example extends the Mesh defined in the previous example to a morphable one by adding two Morph Targets:
@@ -730,7 +733,7 @@ The following example extends the Mesh defined in the previous example to a morp
 }
 ```
 
-After applying morph targets to vertex positions and normals, tangent space must be recalculated. See [Appendix B](#appendix-b-tangent-space-recalculation) for details.
+After applying morph targets to vertex positions and normals, tangent space may need to be recalculated. See [Appendix B](#appendix-b-tangent-space-recalculation) for details.
 
 ### Skins
 

--- a/specification/2.0/schema/mesh.primitive.attribute.schema.json
+++ b/specification/2.0/schema/mesh.primitive.attribute.schema.json
@@ -1,6 +1,0 @@
-{
-    "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "attribute",
-    "allOf": [ { "$ref": "glTFid.schema.json" } ],
-    "description": "A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data."
-}

--- a/specification/2.0/schema/mesh.primitive.schema.json
+++ b/specification/2.0/schema/mesh.primitive.schema.json
@@ -8,10 +8,8 @@
         "attributes": {
             "type": "object",
             "description": "A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.",
-            "properties": {
-            },
             "additionalProperties": {
-                "$ref": "mesh.primitive.attribute.schema.json"
+                "$ref": "glTFid.schema.json"
             }
         },
         "indices": {
@@ -65,9 +63,13 @@
             "type": "array",
             "description": "An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.",
             "items": {
-                "$ref": "mesh.primitive.target.schema.json"
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "glTFid.schema.json"
+                },
+                "description": "A dictionary object specifying attributes displacements in a Morph Target, where each key corresponds to one of the three supported attribute semantic (`POSITION`, `NORMAL`, or `TANGENT`) and each value is the index of the accessor containing the attribute displacements' data."
             },
-            "minItems": 0
+            "minItems": 1
         },
         "extensions": { },
         "extras": { }

--- a/specification/2.0/schema/mesh.primitive.schema.json
+++ b/specification/2.0/schema/mesh.primitive.schema.json
@@ -8,6 +8,7 @@
         "attributes": {
             "type": "object",
             "description": "A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.",
+            "minProperties": 1,
             "additionalProperties": {
                 "$ref": "glTFid.schema.json"
             }
@@ -64,6 +65,7 @@
             "description": "An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.",
             "items": {
                 "type": "object",
+                "minProperties": 1,
                 "additionalProperties": {
                     "$ref": "glTFid.schema.json"
                 },

--- a/specification/2.0/schema/mesh.primitive.target.schema.json
+++ b/specification/2.0/schema/mesh.primitive.target.schema.json
@@ -1,6 +1,0 @@
-{
-    "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "target",
-    "allOf": [ { "$ref": "glTFid.schema.json" } ],
-    "description": "A dictionary object specifying attributes displacements in a Morph Target, where each key corresponds to one of the three supported attribute semantic (`POSITION`, `NORMAL`, or `TANGENT`) and each value is the index of the accessor containing the attribute displacements' data."
-}


### PR DESCRIPTION
Fix #927, remove indirection.

@bghgary 
Should we require that `attributes` isn't empty? It's possible with `"minProperties": 1` schema rule. Same question about elements of the `targets` array.