### PR TITLE
Soft enforcement of unit quaternions for node.rotation

### DIFF
--- a/specification/2.0/schema/node.schema.json
+++ b/specification/2.0/schema/node.schema.json
@@ -42,7 +42,9 @@
             "type": "array",
             "description": "The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.",
             "items": {
-                "type": "number"
+                "type": "number",
+                "minimum": -1.0,
+                "maximum": 1.0
             },
             "minItems": 4,
             "maxItems": 4,


### PR DESCRIPTION
Sadly, we can't check quaternion's length with schema, but it's still better than nothing.