### PR TITLE
Add MSFT vendor extensions 

### DIFF
--- a/extensions/2.0/Vendor/MSFT_lod/README.md
+++ b/extensions/2.0/Vendor/MSFT_lod/README.md
@@ -35,11 +35,18 @@ The following example shows how the `MSFT_lod` extension can be specified at the
         "mesh": 0,
         "extensions": {
             "MSFT_lod": {
-                "ids": [ 1, 2]
+                "ids": [
+                    1,
+                    2
+                ]
             }
         },
         "extras": {
-            "MSFT_screencoverage": [0.5, 0.2, 0.01]
+            "MSFT_screencoverage": [
+                0.5,
+                0.2,
+                0.01
+            ]
         }
     },
     {
@@ -77,7 +84,10 @@ A similar pattern can be followed to create `material` LODs:
         },
         "extensions": {
             "MSFT_lod": {
-                "ids": [ 1, 2]
+                "ids": [
+                    1,
+                    2
+                ]
             }
         }
     },

--- a/extensions/2.0/Vendor/MSFT_lod/README.md
+++ b/extensions/2.0/Vendor/MSFT_lod/README.md
@@ -1,0 +1,118 @@
+# MSFT\_lod 
+
+## Contributors
+
+* Saurabh Bhatia, Microsoft
+* Gary Hsu, Microsoft
+* Adam Gritt, Microsoft
+* John Copic, Microsoft 
+* Marc Appelsmeier, Microsoft
+* Dag Frommhold, Microsoft 
+
+## Status
+
+Complete
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension adds the ability to specify various Levels of Detail (LOD) to a glTF asset. An implementation of this extension can use the LODs for various scenarios like rendering a different LOD based upon the distance of the object or progressively loading the glTF asset starting with the lowest LOD. 
+
+This extension allows an LOD to be defined at the geometry `node` or the `material` level. The `node` LODs can specify different geometry and materials across various levels whereas `material` LODs can specify different materials for the same geometry. 
+
+The `MSFT_lod` extension is added to the highest LOD level. The extensions defines an `ids` property which is an array containing the indices of the lower LOD levels. Each value in the array points to a LOD level that is lower in quality than the previous level. For example, if the extension is defined at the `node` level then the `node` object with the extension is the highest LOD level. Every value specified in the `ids` array of the extension points to the index of another `node` object which should be used as the lower LOD level. 
+
+An implementation of this extension can parse through the `ids` array to create the list of LOD levels available for an asset. If an asset containing this extension is loaded in a client that doesnt implement the extension, then the highest LOD level will be loaded and all lower LODs will be ignored. 
+
+The following example shows how the `MSFT_lod` extension can be specified at the `node` level to create three LOD levels:
+```json
+"nodes": [
+        {
+            "name": "High_LOD",
+            "mesh": 0,
+            "extensions": {
+                "MSFT_lod": {
+                     "ids": [ 1, 2 ]
+                }
+            },
+            "extras": {
+                    "MSFT_screencoverage": [ 0.5, 0.2 , 0.01]
+            }
+        },
+        {
+            "name": "Medium_LOD",
+            "mesh": 1
+        },
+        {
+            "name": "Low_LOD",
+            "mesh": 2
+        }
+    ]
+ ```
+ Since the `MSFT_lod` extension is specified in `node[0]`, it becomes the highest LOD. The first element in the `ids` array is *1*, making `node[1]` the next lower LOD (or the *Medium_LOD*). The second element in the `ids` array is *2*, making `node[2]` the lowest LOD for this sample. 
+
+The `MSFT_screencoverage` metadata values specified in `extras` can be used along with the `MSFT_lod` extension as a hint to determine the switching threshold for the various LODs.
+
+In the example above the screen coverage values can be used as follows:
+
+- LOD0 Rendered from 1.0 to 0.5
+- LOD1 Rendered from 0.5 to 0.2
+- LOD2 Rendered from 0.2 to 0.01
+- Nothing rendered from 0.01 – 0
+
+A similar pattern can be followed to create `material` LODs: 
+```json
+"materials": [
+    {
+        "pbrMetallicRoughness": {
+            "baseColorTexture": {
+                "index": 0
+            }
+        },
+        "normalTexture": {
+            "index": 1
+        },
+        "extensions": {
+            "MSFT_lod": {
+                "ids": [1,2]
+            }
+        }
+    },
+    {
+        "pbrMetallicRoughness": {
+            "baseColorTexture": {
+                "index": 2
+            }
+        },
+        "normalTexture": {
+            "index": 3
+        },
+    },
+    {
+        "pbrMetallicRoughness": {
+            "baseColorTexture": {
+                "index": 4
+            }
+        },
+        "normalTexture": {
+            "index": 5
+        },         
+    }
+]
+```
+If both node level and material level LODs are specified then the material level LODs only apply to the specific node LOD that they were defined for. 
+
+## glTF Schema Updates
+
+* **JSON schema**: [glTF.MSFT_lod.schema.json](schema/glTF.MSFT_lod.schema.json)
+
+## Known Implementations
+
+* [glTF-Toolkit](https://github.com/Microsoft/glTF-Toolkit) can take three individual glTF files as input LODs and merge them into a single glTF file which uses the `MSFT_lod` extension. 
+* [BabylonJS](https://github.com/BabylonJS/Babylon.js/tree/master/loaders/src/glTF) has support for `MSFT_lod` extension defined at the material or node level. The current implementation progressively loads each LOD to improve the initial load time of the asset.  
+* Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality use `MSFT_lod` at the `node` level to support switching LODs based on the render distance.
+
+

--- a/extensions/2.0/Vendor/MSFT_lod/README.md
+++ b/extensions/2.0/Vendor/MSFT_lod/README.md
@@ -30,27 +30,27 @@ An implementation of this extension can parse through the `ids` array to create 
 The following example shows how the `MSFT_lod` extension can be specified at the `node` level to create three LOD levels:
 ```json
 "nodes": [
-        {
-            "name": "High_LOD",
-            "mesh": 0,
-            "extensions": {
-                "MSFT_lod": {
-                     "ids": [ 1, 2 ]
-                }
-            },
-            "extras": {
-                    "MSFT_screencoverage": [ 0.5, 0.2 , 0.01]
+    {
+        "name": "High_LOD",
+        "mesh": 0,
+        "extensions": {
+            "MSFT_lod": {
+                "ids": [ 1, 2]
             }
         },
-        {
-            "name": "Medium_LOD",
-            "mesh": 1
-        },
-        {
-            "name": "Low_LOD",
-            "mesh": 2
+        "extras": {
+            "MSFT_screencoverage": [0.5, 0.2, 0.01]
         }
-    ]
+    },
+    {
+        "name": "Medium_LOD",
+        "mesh": 1
+    },
+    {
+        "name": "Low_LOD",
+        "mesh": 2
+    }
+]
  ```
  Since the `MSFT_lod` extension is specified in `node[0]`, it becomes the highest LOD. The first element in the `ids` array is *1*, making `node[1]` the next lower LOD (or the *Medium_LOD*). The second element in the `ids` array is *2*, making `node[2]` the lowest LOD for this sample. 
 
@@ -77,7 +77,7 @@ A similar pattern can be followed to create `material` LODs:
         },
         "extensions": {
             "MSFT_lod": {
-                "ids": [1,2]
+                "ids": [ 1, 2]
             }
         }
     },
