### PR TITLE
Clarify the case where image.mimeType is required in Properties Reference section.

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -2454,7 +2454,7 @@ The uri of the image.  Relative paths are relative to the .gltf file.  Instead o
 
 #### image.mimeType
 
-The image's MIME type.
+The image's MIME type. Required if `bufferView` is defined.
 
 * **Type**: `string`
 * **Required**: No


### PR DESCRIPTION
I think it's worth to mention the case where `image.mimeType` is required in Reference section

https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#imagemimetype

as well as

https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#images

----

Another thing (not included in this PR), I suppose adding "if defined" to

> Use this instead of the image's uri property.

in

https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#imagebufferview

would make the sentence clearer.

> Use this instead of the image's uri property if defined.

What do you think?
