### PR TITLE
Updated mime type for binary buffer 

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -164,7 +164,7 @@ Major version updates are not expected to be compatible with previous versions.
 ## File Extensions and MIME Types
 
 * `*.gltf` files use `model/gltf+json`
-* `*.bin` files use `application/octet-stream`
+* `*.bin` files use `application/gltf-buffer`
 * Texture files use the official `image/*` type based on the specific image format. For compatibility with modern web browsers, the following image formats are supported: `image/jpeg`, `image/png`.
 
 ## JSON encoding


### PR DESCRIPTION
The registration request is still pending with IANA but getting the PR started for issue #944 

In addition to switching to a specific MIME type do we also want to change the recommended extension (.bin) to something else?
My current thinking is rather than creating a new extension we can keep the recommended extension to .bin but add an implementation note that the implementations could chose to have a different extension if they wanted. This would essentially mean any glTF loader should not explicitly check for a .bin extension and simply load whatever filename the buffer uri points to.
