### PR TITLE
Clean up image files format description

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -121,7 +121,7 @@ glTF assets are JSON files plus supporting external data. Specifically, a glTF a
 
 * A JSON-formatted file (`.gltf`) containing a full scene description: node hierarchy, materials, cameras, as well as descriptor information for meshes, animations, and other constructs
 * Binary files (`.bin`) containing geometry and animation data, and other buffer-based data
-* Image files (`.jpg`, `.png`, etc.) for textures
+* Image files (`.jpg`, `.png`) for textures
 
 Assets defined in other formats, such as images, may be stored in external files referenced via URI, stored side-by-side in GLB container, or embedded directly into the JSON using [data URIs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
 


### PR DESCRIPTION
In [image.uri section](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#imageuri) we see

> The image format must be jpg or png.

then I think I should remove "etc." from

> Image files (.jpg, .png, etc.) for textures

in [glTF Basics section](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#gltf-basics) for the consistency.