### PR TITLE
Updated Rust Loader link to active repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ To compare WebGL-based glTF loaders, see [gltf-test](https://github.com/cx20/glt
 
 | Tool | Status | Description |
 |------|--------|-------------|
-| [Loader](https://github.com/Alteous/gltf) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | A crate for loading glTF 2.0 |
+| [Loader](https://github.com/gltf-rs/gltf) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | A crate for loading glTF 2.0 |
 | [Viewer](https://github.com/bwasty/gltf-viewer) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | glTF 2.0 Viewer written in Rust |
 
 #### Haxe


### PR DESCRIPTION
Current link is pointing to a fork that hasn't been updated/maintained like the original repo