### PR TITLE
Cleanup links for gltf 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ glTF™ (GL Transmission Format) is a royalty-free specification for the efficie
 
 ## Specification
 
-* [glTF Specification, 1.1](specification/1.1/README.md) (or [all specification versions](specification/README.md))
+* [glTF Specification, 2.0](specification/2.0/README.md) (or [all specification versions](specification/README.md))
 * [glTF Extension Registry](extensions/README.md)
 
 Please provide feedback by submitting [issues](https://github.com/KhronosGroup/glTF/issues).
@@ -15,12 +15,6 @@ Please provide feedback by submitting [issues](https://github.com/KhronosGroup/g
 
 [Sample models](https://github.com/KhronosGroup/glTF-Sample-Models) for learning glTF, and testing runtime engines and content pipeline tools.
 
-## Overview
-
-<p align="center">
-<a href="specification/1.0/figures/gltfOverview-0.2.0.png"><img src="specification/1.0/figures/gltfOverview-0.2.0-small.png" /></a>
-</p>
-Diagram by [Marco Hutter](http://marco-hutter.de/) ([repo](https://github.com/javagl/gltfOverview)).
 
 ## glTF Tools
 

--- a/extensions/Khronos/KHR_binary_glTF/README.md
+++ b/extensions/Khronos/KHR_binary_glTF/README.md
@@ -14,7 +14,7 @@ Complete
 
 ## Dependencies
 
-Written against the glTF 1.0 spec.
+Written against the glTF 1.0 spec. This extension is no longer needed in glTF 2.0 as glTF 2.0 includes [GLB File Format Specification](/specification/2.0/README.md#glb-file-format-specification).
 
 ## Overview
 

--- a/extensions/Khronos/KHR_materials_pbrSpecularGlossiness/README.md
+++ b/extensions/Khronos/KHR_materials_pbrSpecularGlossiness/README.md
@@ -16,7 +16,7 @@
 
 ## Status
 
-Draft 
+Complete 
 
 ## Dependencies
 
@@ -76,7 +76,7 @@ The following equations show how to calculate bidirectional reflectance distribu
 <br>
 *&alpha;* = `(1 - glossiness) ^ 2`
 
-All implementations should use the same calculations for the BRDF inputs. Implementations of the BRDF itself can vary based on device performance and resource constraints. See [appendix](/specification/2.0/README.md#appendix-a) for more details on the BRDF calculations.
+All implementations should use the same calculations for the BRDF inputs. Implementations of the BRDF itself can vary based on device performance and resource constraints. See [appendix](/specification/2.0/README.md#appendix-b-brdf-implementation) for more details on the BRDF calculations.
 
 The following table lists the allowed types and ranges for the specular-glossiness model:
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,14 +1,19 @@
 # glTF Extension Registry
 
-## Khronos extensions
+## Extensions for glTF 2.0
 
-* [KHR_binary_glTF](Khronos/KHR_binary_glTF/README.md)
+#### Khronos extensions
+* [KHR_materials_pbrSpecularGlossiness](Khronos/KHR_materials_pbrSpecularGlossiness/README.md)
 
-## Draft Khronos extensions
-
+#### Draft Khronos extensions
 _Draft Khronos extensions are not ratified yet._
+* [KHR_materials_common](Khronos/KHR_materials_common/README.md)
+* [KHR_technique_webgl](Khronos/KHR_technique_webgl/README.md)
 
-* [KHR_materials_common](Khronos/KHR_materials_common)
+## Extensions for glTF 1.0
+
+#### Khronos extensions
+* [KHR_binary_glTF](Khronos/KHR_binary_glTF/README.md)
 
 ## Vendor extensions
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -15,7 +15,7 @@ _Draft Khronos extensions are not ratified yet._
 #### Khronos extensions
 * [KHR_binary_glTF](Khronos/KHR_binary_glTF/README.md)
 
-## Vendor extensions
+#### Vendor extensions
 
 * [CESIUM_RTC](Vendor/CESIUM_RTC/README.md)
 * [WEB3D_quantized_attributes](Vendor/WEB3D_quantized_attributes/README.md)

--- a/specification/README.md
+++ b/specification/README.md
@@ -8,3 +8,10 @@ glTF registry contains base specifications; specifications of Khronos- and vendo
 
 ## glTF Extensions
 [glTF Extension Registry](../extensions)
+
+## glTF 1.0 overview
+
+<p align="center">
+<a href="1.0/figures/gltfOverview-0.2.0.png"><img src="1.0/figures/gltfOverview-0.2.0-small.png" /></a>
+</p>
+Diagram by [Marco Hutter](http://marco-hutter.de/) ([repo](https://github.com/javagl/gltfOverview)).


### PR DESCRIPTION
1) Fix link to 2.0 spec on landing page
2) Move overview image from landing page to spec links page since its 1.0 specific
3) Update extension registry and fix links to individual extension specs
4) Mark specgloss extension as complete
5) Add note to binary extension that it is only needed in gltf 1.0
