### PR TITLE
KHR_materials_cmnConstant

### DIFF
--- a/extensions/Khronos/KHR_materials_cmnConstant/README.md
+++ b/extensions/Khronos/KHR_materials_cmnConstant/README.md
@@ -14,36 +14,23 @@ Written against the glTF 2.0 spec.
 
 ## Overview
 
-This extension defines an unlit ("constant") model based material for use with glTF 2.0 in the same way as the core specification defines Physically Based Rendering (PBR) based materials. Other extension may define additional commonly used materials. 
-
-In mobile devices with limited resources, unlit materials remain a performant alternative to higher-quality shading models.
+This extension defines an unlit ("constant") model based material for use with glTF 2.0 in the same way as the core specification defines Physically Based Rendering (PBR) based materials. In mobile devices with limited resources, unlit materials offer a performant alternative to higher-quality shading models.
 
 This extension defines a single material type, Constant.
 
 ## Extending Materials
 
-The common Constant material is defined by adding the `KHR_materials_cmnConstant` extension to any glTF material. 
-For example, the following defines a material having all possible parameters:
+The common Constant material is defined by adding the `KHR_materials_cmnConstant` extension to any glTF material. When present, the extension indicates that a material should use the Constant shading model. Unrelated default values in the default PBR shading model, such as `diffuseFactor`, should be ignored.
 
 ```
 {
     "materials": [
         {
-            "name": "CustomEmissive",
+            "name": "MyUnlitMaterial",
+            "emissiveFactor": [ 0.2, 0.1, 0.0 ],
             "extensions": {
-                "KHR_materials_cmnConstant": {
-                    "emissionFactor" : [
-                        0.8, 
-                        0.8, 
-                        0.8, 
-                        1.0
-                    ],
-                    "emissionTexture" : {
-                        "index" : 0
-                    }
-                }
+                "KHR_materials_cmnConstant": {}
             }
-
         }
     ]
 }
@@ -51,25 +38,21 @@ For example, the following defines a material having all possible parameters:
 
 ### Constant
 
-The Constant material model describes a constantly shaded surface that is independent of lighting. The material is defined by the following properties:
+The Constant material model describes a constantly shaded surface that is independent of lighting. The material is defined only by properties already
+present in the [glTF 2.0 material specification](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#material): no new properties are added by this extension.
 
-* `emission` - Emitted color of the material
-
-The following table lists the allowed types and ranges for the constant model:
-
-|                    |Type         |Description|Required|
-|--------------------|-------------|-----------|--------|
-|**emissionFactor**  | `number[4]` | The emissive RGBA factor of the material. | No, default: `[1.0,1.0,1.0,1.0]` |
-|**emissionTexture** | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo) | The emissive texture. | No |
-
-Additional properties are allowed and may lead to undefined behaviour in conforming viewers.
+Additional properties are allowed, but may lead to undefined behaviour in conforming viewers.
 
 The material is intended for unlit shading. Color is calculated as:
 
 ```
-color = <emission> + <ambient> * al
+color = <emissiveTerm> + <occlusionTerm> * <ambientLight>
 ```
 
 where
 
-* `al` – A constant amount of ambient light contribution coming from the scene, i.e. the sum of all ambient light values.
+* `emissiveTerm` – emissiveFactor * emissiveTexture
+* `occlusionTerm` – occlusionFactor * occlusionTexture
+* `ambientLight` – A constant amount of ambient light contribution coming from the scene, i.e. the sum of all ambient light values.
+
+> **Implementation Note**: The Constant material model can also be emulated by setting specific factors to `0` in Blinn-Phong or Lambert shaders. Viewers may optionally take advantage of this to reduce the number of materials they maintain.

--- a/extensions/Khronos/KHR_materials_cmnConstant/README.md
+++ b/extensions/Khronos/KHR_materials_cmnConstant/README.md
@@ -1,0 +1,75 @@
+# KHR\_materials\_cmnConstant
+
+## Contributors
+
+* Don McCurdy, Google, <mailto:donmccurdy@google.com>
+
+## Status
+
+Draft (not ratified yet)
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension defines an unlit ("constant") model based material for use with glTF 2.0 in the same way as the core specification defines Physically Based Rendering (PBR) based materials. Other extension may define additional commonly used materials. 
+
+In mobile devices with limited resources, unlit materials remain a performant alternative to higher-quality shading models.
+
+This extension defines a single material type, Constant.
+
+## Extending Materials
+
+The common Constant material is defined by adding the `KHR_materials_cmnConstant` extension to any glTF material. 
+For example, the following defines a material having all possible parameters:
+
+```
+{
+    "materials": [
+        {
+            "name": "CustomEmissive",
+            "extensions": {
+                "KHR_materials_cmnConstant": {
+                    "emissionFactor" : [
+                        0.8, 
+                        0.8, 
+                        0.8, 
+                        1.0
+                    ],
+                    "emissionTexture" : {
+                        "index" : 0
+                    }
+                }
+            }
+
+        }
+    ]
+}
+```
+
+### Constant
+
+The Constant material model describes a constantly shaded surface that is independent of lighting. The material is defined by the following properties:
+
+* `emission` - Emitted color of the material
+
+The following table lists the allowed types and ranges for the constant model:
+
+|                    |Type         |Description|Required|
+|--------------------|-------------|-----------|--------|
+|**emissionFactor**  | `number[4]` | The emissive RGBA factor of the material. | No, default: `[1.0,1.0,1.0,1.0]` |
+|**emissionTexture** | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo) | The emissive texture. | No |
+
+Additional properties are allowed and may lead to undefined behaviour in conforming viewers.
+
+The material is intended for unlit shading. Color is calculated as:
+
+```
+color = <emission> + <ambient> * al
+```
+
+where
+
+* `al` – A constant amount of ambient light contribution coming from the scene, i.e. the sum of all ambient light values.


### PR DESCRIPTION
Based on the syntax of #1075. For mobile devices trying to maintain 90+ FPS, I think it may be worth keeping an unlit shading model available.