### PR TITLE
Move enum long descriptions to per-value fields.

### DIFF
--- a/specification/2.0/schema/animation.sampler.schema.json
+++ b/specification/2.0/schema/animation.sampler.schema.json
@@ -13,19 +13,23 @@
         "interpolation": {
             "description": "Interpolation algorithm.",
             "default": "LINEAR",
-            "gltf_detailedDescription": "Interpolation algorithm. When an animation targets a node's rotation, and the animation's interpolation is `\"LINEAR\"`, spherical linear interpolation (slerp) should be used to interpolate quaternions. When interpolation is `\"STEP\"`, animated value remains constant to the value of the first point of the timeframe, until the next timeframe. When interpolation is `\"CATMULLROMSPLINE\"`, the animation's interpolation is computed using a uniform Catmull-Rom spline. When interpolation is `\"CUBICSPLINE\"`, the animation's interpolation is computed using a cubic spline with specified tangents. For each input value, the output stores three values: in-tangent, spline vertex, and out-tangent.",
+            "gltf_detailedDescription": "Interpolation algorithm.",
             "anyOf": [
                 {
-                    "enum": [ "LINEAR" ]
+                    "enum": [ "LINEAR" ],
+                    "description": "When an animation targets a node's rotation, spherical linear interpolation (slerp) should be used to interpolate quaternions."
                 },
                 {
-                    "enum": [ "STEP" ]
+                    "enum": [ "STEP" ],
+                    "description": "The animated value remains constant to the value of the first point of the timeframe, until the next timeframe."
                 },
                 {
-                    "enum": [ "CATMULLROMSPLINE" ]
+                    "enum": [ "CATMULLROMSPLINE" ],
+                    "description": "The animation's interpolation is computed using a uniform Catmull-Rom spline."
                 },
                 {
-                    "enum": [ "CUBICSPLINE" ]
+                    "enum": [ "CUBICSPLINE" ],
+                    "description": "The animation's interpolation is computed using a cubic spline with specified tangents. For each input value, the output stores three values: in-tangent, spline vertex, and out-tangent."
                 },
                 {
                     "type": "string"

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -43,16 +43,19 @@
         "alphaMode": {
             "default": "OPAQUE",
             "description": "The alpha rendering mode of the material.",
-            "gltf_detailedDescription": "The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture. In `OPAQUE` mode, the alpha value is ignored and the rendered output is fully opaque. In `MASK` mode, the rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value. In `BLEND` mode, the alpha value is used to composite the source and destination areas. The rendered output is combined with the background using the normal painting operation (i.e. the Porter and Duff over operator).",
+            "gltf_detailedDescription": "The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.",
             "anyOf": [
                 {
-                    "enum": [ "OPAQUE" ]
+                    "enum": [ "OPAQUE" ],
+                    "description": "The alpha value is ignored and the rendered output is fully opaque."
                 },
                 {
-                    "enum": [ "MASK" ]
+                    "enum": [ "MASK" ],
+                    "description": "The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value."
                 },
                 {
-                    "enum": [ "BLEND" ]
+                    "enum": [ "BLEND" ],
+                    "description": "The alpha value is used to composite the source and destination areas. The rendered output is combined with the background using the normal painting operation (i.e. the Porter and Duff over operator)."
                 },
                 {
                     "type": "string"


### PR DESCRIPTION
Wetzel can handle this now as of AnalyticalGraphicsInc/wetzel#18.

---
Current version:

### animation sampler.interpolation

Interpolation algorithm. When an animation targets a node's rotation, and the animation's interpolation is `"LINEAR"`, spherical linear interpolation (slerp) should be used to interpolate quaternions. When interpolation is `"STEP"`, animated value remains constant to the value of the first point of the timeframe, until the next timeframe. When interpolation is `"CATMULLROMSPLINE"`, the animation's interpolation is computed using a uniform Catmull-Rom spline. When interpolation is `"CUBICSPLINE"`, the animation's interpolation is computed using a cubic spline with specified tangents. For each input value, the output stores three values: in-tangent, spline vertex, and out-tangent.

* **Type**: `string`
* **Required**: No, default: `"LINEAR"`
* **Allowed values**:
   * `"LINEAR"`
   * `"STEP"`
   * `"CATMULLROMSPLINE"`
   * `"CUBICSPLINE"`

### material.alphaMode

The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture. In `OPAQUE` mode, the alpha value is ignored and the rendered output is fully opaque. In `MASK` mode, the rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value. In `BLEND` mode, the alpha value is used to composite the source and destination areas. The rendered output is combined with the background using the normal painting operation (i.e. the Porter and Duff over operator).

* **Type**: `string`
* **Required**: No, default: `"OPAQUE"`
* **Allowed values**:
   * `"OPAQUE"`
   * `"MASK"`
   * `"BLEND"`

---
New version:

### animation sampler.interpolation

Interpolation algorithm.

* **Type**: `string`
* **Required**: No, default: `"LINEAR"`
* **Allowed values**:
   * `"LINEAR"` When an animation targets a node's rotation, spherical linear interpolation (slerp) should be used to interpolate quaternions.
   * `"STEP"` The animated value remains constant to the value of the first point of the timeframe, until the next timeframe.
   * `"CATMULLROMSPLINE"` The animation's interpolation is computed using a uniform Catmull-Rom spline.
   * `"CUBICSPLINE"` The animation's interpolation is computed using a cubic spline with specified tangents. For each input value, the output stores three values: in-tangent, spline vertex, and out-tangent.

### material.alphaMode

The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.

* **Type**: `string`
* **Required**: No, default: `"OPAQUE"`
* **Allowed values**:
   * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
   * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
   * `"BLEND"` The alpha value is used to composite the source and destination areas. The rendered output is combined with the background using the normal painting operation (i.e. the Porter and Duff over operator).

