### PR TITLE
Add qtek-model-viewer to viewers and debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Preview tools:
 | [BabylonJS Sandbox](https://www.babylonjs.com/sandbox/) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Drag-and-drop online viewer for model preview and debugging, using BabylonJS |
 | [glTF Animation Visualizer](https://bengfarrell.github.io/animation-visualizer/) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Frame-by-frame debugging for glTF animations. |
 | [glTF Viewer](https://gltf-viewer.donmccurdy.com/) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Drag-and-drop viewer (web and [desktop](https://github.com/donmccurdy/three-gltf-viewer#gltf-viewer)) for model preview and debugging, using three.js |
+| [QTEK Model Viewer](https://pissang.github.io/qtek-model-viewer/editor/) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Drag-and-drop glTF2.0 viewer with high quality rendering and PBR material editing.
 
 ### Applications
 


### PR DESCRIPTION
Have been tested on glTF2.0 models from [glTF Sample Models](https://github.com/KhronosGroup/glTF-Sample-Models) and [Sketchfab](https://sketchfab.com/features/gltf)

![editor](https://user-images.githubusercontent.com/841551/32206954-a00e1c22-bdc6-11e7-8130-2b448af3fd80.jpg)
