### PR TITLE
Enforce extension lists dependency

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -1455,6 +1455,8 @@ All glTF extensions required to load and/or render an asset must be listed in th
 }
 ```
 
+`extensionsRequired` is a subset of `extensionsUsed`. All values in `extensionsRequired` must also exist in `extensionsUsed`.
+
 For more information on glTF extensions, consult the [extensions registry specification](../../extensions/README.md).
 
 # GLB File Format Specification


### PR DESCRIPTION
From [Specifying Extensions](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#specifying-extensions):
> All extensions used in a glTF asset must be listed in the top-level `extensionsUsed` array object...

> All glTF extensions required to load and/or render an asset must be listed in the top-level `extensionsRequired` array...

That implies, that all required extensions must also be listed in `extensionsUsed` array. However, schema allows `extensionsRequired` without `extensionsUsed`. This PR aligns schema with spec. 

@bghgary Please check whether such update is possible.