### PR TITLE
Remove the max 1.0 restriction on emissiveFactor

### DIFF
--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -31,8 +31,7 @@
             "type": "array",
             "items": {
                 "type": "number",
-                "minimum": 0.0,
-                "maximum": 1.0
+                "minimum": 0.0
             },
             "minItems": 3,
             "maxItems": 3,


### PR DESCRIPTION
Fixes #1083 

I came across a model using 1.5 for the `emissiveFactor`, seems to work fine in the JS engines I normally test (Cesium, Babylon, ThreeJS).

Note however, Windows 10's apps (I tested Paint 3D, Mixed Reality Viewer) are very strict about this value, and will reject models that contain >1.0 emissiveFactor.  Is it OK for us to remove a restriction from the spec like this?

(The model I tested with was "blackvan" from AnalyticalGraphicsInc/gltf-vscode#80).

/cc @bghgary @sbtron 