### PR TITLE
Update all remaining format:uri to format:uriref, tweak version 1.

### DIFF
--- a/extensions/Khronos/KHR_technique_webgl/schema/shader.schema.json
+++ b/extensions/Khronos/KHR_technique_webgl/schema/shader.schema.json
@@ -8,7 +8,7 @@
         "uri" : {
             "type" : "string",
             "description" : "The uri of the GLSL source.",
-            "format" : "uri",
+            "format" : "uriref",
             "gltf_detailedDescription" : "The uri of the GLSL source.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.",
             "gltf_uriType" : "text"
         },

--- a/specification/1.0/schema/asset.schema.json
+++ b/specification/1.0/schema/asset.schema.json
@@ -27,6 +27,7 @@
         },
         "version" : {
             "type" : "string",
+            "pattern": "^1\\.",
             "description" : "The glTF version."
         }
     },

--- a/specification/1.0/schema/buffer.schema.json
+++ b/specification/1.0/schema/buffer.schema.json
@@ -11,7 +11,7 @@
         "uri" : {
             "type" : "string",
             "description" : "The uri of the buffer.",
-            "format" : "uri",
+            "format" : "uriref",
             "gltf_detailedDescription" : "The uri of the buffer.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.",
             "gltf_uriType" : "application"
         },

--- a/specification/1.0/schema/image.schema.json
+++ b/specification/1.0/schema/image.schema.json
@@ -11,7 +11,7 @@
         "uri" : {
             "type" : "string",
             "description" : "The uri of the image.",
-            "format" : "uri",
+            "format" : "uriref",
             "gltf_detailedDescription" : "The uri of the image.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.  The image format must be jpg, png, bmp, or gif.",
             "gltf_uriType" : "image"
         }

--- a/specification/1.0/schema/shader.schema.json
+++ b/specification/1.0/schema/shader.schema.json
@@ -11,7 +11,7 @@
         "uri" : {
             "type" : "string",
             "description" : "The uri of the GLSL source.",
-            "format" : "uri",
+            "format" : "uriref",
             "gltf_detailedDescription" : "The uri of the GLSL source.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.",
             "gltf_uriType" : "text"
         },


### PR DESCRIPTION
Following the example set in glTF 2.0 by #838, this updates old glTF 1.0 URI formats from `uri` to `uriref`.  The same is done for `KHR_technique_webgl` for the same reason.

Additionally, the glTF 1.0 `asset.version` has gained a regex pattern-match such that it must begin with `1.`.  This is to make the schema "not match" any later versions.

Fixes #1149

/cc @lexaknyazev 