### PR TITLE
Added jMonkeyEngine to the list of engines supporting glTF

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ To compare WebGL-based glTF loaders, see [gltf-test](https://github.com/cx20/glt
 |------|--------|-------------|
 | [Unity Loader](https://github.com/AltspaceVR/UnityGLTF) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Unity3D library for exporting, loading, parsing, and rendering glTF assets |
 | [Godot Game Engine](https://godotengine.org/) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Godot 3.0 fully supports glTF import |
+| [jMonkeyEngine](http://jmonkeyengine.org/) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | jME 3.2 supports glTF 2.0 |
 
 ### Languages
 


### PR DESCRIPTION
As of today, jMonkeyEngine officially supports gltf2.0
https://github.com/jMonkeyEngine/jmonkeyengine/releases/tag/v3.2.0-stable

So I thought it would be nice it appears in the readme. 