### PR TITLE
First attempt at normalizing schema titles with unique hierarchical values.

### DIFF
--- a/specification/2.0/schema/accessor.schema.json
+++ b/specification/2.0/schema/accessor.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "accessor",
+    "title": "Accessor",
     "type": "object",
     "description": "A typed view into a bufferView.  A bufferView contains raw binary data.  An accessor provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/accessor.sparse.indices.schema.json
+++ b/specification/2.0/schema/accessor.sparse.indices.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "indices",
+    "title": "Accessor Sparse Indices",
     "type": "object",
     "description": "Indices of those attributes that deviate from their initialization value.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/accessor.sparse.schema.json
+++ b/specification/2.0/schema/accessor.sparse.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "sparse",
+    "title": "Accessor Sparse",
     "type": "object",
     "description": "Sparse storage of attributes that deviate from their initialization value.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/accessor.sparse.values.schema.json
+++ b/specification/2.0/schema/accessor.sparse.values.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "values",
+    "title": "Accessor Sparse Values",
     "type": "object",
     "description": "Array of size `accessor.sparse.count` times number of components storing the displaced accessor attributes pointed by `accessor.sparse.indices`.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.channel.schema.json
+++ b/specification/2.0/schema/animation.channel.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "channel",
+    "title": "Animation Channel",
     "type": "object",
     "description": "Targets an animation's sampler at a node's property.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.channel.target.schema.json
+++ b/specification/2.0/schema/animation.channel.target.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "target",
+    "title": "Animation Channel Target",
     "type": "object",
     "description": "The index of the node and TRS property that an animation channel targets.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.sampler.schema.json
+++ b/specification/2.0/schema/animation.sampler.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "sampler",
+    "title": "Animation Sampler",
     "type": "object",
     "description": "Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.schema.json
+++ b/specification/2.0/schema/animation.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "animation",
+    "title": "Animation",
     "type": "object",
     "description": "A keyframe animation.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/asset.schema.json
+++ b/specification/2.0/schema/asset.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "asset",
+    "title": "Asset",
     "type": "object",
     "description": "Metadata about the glTF asset.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/buffer.schema.json
+++ b/specification/2.0/schema/buffer.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "buffer",
+    "title": "Buffer",
     "type": "object",
     "description": "A buffer points to binary geometry, animation, or skins.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/bufferView.schema.json
+++ b/specification/2.0/schema/bufferView.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "bufferView",
+    "title": "Buffer View",
     "type": "object",
     "description": "A view into a buffer generally representing a subset of the buffer.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/camera.orthographic.schema.json
+++ b/specification/2.0/schema/camera.orthographic.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "orthographic",
+    "title": "Camera Orthographic",
     "type": "object",
     "description": "An orthographic camera containing properties to create an orthographic projection matrix.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/camera.perspective.schema.json
+++ b/specification/2.0/schema/camera.perspective.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "perspective",
+    "title": "Camera Perspective",
     "type": "object",
     "description": "A perspective camera containing properties to create a perspective projection matrix.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/camera.schema.json
+++ b/specification/2.0/schema/camera.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "camera",
+    "title": "Camera",
     "type": "object",
     "description": "A camera's projection.  A node can reference a camera to apply a transform to place the camera in the scene.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/extension.schema.json
+++ b/specification/2.0/schema/extension.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "extension",
+    "title": "Extension",
     "type": "object",
     "description": "Dictionary object with extension-specific objects.",
     "properties": {

--- a/specification/2.0/schema/extras.schema.json
+++ b/specification/2.0/schema/extras.schema.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "extras",
+    "title": "Extras",
     "description": "Application-specific data."
 }

--- a/specification/2.0/schema/glTFChildOfRootProperty.schema.json
+++ b/specification/2.0/schema/glTFChildOfRootProperty.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Child of a glTF root property",
+    "title": "glTF Child of Root Property",
     "type": "object",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {

--- a/specification/2.0/schema/glTFProperty.schema.json
+++ b/specification/2.0/schema/glTFProperty.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "glTF property",
+    "title": "glTF Property",
     "type": "object",
     "properties": {
         "extensions": {

--- a/specification/2.0/schema/glTFid.schema.json
+++ b/specification/2.0/schema/glTFid.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "glTF element index",
+    "title": "glTF Id",
     "type": "integer",
     "minimum": 0
 }

--- a/specification/2.0/schema/image.schema.json
+++ b/specification/2.0/schema/image.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "image",
+    "title": "Image",
     "type": "object",
     "description": "Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/material.normalTextureInfo.schema.json
+++ b/specification/2.0/schema/material.normalTextureInfo.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "normalTextureInfo",
+    "title": "Material Normal Texture Info",
     "type": "object",
     "allOf": [ { "$ref": "textureInfo.schema.json" } ],
     "properties": {

--- a/specification/2.0/schema/material.occlusionTextureInfo.schema.json
+++ b/specification/2.0/schema/material.occlusionTextureInfo.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "occlusionTextureInfo",
+    "title": "Material Occlusion Texture Info",
     "type": "object",
     "allOf": [ { "$ref": "textureInfo.schema.json" } ],
     "properties": {

--- a/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
+++ b/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "pbrMetallicRoughness",
+    "title": "Material PBR Metallic Roughness",
     "type": "object",
     "description": "A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "material",
+    "title": "Material",
     "type": "object",
     "description": "The material appearance of a primitive.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/mesh.primitive.schema.json
+++ b/specification/2.0/schema/mesh.primitive.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "primitive",
+    "title": "Mesh Primitive",
     "type": "object",
     "description": "Geometry to be rendered with the given material.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/mesh.schema.json
+++ b/specification/2.0/schema/mesh.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "mesh",
+    "title": "Mesh",
     "type": "object",
     "description": "A set of primitives to be rendered.  A node can contain one mesh.  A node's transform places the mesh in the scene.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/node.schema.json
+++ b/specification/2.0/schema/node.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "node",
+    "title": "Node",
     "type": "object",
     "description": "A node in the node hierarchy.  When the node contains `skin`, all `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/sampler.schema.json
+++ b/specification/2.0/schema/sampler.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "sampler",
+    "title": "Sampler",
     "type": "object",
     "description": "Texture sampler properties for filtering and wrapping modes.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/scene.schema.json
+++ b/specification/2.0/schema/scene.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "scene",
+    "title": "Scene",
     "type": "object",
     "description": "The root nodes of a scene.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/skin.schema.json
+++ b/specification/2.0/schema/skin.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "skin",
+    "title": "Skin",
     "type": "object",
     "description": "Joints and matrices defining a skin.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/texture.schema.json
+++ b/specification/2.0/schema/texture.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "texture",
+    "title": "Texture",
     "type": "object",
     "description": "A texture and its sampler.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/textureInfo.schema.json
+++ b/specification/2.0/schema/textureInfo.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "textureInfo",
+    "title": "Texture Info",
     "type": "object",
     "description": "Reference to a texture.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],


### PR DESCRIPTION
Both the C# Loader and Wetzel expect the schema titles to be unique. Making them hierarchical is an easy way to achive that, but includes redundant data with the file name. Any solution that makes then unique and descriptive is acceptable. This is my first attempt.

@lexaknyazev 
@bghgary 
@pjcozzi 