### PR TITLE
Add note to the pbrMetallicRoughness schema

### DIFF
--- a/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
+++ b/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
@@ -16,7 +16,7 @@
             "default": [ 1.0, 1.0, 1.0, 1.0 ],
             "minItems": 4,
             "maxItems": 4,
-            "gltf_detailedDescription": "The RGBA components of the base color of the material. The fourth component (A) is the alpha coverage of the material. The `alphaMode` property specifies how alpha is interpreted. These values are linear."
+            "gltf_detailedDescription": "The RGBA components of the base color of the material. The fourth component (A) is the alpha coverage of the material. The `alphaMode` property specifies how alpha is interpreted. These values are linear. If a baseColorTexture is specified, this value is multiplied with the texel values."
         },
         "baseColorTexture": {
             "allOf": [ { "$ref": "textureInfo.schema.json" } ],
@@ -29,7 +29,7 @@
             "default": 1.0,
             "minimum": 0.0,
             "maximum": 1.0,
-            "gltf_detailedDescription": "The metalness of the material. A value of 1.0 means the material is a metal. A value of 0.0 means the material is a dielectric. Values in between are for blending between metals and dielectrics such as dirty metallic surfaces. This value is linear."
+            "gltf_detailedDescription": "The metalness of the material. A value of 1.0 means the material is a metal. A value of 0.0 means the material is a dielectric. Values in between are for blending between metals and dielectrics such as dirty metallic surfaces. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the metallic texel values."
         },
         "roughnessFactor": {
             "type": "number",
@@ -37,7 +37,7 @@
             "default": 1.0,
             "minimum": 0.0,
             "maximum": 1.0,
-            "gltf_detailedDescription": "The roughness of the material. A value of 1.0 means the material is completely rough. A value of 0.0 means the material is completely smooth. This value is linear."
+            "gltf_detailedDescription": "The roughness of the material. A value of 1.0 means the material is completely rough. A value of 0.0 means the material is completely smooth. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the roughness texel values."
         },
         "metallicRoughnessTexture": {
             "allOf": [ { "$ref": "textureInfo.schema.json" } ],

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -38,7 +38,7 @@
             "maxItems": 3,
             "default": [ 0.0, 0.0, 0.0 ],
             "description": "The emissive color of the material.",
-            "gltf_detailedDescription": "The RGB components of the emissive color of the material. If an emissiveTexture is specified, this value is multiplied with the texel values."
+            "gltf_detailedDescription": "The RGB components of the emissive color of the material. These values are linear. If an emissiveTexture is specified, this value is multiplied with the texel values."
         },
         "alphaMode": {
             "default": "OPAQUE",


### PR DESCRIPTION
Copied this note from the `emissiveFactor` to the other factors:

>  If an emissiveTexture is specified, this value is multiplied with the texel values.

Feel free to edit the wording.