### PR TITLE
Extension: Static lightmap textures

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -10,6 +10,9 @@ _Draft Khronos extensions are not ratified yet._
 * [KHR_materials_common](Khronos/KHR_materials_common/README.md)
 * [KHR_technique_webgl](Khronos/KHR_technique_webgl/README.md)
 
+#### Vendor extensions
+* [AVR_lights_static](Vendor/AVR_lights_static/README.md)
+
 ## Extensions for glTF 1.0
 
 #### Khronos extensions
@@ -22,7 +25,7 @@ _Draft Khronos extensions are not ratified yet._
 
 # About glTF Extensions
 
-glTF extensions extend the base glTF model format.  Extensions can introduce new properties (including properties that reference external data, and the extension can define the format of those data), new parameter semantics, reserved IDs, and new container formats.  Extensions are written against a specific version of glTF and may be promoted to core glTF in a later glTF version. 
+glTF extensions extend the base glTF model format.  Extensions can introduce new properties (including properties that reference external data, and the extension can define the format of those data), new parameter semantics, reserved IDs, and new container formats.  Extensions are written against a specific version of glTF and may be promoted to core glTF in a later glTF version.
 
 ## Extension Mechanics
 

--- a/extensions/Vendor/AVR_lights_static/README.md
+++ b/extensions/Vendor/AVR_lights_static/README.md
@@ -26,7 +26,7 @@ The `AVR_lights_static` extension may be defined on `material` structures. It ma
 
 | Name       | Type      | Default    | Description
 |------------|-----------|------------|---------------------------------
-| `index`    | `glTFid`  | *required* | Texture reference to a lightmap.
+| `index`    | `glTFid`  | *required* | Texture reference to a lightmap. The referenced texture contains RGB components in sRGB color space. If a fourth component (A) is present, it is ignored.
 | `texCoord` | `integer` | `0`        | The set index of texture's TEXCOORD attribute used for texture coordinate mapping.
 | `strength` | `number`  | `1.0`      | The influence of the lightmap on the final output.
 

--- a/extensions/Vendor/AVR_lights_static/README.md
+++ b/extensions/Vendor/AVR_lights_static/README.md
@@ -10,7 +10,7 @@ Draft
 
 ## Dependencies
 
-Written against the glTF 2.0 spec.
+Written against the glTF 2.0 spec, and the draft [AVR_texture_offset_tile](../AVR_texture_offset_tile/README.md) extension.
 
 ## Overview
 
@@ -22,13 +22,16 @@ This extension allows glTF materials to provide one of these precomputed texture
 
 ## glTF Schema Updates
 
-The `AVR_lights_static` extension may be defined on `material` structures. It may contain the following properties:
+The `AVR_lights_static` extension may be defined on `node` structures. This data is specified on the node instead of the material or texture because every node with a lightmap is going to need a separate texture from an otherwise identical but differently-placed node.
 
-| Name       | Type      | Default    | Description
-|------------|-----------|------------|---------------------------------
-| `index`    | `glTFid`  | *required* | Texture reference to a lightmap. The referenced texture contains RGB components in sRGB color space. If a fourth component (A) is present, it is ignored.
-| `texCoord` | `integer` | `0`        | The set index of texture's TEXCOORD attribute used for texture coordinate mapping.
-| `strength` | `number`  | `1.0`      | The influence of the lightmap on the final output.
+The extension object may contain the following properties:
+
+| Name         | Type      | Default    | Description
+|--------------|-----------|------------|---------------------------------
+| `index`      | `glTFid`  | *required* | Texture reference to a lightmap. The referenced texture contains RGB components in sRGB color space. If a fourth component (A) is present, it is ignored.
+| `texCoord`   | `integer` | `0`        | The set index of texture's TEXCOORD attribute used for texture coordinate mapping.
+| `strength`   | `number`  | `1.0`      | The influence of the lightmap on the final output.
+| `extensions` | `object`  |            | If desired, use the `AVR_texture_offset_tile` extension to use a texture atlas as a lightmap.
 
 ### JSON Schema
 

--- a/extensions/Vendor/AVR_lights_static/README.md
+++ b/extensions/Vendor/AVR_lights_static/README.md
@@ -1,0 +1,33 @@
+# AVR_lights_static
+
+## Contributors
+
+* Steven Vergenz, AltspaceVR ([steven@altvr.com](mailto:steven@altvr.com))
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec, and the draft [AVR_sampler_offset_tile](../AVR_sampler_offset_tile/README.md) extension.
+
+## Overview
+
+As a performance optimization, many game engines support computing ("baking") certain lighting information in advance, and storing it to a texture for use at runtime.
+
+## glTF Schema Updates
+
+TODO
+
+### JSON Schema
+
+TODO: Links to the JSON schema for the new extension properties.
+
+## Known Implementations
+
+* TODO: List of known implementations, with links to each if available.
+
+## Resources
+
+* TODO: Resources, if any.

