### PR TITLE
Add ALI extension prefix for Alibaba

### DIFF
--- a/extensions/Prefixes.md
+++ b/extensions/Prefixes.md
@@ -2,6 +2,7 @@
 
 The following extension prefixes are reserved:
 
+* `ALI` - Alibaba
 * `AVR` - AltspaceVR
 * `BLENDER` - Blender
 * `CESIUM` - Cesium


### PR DESCRIPTION
Please add a "vendor extension prefix" for Alibaba.
[Hilo3d](https://github.com/hiloteam/Hilo3d) is a WebGL Rendering Engine developed by Alibaba Group.