### PR TITLE
KHR_blend

### DIFF
--- a/extensions/2.0/Khronos/KHR_blend/README.md
+++ b/extensions/2.0/Khronos/KHR_blend/README.md
@@ -1,4 +1,4 @@
-# EXT_blend
+# KHR_blend
 
 ## Contributors
 
@@ -14,15 +14,15 @@ Written against the glTF 2.0 spec.
 
 ## Overview
 
-This extension defines blending operations on glTF materials. The `EXT_blend`
+This extension defines blending operations on glTF materials. The `KHR_blend`
 extension may be used alongside the default PBR materials, or materials defined
 in glTF extensions. When combined with other materials and techniques, blending
 may be used to achieve effects like fire, steam, or holograms.
 
-For any material with the `EXT_blend` extension, blending must use the
+For any material with the `KHR_blend` extension, blending must use the
 specified blend equation/operation and factors.
 
-For any materials without the `EXT_blend` extension, blending is assumed to be
+For any materials without the `KHR_blend` extension, blending is assumed to be
 off unless otherwise specified.
 
 ### Properties
@@ -78,7 +78,7 @@ Defines parameters to the blending equation.
         "name": "My_Additive_Material",
         "pbrMetallicRoughness": {},
         "extensions": {
-            "EXT_blend": {
+            "KHR_blend": {
                 "blendEquation": [32778, 32778],
                 "blendFactors": [1, 1, 1, 1]
             }

--- a/extensions/2.0/Vendor/EXT_blend/README.md
+++ b/extensions/2.0/Vendor/EXT_blend/README.md
@@ -1,0 +1,96 @@
+# EXT_blend
+
+## Contributors
+
+TODO
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension defines blending operations on glTF materials. The `EXT_blend`
+extension may be used alongside the default PBR materials, or materials defined
+in glTF extensions. When combined with other materials and techniques, blending
+may be used to achieve effects like fire, steam, or holograms.
+
+For any material with the `EXT_blend` extension, blending must use the
+specified blend equation/operation and factors.
+
+For any materials without the `EXT_blend` extension, blending is assumed to be
+off unless otherwise specified.
+
+### Properties
+
+**blendEquation** :white_check_mark:
+
+Determines how a new pixel is combined with a pixel already in the frame buffer.
+
+* **Type:** `number` `[2]`
+    - `0` *color* equation
+    - `1` *alpha* equation
+* **Required:** Yes
+* **Allowed values:**
+
+| name                     | blendEquation | description |
+|--------------------------|---------------|-------------|
+| FUNC_ADD                 | 0x8006        | Set an addition blend function. |
+| FUNC_SUBTRACT            | 0x800A        | Specify a subtraction blend function (source - destination). |
+| FUNC_REVERSE_SUBTRACT    | 0x800B        | Specify a reverse subtraction blend function (destination - source). |
+| MIN                      | 0x8007        | Produces the minimum color components of the source and destination colors. |
+| MAX                      | 0x8008        | Produces the maximum color components of the source and destination colors. |
+
+**blendFactors** :white_check_mark:
+
+Defines parameters to the blending equation.
+
+* **Type:** `number` `[4]`
+    - `0` : *source color* multiplier
+    - `1` : *destination color* multiplier
+    - `2` : *source alpha* multiplier
+    - `3` : *destination alpha* multiplier
+* **Required:** Yes
+* **Allowed values:**
+
+| name                | blendFactor | description |
+|---------------------|-------------|-------------|
+| ZERO                | 0           | Turn off a component. |
+| ONE                 | 1           | Turn on a component. |
+| SRC_COLOR           | 0x0300      | Multiply a component by the source's color. |
+| ONE_MINUS_SRC_COLOR | 0x0301      | Multiply a component by one minus the source's color. |
+| SRC_ALPHA           | 0x0302      | Multiply a component by the source's alpha. |
+| ONE_MINUS_SRC_ALPHA | 0x0303      | Multiply a component by one minus the source's alpha. |
+| DST_ALPHA           | 0x0304      | Multiply a component by the destination's alpha. |
+| ONE_MINUS_DST_ALPHA | 0x0305      | Multiply a component by one minus the destination's alpha. |
+| DST_COLOR           | 0x0306      | Multiply a component by the destination's color. |
+| ONE_MINUS_DST_COLOR | 0x0307      | Multiply a component by one minus the destination's color. |
+
+### Example
+
+```json
+"materials": [
+    {
+        "name": "My_Additive_Material",
+        "pbrMetallicRoughness": {},
+        "extensions": {
+            "EXT_blend": {
+                "blendEquation": [32778, 32778],
+                "blendFactors": [1, 1, 1, 1]
+            }
+        }
+    }
+]
+ ```
+
+## glTF Schema Updates
+
+**JSON schema**: TODO
+
+## Known Implementations
+
+TODO

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -3,6 +3,7 @@
 ## Extensions for glTF 2.0
 
 #### Khronos extensions
+* [KHR_blend](2.0/Khronos/KHR_blend/README.md)
 * [KHR_materials_pbrSpecularGlossiness](2.0/Khronos/KHR_materials_pbrSpecularGlossiness/README.md)
 * [KHR_materials_unlit](2.0/Khronos/KHR_materials_unlit/README.md)
 * [KHR_draco_mesh_compression](2.0/Khronos/KHR_draco_mesh_compression/README.md)


### PR DESCRIPTION
Complement to #1296, in the hope that blending can be kept WebGL-agnostic. DirectX supports many blend operations that GL does not; currently those are omitted from this extension for compatibility. I also did not attempt to include `gl.blendColor`.

BabylonJS and Unreal appear to skip many of these blending equations. I wouldn't be opposed to cutting back to just the intersection, but would like to get more feedback on this first. @bghgary any preference, or rationale behind Babylon's choices here? Found [this thread](http://www.html5gamedevs.com/topic/15696-blend-modes/).

TODO:
* [ ] Clarify `alphaMode == BLEND` requirement. Is extension invalid when this is not the case, or simply ignored? Do we allow `alphaMode === MASK`, too?
* [ ] Clarify that MIN and MAX equations do not use `blendFactors`.
* [ ] Consider simplifying allowed blend states.
* [ ] Replace GL integer constants with string enums.

References:
- [Unity: Blending](https://docs.unity3d.com/Manual/SL-Blend.html)
- [Unreal: Blend modes](https://docs.unrealengine.com/en-us/Engine/Rendering/Materials/MaterialProperties/BlendModes)
- [OpenGL: Blending](https://www.khronos.org/opengl/wiki/Blending#Blend_Equations)
- [THREE: Blending equation constants](https://threejs.org/docs/#api/constants/CustomBlendingEquations)
- [BabylonJS: Blend modes](https://doc.babylonjs.com/how_to/how_to_use_blend_modes)
- [WebGL constants](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Constants)
- [Visual glBlendEquation tool](https://www.andersriggelsen.dk/glblendfunc.php)

Reference: https://user-images.githubusercontent.com/1848368/38159786-bca1e3ea-3464-11e8-9d3b-9d1a1e8cac74.jpg