--- a/extensions/Vendor/AVR_lights_static/README.md
+++ b/extensions/Vendor/AVR_lights_static/README.md
@@ -10,24 +10,34 @@ Draft
 
 ## Dependencies
 
-Written against the glTF 2.0 spec, and the draft [AVR_sampler_offset_tile](../AVR_sampler_offset_tile/README.md) extension.
+Written against the glTF 2.0 spec.
 
 ## Overview
 
-As a performance optimization, many game engines support computing ("baking") certain lighting information in advance, and storing it to a texture for use at runtime.
+As a performance optimization, many game engines support computing ("baking") certain lighting information in advance, and storing it to a texture ("lightmap") for use at runtime. This has the advantage of not only reducing the computational load of rendering the scene, but it also allows the use of more accurate lighting simulations that would normally not be possible, like raytracing. In practice, this is usually used for global illumination. This is where light is virtually bounced around the scene before being recorded, producing realistic shadows and diffuse reflections that are hard to produce with standard realtime techniques.
+
+However, this approach is not always applicable. The downside of precomputing your lighting is that changes to an object's position or material will not be reflected in the lighting on the rest of the scene. So if you move an object, the shadow it cast would stay in place. For this reason, this technique is also called "static" lighting, because it cannot change without rebaking.
+
+This extension allows glTF materials to provide one of these precomputed textures to a consuming application, providing greater realism for a reduced computational cost. The details of how this lightmap is applied will depend on the lighting model in use by the consumer.
 
 ## glTF Schema Updates
 
-TODO
+The `AVR_lights_static` extension may be defined on `material` structures. It may contain the following properties:
+
+| Name       | Type      | Default    | Description
+|------------|-----------|------------|---------------------------------
+| `index`    | `glTFid`  | *required* | Texture reference to a lightmap.
+| `texCoord` | `integer` | `0`        | The set index of texture's TEXCOORD attribute used for texture coordinate mapping.
+| `strength` | `number`  | `1.0`      | The influence of the lightmap on the final output.
 
 ### JSON Schema
 
-TODO: Links to the JSON schema for the new extension properties.
+[AVR_lights_static.lightmapTextureInfo.schema.json](schema/AVR_lights_static.lightmapTextureInfo.schema.json)
 
 ## Known Implementations
 
-* TODO: List of known implementations, with links to each if available.
+* [UnityGLTF](https://github.com/AltspaceVR/UnityGLTF) (upcoming)
 
 ## Resources
 
-* TODO: Resources, if any.
+* [Explanation of Unity 5's GI formula](http://www.shadercat.com/how-to-explore-unity-5s-shader-system-code-iv-global-illumination-code-overview/)

--- a/extensions/Vendor/AVR_lights_static/schema/AVR_lights_static.lightmapTextureInfo.schema.json
+++ b/extensions/Vendor/AVR_lights_static/schema/AVR_lights_static.lightmapTextureInfo.schema.json
@@ -2,10 +2,9 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "lightmapTextureInfo",
     "type": "object",
+    "description": "This extension allows glTF materials to provide one of these precomputed textures to a consuming application, providing greater realism for a reduced computational cost. The details of how this lightmap is applied will depend on the lighting model in use by the consumer.",
     "allOf": [ { "$ref": "textureInfo.schema.json" } ],
     "properties": {
-        "index": { },
-        "texCoord": { },
         "strength": {
             "type": "number",
             "description": "A scalar multiplier controlling the amount of light applied from the lightmap.",

--- a/extensions/Vendor/AVR_lights_static/schema/AVR_lights_static.lightmapTextureInfo.schema.json
+++ b/extensions/Vendor/AVR_lights_static/schema/AVR_lights_static.lightmapTextureInfo.schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "lightmapTextureInfo",
+    "type": "object",
+    "allOf": [ { "$ref": "textureInfo.schema.json" } ],
+    "properties": {
+        "index": { },
+        "texCoord": { },
+        "strength": {
+            "type": "number",
+            "description": "A scalar multiplier controlling the amount of light applied from the lightmap.",
+            "default": 1.0,
+            "minimum": 0.0,
+            "maximum": 1.0
+        }
+    }
+}


### PR DESCRIPTION
An initial pass on an extension to provide precomputed lighting and global illumination to glTF materials. I'm going to attempt to implement this in the UnityGLTF project, but I want to run it by this group too. Thoughts?