@@ -99,7 +99,7 @@ A similar pattern can be followed to create `material` LODs:
         },
         "normalTexture": {
             "index": 5
-        },         
+        },
     }
 ]
 ```

--- a/extensions/2.0/Vendor/MSFT_lod/schema/glTF.MSFT_lod.schema.json
+++ b/extensions/2.0/Vendor/MSFT_lod/schema/glTF.MSFT_lod.schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "MSFT_lod glTF extension",
     "type": "object",
-    "description": "glTF extension for specifying Levels of Detail.",
+    "description": "glTF extension for specifying levels of detail (LOD).",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "ids": {

--- a/extensions/2.0/Vendor/MSFT_lod/schema/glTF.MSFT_lod.schema.json
+++ b/extensions/2.0/Vendor/MSFT_lod/schema/glTF.MSFT_lod.schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "MSFT_lod glTF extension",
+    "type": "object",
+    "description": "glTF extension for specifying Levels of Detail.",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "ids": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            },
+            "description": "Array containing the indices of progressively lower LOD nodes.",
+            "minItems": 1
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}

--- a/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/README.md
+++ b/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/README.md
@@ -20,7 +20,7 @@ Written against the glTF 2.0 spec.
 
 This extension adds support for alternate texture packing and is meant to be used for Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality.
 
-This extension defines an additional property for `normalRoughnessMetallicTexture`. This property specifies the index of a texture with the packing Normal (RG), Roughness  (B), Metallic (A). This specialized packing is meant to provide an optimized alternative to the one specified in the core glTF 2.0 specification. 
+This extension defines an additional property for `normalRoughnessMetallicTexture`. This property specifies the index of a texture with the packing Normal (RG), Roughness (B), Metallic (A). This specialized packing is meant to provide an optimized alternative to the one specified in the core glTF 2.0 specification. 
 
 The extension should only be used when creating glTF assets for engines that support this packing and is not meant to be a general purpose packing extension. Any client that does not support this extension can safely ignore these additional packed texture and rely on the default packing in glTF 2.0. This extension can also be used along with other extensions like [MSFT_texture_dds](../MSFT_texture_dds/README.md) to store the packed textures in DDS files. 
 
@@ -34,8 +34,8 @@ The example below shows how this extension can be used along with the MSFT_textu
                 "baseColorTexture": {
                     "index": 0
                 },
-				"roughnessMetallicTexture": {
-					"index": 1
+                "roughnessMetallicTexture": {
+                    "index": 1
                 }
             },
             "normalTexture": {
@@ -52,24 +52,24 @@ The example below shows how this extension can be used along with the MSFT_textu
     ],
     "textures": [
         {
-            "name":"baseColorTexture",
-            "source":0,
+            "name": "baseColorTexture",
+            "source": 0,
             "extensions": {
                 "MSFT_texture_dds": {
                     "source": 3
                 }
             }
         },
-		{
-            "name":"roughnessMetallicTexture",
-            "source":1
+        {
+            "name": "roughnessMetallicTexture",
+            "source": 1
         },
-		{
-            "name":"normalTexture",
-            "source":2
+        {
+            "name": "normalTexture",
+            "source": 2
         },
-		{
-            "name":"normalRoughnessMetallic",
+        {
+            "name": "normalRoughnessMetallic",
             "extensions": {
                 "MSFT_texture_dds": {
                     "source": 4
@@ -79,28 +79,28 @@ The example below shows how this extension can be used along with the MSFT_textu
     ],
     "images": [
         {
-            "name":"baseColorTexture.png",
-			"mimeType": "image/png",
+            "name": "baseColorTexture.png",
+            "mimeType": "image/png",
             "bufferView": 0
         },
         {
-            "name":"roughnessMetallicTexture.png",
-			"mimeType": "image/png",
+            "name": "roughnessMetallicTexture.png",
+            "mimeType": "image/png",
             "bufferView": 1
         },
         {
-            "name":"normalTexture.png",
-			"mimeType": "image/png",
+            "name": "normalTexture.png",
+            "mimeType": "image/png",
             "bufferView": 2
         },
         {
-            "name":"baseColorTexture.dds",
-			"mimeType": "image/vnd-ms.dds",
+            "name": "baseColorTexture.dds",
+            "mimeType": "image/vnd-ms.dds",
             "bufferView": 3
         },
         {
-            "name":"normalRoughnessMetallic.dds",
-			"mimeType": "image/vnd-ms.dds",
+            "name": "normalRoughnessMetallic.dds",
+            "mimeType": "image/vnd-ms.dds",
             "bufferView": 4
         }
     ]

--- a/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/README.md
+++ b/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/README.md
@@ -1,0 +1,117 @@
+# MSFT_packing_normalRoughnessMetallic
+
+## Contributors
+
+* Saurabh Bhatia, Microsoft
+* Gary Hsu, Microsoft
+* Marc Appelsmeier, Microsoft
+* Dag Frommhold, Microsoft 
+* John Copic, Microsoft 
+
+## Status
+
+Complete
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension adds support for alternate texture packing and is meant to be used for Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality.
+
+This extension defines an additional property for `normalRoughnessMetallicTexture`. This property specifies the index of a texture with the packing Normal (RG), Roughness  (B), Metallic (A). This specialized packing is meant to provide an optimized alternative to the one specified in the core glTF 2.0 specification. 
+
+The extension should only be used when creating glTF assets for engines that support this packing and is not meant to be a general purpose packing extension. Any client that does not support this extension can safely ignore these additional packed texture and rely on the default packing in glTF 2.0. This extension can also be used along with other extensions like [MSFT_texture_dds](../MSFT_texture_dds/README.md) to store the packed textures in DDS files. 
+
+The example below shows how this extension can be used along with the MSFT_texture_dds extension in a glTF Binary (.glb) file:
+
+```json
+{
+    "materials": [
+        {
+            "pbrMetallicRoughness": {
+                "baseColorTexture": {
+                    "index": 0
+                },
+				"roughnessMetallicTexture": {
+					"index": 1
+                }
+            },
+            "normalTexture": {
+                "index": 2
+            },
+            "extensions": {
+                "MSFT_packing_normalRoughnessMetallic": {
+                    "normalRoughnessMetallicTexture": {
+                        "index": 3
+                    }
+                }
+            }
+        }
+    ],
+    "textures": [
+        {
+            "name":"baseColorTexture",
+            "source":0,
+            "extensions": {
+                "MSFT_texture_dds": {
+                    "source": 3
+                }
+            }
+        },
+		{
+            "name":"roughnessMetallicTexture",
+            "source":1
+        },
+		{
+            "name":"normalTexture",
+            "source":2
+        },
+		{
+            "name":"normalRoughnessMetallic",
+            "extensions": {
+                "MSFT_texture_dds": {
+                    "source": 4
+                }
+            }
+        },
+    ],
+    "images": [
+        {
+            "name":"baseColorTexture.png",
+			"mimeType": "image/png",
+            "bufferView": 0
+        },
+        {
+            "name":"roughnessMetallicTexture.png",
+			"mimeType": "image/png",
+            "bufferView": 1
+        },
+        {
+            "name":"normalTexture.png",
+			"mimeType": "image/png",
+            "bufferView": 2
+        },
+        {
+            "name":"baseColorTexture.dds",
+			"mimeType": "image/vnd-ms.dds",
+            "bufferView": 3
+        },
+        {
+            "name":"normalRoughnessMetallic.dds",
+			"mimeType": "image/vnd-ms.dds",
+            "bufferView": 4
+        }
+    ]
+}
+```
+
+## glTF Schema Updates
+
+* **JSON schema**: [glTF.MSFT_packing_normalRoughnessMetallic.schema.json](schema/glTF.MSFT_packing_normalRoughnessMetallic.schema.json)
+
+
+## Known Implementations
+
+This extension is used by Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality to improve performance by using the specially packed textures. [glTF-Toolkit](https://github.com/Microsoft/glTF-Toolkit) can be used to generate files that use this extension.

--- a/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/schema/glTF.MSFT_packing_normalRoughnessMetallic.schema.json
+++ b/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/schema/glTF.MSFT_packing_normalRoughnessMetallic.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "MSFT_packing_normalRoughnessMetallic extension",
+  "type": "object",
+  "description": "glTF extension the specifies a packing of normalRoughnessMetallic in a single texture.",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+  "properties": {
+    "normalRoughnessMetallicTexture": {
+      "type": "object",
+      "description": "A texture with the packing Normal (RG), Roughness  (B), Metallic (A).",
+      "properties": {
+        "index": {
+          "allOf": [ { "$ref": "glTFid.schema.json" } ],
+          "description": "The index of the texture."
+        }
+      }
+    },
+    "extensions": {},
+    "extras": {}
+  }
+}

--- a/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/schema/glTF.MSFT_packing_normalRoughnessMetallic.schema.json
+++ b/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/schema/glTF.MSFT_packing_normalRoughnessMetallic.schema.json
@@ -2,12 +2,12 @@
   "$schema": "http://json-schema.org/draft-04/schema",
   "title": "MSFT_packing_normalRoughnessMetallic extension",
   "type": "object",
-  "description": "glTF extension the specifies a packing of normalRoughnessMetallic in a single texture.",
+  "description": "glTF extension the specifies a packing of normal, roughness and metallic in a single texture.",
   "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
   "properties": {
     "normalRoughnessMetallicTexture": {
       "type": "object",
-      "description": "A texture with the packing Normal (RG), Roughness  (B), Metallic (A).",
+      "description": "A texture with the packing Normal (RG), Roughness (B), Metallic (A).",
       "properties": {
         "index": {
           "allOf": [ { "$ref": "glTFid.schema.json" } ],

--- a/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md
+++ b/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md
@@ -21,8 +21,8 @@ Written against the glTF 2.0 spec.
 This extension adds support for alternate texture packing and is meant to be used for Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality.
 
 This extension defines three additional properties:
-- `occlusionRoughnessMetallicTexture`: Specifies the index of a texture with the packing Occlusion (R), Roughness  (G), Metallic (B)
-- `roughnessMetallicOcclusionTexture`: Specifies the index of a texture with the packing Roughness (R), Metallic  (G), Occlusion (B)
+- `occlusionRoughnessMetallicTexture`: Specifies the index of a texture with the packing Occlusion (R), Roughness (G), Metallic (B)
+- `roughnessMetallicOcclusionTexture`: Specifies the index of a texture with the packing Roughness (R), Metallic (G), Occlusion (B)
 - `normalTexture`: Specifies the index of a texture which contains two channel (RG) normal map. 
 
 The extension should only be used when creating glTF assets for engines that support this packing and is not meant to be a general purpose packing extension. Any client that does not support this extension can safely ignore these additional packed textures and rely on the default packing in glTF 2.0. This extension can also be used along with other extensions like [MSFT_texture_dds](../MSFT_texture_dds/README.md) to store the packed textures in DDS files. 
@@ -38,7 +38,7 @@ The example below shows how this extension can be used along with the MSFT_textu
                     "index": 0
                 },
                 "roughnessMetallicTexture": {
-                "index": 1
+                    "index": 1
                 },
             },
             "normalTexture": {
@@ -61,8 +61,8 @@ The example below shows how this extension can be used along with the MSFT_textu
     ],
     "textures": [
         {
-            "name":"baseColorTexture",
-            "source":0,
+            "name": "baseColorTexture",
+            "source": 0,
             "extensions": {
                 "MSFT_texture_dds": {
                     "source": 6
@@ -70,19 +70,19 @@ The example below shows how this extension can be used along with the MSFT_textu
             }
         },
         {
-            "name":"roughnessMetallicTexture",
-            "source":1
+            "name": "roughnessMetallicTexture",
+            "source": 1
         },
         {
-            "name":"normalTexture",
-            "source":2
+            "name": "normalTexture",
+            "source": 2
         },
         {
-            "name":"occlusionTexture",
-            "source":3
+            "name": "occlusionTexture",
+            "source": 3
         },
         {
-            "name":"occlusionRoughnessMetallic",
+            "name": "occlusionRoughnessMetallic",
             "extensions": {
                 "MSFT_texture_dds": {
                     "source": 4
@@ -90,7 +90,7 @@ The example below shows how this extension can be used along with the MSFT_textu
             }
         },
         {
-            "name":"normalTexture_RG",
+            "name": "normalTexture_RG",
             "extensions": {
                 "MSFT_texture_dds": {
                     "source": 5

--- a/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md
+++ b/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md
@@ -1,0 +1,142 @@
+# MSFT_packing_occlusionRoughnessMetallic
+
+## Contributors
+
+* Saurabh Bhatia, Microsoft
+* Gary Hsu, Microsoft
+* Marc Appelsmeier, Microsoft
+* Dag Frommhold, Microsoft 
+* John Copic, Microsoft 
+
+## Status
+
+Complete
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension adds support for alternate texture packing and is meant to be used for Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality.
+
+This extension defines three additional properties:
+- `occlusionRoughnessMetallicTexture`: Specifies the index of a texture with the packing Occlusion (R), Roughness  (G), Metallic (B)
+- `roughnessMetallicOcclusionTexture`: Specifies the index of a texture with the packing Roughness (R), Metallic  (G), Occlusion (B)
+- `normalTexture`: Specifies the index of a texture which contains two channel (RG) normal map. 
+
+The extension should only be used when creating glTF assets for engines that support this packing and is not meant to be a general purpose packing extension. Any client that does not support this extension can safely ignore these additional packed textures and rely on the default packing in glTF 2.0. This extension can also be used along with other extensions like [MSFT_texture_dds](../MSFT_texture_dds/README.md) to store the packed textures in DDS files. 
+
+The example below shows how this extension can be used along with the MSFT_texture_dds extension in a glTF Binary (.glb) file:
+
+```json
+{
+    "materials": [
+        {
+            "pbrMetallicRoughness": {
+                "baseColorTexture": {
+                    "index": 0
+                },
+                "roughnessMetallicTexture": {
+                "index": 1
+                },
+            },
+            "normalTexture": {
+                "index": 2
+            },
+            "occlusionTexture": {
+                "index": 3
+            },
+            "extensions": {
+                "MSFT_packing_occlusionRoughnessMetallic": {
+                    "occlusionRoughnessMetallicTexture": {
+                        "index": 4
+                    },
+                    "normalTexture": {
+                        "index": 5
+                    }
+                }
+            }
+        }
+    ],
+    "textures": [
+        {
+            "name":"baseColorTexture",
+            "source":0,
+            "extensions": {
+                "MSFT_texture_dds": {
+                    "source": 6
+                }
+            }
+        },
+        {
+            "name":"roughnessMetallicTexture",
+            "source":1
+        },
+        {
+            "name":"normalTexture",
+            "source":2
+        },
+        {
+            "name":"occlusionTexture",
+            "source":3
+        },
+        {
+            "name":"occlusionRoughnessMetallic",
+            "extensions": {
+                "MSFT_texture_dds": {
+                    "source": 4
+                }
+            }
+        },
+        {
+            "name":"normalTexture_RG",
+            "extensions": {
+                "MSFT_texture_dds": {
+                    "source": 5
+                }
+            }
+        }
+    ],
+    "images": [
+        {
+            "mimeType": "image/png",
+            "bufferView": 0
+        },
+        {
+            "mimeType": "image/png",
+            "bufferView": 1
+        },
+        {
+            "mimeType": "image/png",
+            "bufferView": 2
+        },
+        {
+            "mimeType": "image/png",
+            "bufferView": 3
+        },
+        {
+            "mimeType": "image/vnd-ms.dds",
+            "bufferView": 4
+        },
+        {
+            "mimeType": "image/vnd-ms.dds",
+            "bufferView": 5
+        },
+        {
+            "mimeType": "image/vnd-ms.dds",
+            "bufferView": 6
+        }
+    ]
+}
+```
+
+## glTF Schema Updates
+
+* **JSON schema**: [glTF.MSFT_packing_occlusionRoughnessMetallic.schema.json](schema/glTF.MSFT_packing_occlusionRoughnessMetallic.schema.json)
+
+
+## Known Implementations
+
+This extension is used by Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality to improve performance by using the specially packed textures. [glTF-Toolkit](https://github.com/Microsoft/glTF-Toolkit) can be used to generate files that use this extension.
+

--- a/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/schema/glTF.MSFT_packing_occlusionRoughnessMetallic.schema.json
+++ b/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/schema/glTF.MSFT_packing_occlusionRoughnessMetallic.schema.json
@@ -2,12 +2,12 @@
   "$schema": "http://json-schema.org/draft-04/schema",
   "title": "MSFT_packing_occlusionRoughnessMetallic extension",
   "type": "object",
-  "description": "glTF extension the specifies a packing of occlusionRoughnessMetallic in a single texture and a two channel normal map.",
+  "description": "glTF extension the specifies a packing of occlusion, roughness and metallic in a single texture and a two channel normal map.",
   "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
   "properties": {
     "occlusionRoughnessMetallicTexture": {
       "type": "object",
-      "description": "A texture with packing Occlusion (R), Roughness  (G), Metallic (B).",
+      "description": "A texture with packing Occlusion (R), Roughness (G), Metallic (B).",
       "properties": {
         "index": {
           "allOf": [ { "$ref": "glTFid.schema.json" } ],
@@ -17,7 +17,7 @@
     },
     "roughnessMetallicOcclusionTexture": {
       "type": "object",
-      "description": "A texture with packing Roughness (R), Metallic  (G), Occlusion (B).",
+      "description": "A texture with packing Roughness (R), Metallic (G), Occlusion (B).",
       "properties": {
         "index": {
           "allOf": [ { "$ref": "glTFid.schema.json" } ],

--- a/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/schema/glTF.MSFT_packing_occlusionRoughnessMetallic.schema.json
+++ b/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/schema/glTF.MSFT_packing_occlusionRoughnessMetallic.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "MSFT_packing_occlusionRoughnessMetallic extension",
+  "type": "object",
+  "description": "glTF extension the specifies a packing of occlusionRoughnessMetallic in a single texture and a two channel normal map.",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+  "properties": {
+    "occlusionRoughnessMetallicTexture": {
+      "type": "object",
+      "description": "A texture with packing Occlusion (R), Roughness  (G), Metallic (B).",
+      "properties": {
+        "index": {
+          "allOf": [ { "$ref": "glTFid.schema.json" } ],
+          "description": "The index of the texture."
+        }
+      }
+    },
+    "roughnessMetallicOcclusionTexture": {
+      "type": "object",
+      "description": "A texture with packing Roughness (R), Metallic  (G), Occlusion (B).",
+      "properties": {
+        "index": {
+          "allOf": [ { "$ref": "glTFid.schema.json" } ],
+          "description": "The index of the texture."
+        }
+      }
+    },
+    "normalTexture": {
+      "type": "object",
+      "description": "A texture which contains two channel (RG) normal map.",
+      "properties": {
+        "index": {
+          "allOf": [ { "$ref": "glTFid.schema.json" } ],
+          "description": "The index of the texture."
+        }
+      }
+    },
+    "extensions": {},
+    "extras": {}
+  }
+}

--- a/extensions/2.0/Vendor/MSFT_texture_dds/README.md
+++ b/extensions/2.0/Vendor/MSFT_texture_dds/README.md
@@ -1,0 +1,69 @@
+# MSFT_texture_dds 
+
+## Contributors
+
+* Saurabh Bhatia, Microsoft
+* Gary Hsu, Microsoft
+* Marc Appelsmeier, Microsoft
+* Dag Frommhold, Microsoft 
+* John Copic, Microsoft 
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension adds the ability to specify textures using the DirectDraw Surface file format (DDS). An implementation of this extension can use the textures provided in the DDS files as an alternative to the PNG or JPG textures available in glTF 2.0.
+
+The extension is added to the `textures` node and specifies a `source` property that points to the index of the `images` node which in turn points to the DDS texture file. A client that does not understand this extension can ignore the DDS file and continue to rely on the PNG or JPG textures specified.
+
+```json
+"textures": [
+    {
+        "source": 0,
+        "extensions": {
+            "MSFT_texture_dds": {
+                    "source": 1
+                }
+            }
+    }
+    ],
+"images": [
+    {
+      "uri": "defaultTexture.png"
+    },
+    {
+      "uri": "DDSTexture.dds"
+    }
+```
+When used in the glTF Binary (.glb) format the `images` node that points to the DDS file uses the `mimeType` value of *image/vnd-ms.dds*.
+
+```json
+"textures": [
+    {
+        "source": 0,
+        "extensions": {
+            "MSFT_texture_dds": {
+                    "source": 1
+                }
+            }
+    }
+    ],
+"images": [
+    {
+      "mimeType": "image/png",
+      "bufferView": 1
+    },
+    {
+      "mimeType": "image/vnd-ms.dds",
+      "bufferView": 2
+    }
+```
+## Known Implementations
+
+This extension is used by Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality to improve performance by including DDS textures. [glTF-Toolkit](https://github.com/Microsoft/glTF-Toolkit) can be used to generate files that use this extension.

--- a/extensions/2.0/Vendor/MSFT_texture_dds/README.md
+++ b/extensions/2.0/Vendor/MSFT_texture_dds/README.md
@@ -28,18 +28,19 @@ The extension is added to the `textures` node and specifies a `source` property 
         "source": 0,
         "extensions": {
             "MSFT_texture_dds": {
-                    "source": 1
-                }
+                "source": 1
             }
+        }
     }
-    ],
+],
 "images": [
     {
-      "uri": "defaultTexture.png"
+        "uri": "defaultTexture.png"
     },
     {
-      "uri": "DDSTexture.dds"
+        "uri": "DDSTexture.dds"
     }
+]
 ```
 When used in the glTF Binary (.glb) format the `images` node that points to the DDS file uses the `mimeType` value of *image/vnd-ms.dds*.
 
@@ -49,21 +50,27 @@ When used in the glTF Binary (.glb) format the `images` node that points to the 
         "source": 0,
         "extensions": {
             "MSFT_texture_dds": {
-                    "source": 1
-                }
+                "source": 1
             }
+        }
     }
