### PR TITLE
Add note about zero xmag/ymag

### DIFF
--- a/specification/2.0/schema/camera.orthographic.schema.json
+++ b/specification/2.0/schema/camera.orthographic.schema.json
@@ -7,11 +7,11 @@
     "properties": {
         "xmag": {
             "type": "number",
-            "description": "The floating-point horizontal magnification of the view."
+            "description": "The floating-point horizontal magnification of the view. Must not be zero."
         },
         "ymag": {
             "type": "number",
-            "description": "The floating-point vertical magnification of the view."
+            "description": "The floating-point vertical magnification of the view. Must not be zero."
         },
         "zfar": {
             "type": "number",


### PR DESCRIPTION
We can't disallow such case with schema, but it's worth noting.