-    ],
+],
 "images": [
     {
-      "mimeType": "image/png",
-      "bufferView": 1
+        "mimeType": "image/png",
+        "bufferView": 1
     },
     {
-      "mimeType": "image/vnd-ms.dds",
-      "bufferView": 2
+        "mimeType": "image/vnd-ms.dds",
+        "bufferView": 2
     }
+]
 ```
+
+## glTF Schema Updates
+
+* **JSON schema**: [glTF.MSFT_texture_dds.schema.json](schema/glTF.MSFT_texture_dds.schema.json)
+
 ## Known Implementations
 
 This extension is used by Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality to improve performance by including DDS textures. [glTF-Toolkit](https://github.com/Microsoft/glTF-Toolkit) can be used to generate files that use this extension.

--- a/extensions/2.0/Vendor/MSFT_texture_dds/schema/glTF.MSFT_texture_dds.schema.json
+++ b/extensions/2.0/Vendor/MSFT_texture_dds/schema/glTF.MSFT_texture_dds.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "MSFT_texture_dds extension",
+  "type": "object",
+  "description": "glTF extension to specify textures using the DirectDraw Surface file format (DDS).",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+  "properties": {
+    "source": {
+      "allOf": [ { "$ref": "glTFid.schema.json" } ],
+      "description": "The index of the images node which points to a DDS texture file."
+    },
+    "extensions": {},
+    "extras": {}
+  }
+}

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -11,6 +11,14 @@ _Draft Khronos extensions are not ratified yet._
 * KHR_materials_common *(in progress)*
 * KHR_technique_webgl *(in progress)*
 
+#### Vendor extensions
+
+* [MSFT_lod](2.0/Vendor/MSFT_lod/README.md)
+* [MSFT_texture_dds](2.0/Vendor/MSFT_texture_dds/README.md)
+* [MSFT_packing_normalRoughnessMetallic](2.0/Vendor/MSFT_packing_normalRoughnessMetallic/README.md)
+* [MSFT_packing_occlusionRoughnessMetallic](2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md)
+
+
 ## Extensions for glTF 1.0
 
 #### Khronos extensions


### PR DESCRIPTION
Merging these Microsoft specific extensions back into master so that they are more discoverable. 

There are some ongoing discussions for others adopting some of these like the LOD extension. If there is interest in that, a separate multi-vendor extension can be added. Wanted to get these is in so that there is good documentation/snapshot of what we are currently doing.  