### PR TITLE
MOZ_alt_materials Extension

### DIFF
--- a/extensions/2.0/Vendor/MOZ_alt_materials/README.md
+++ b/extensions/2.0/Vendor/MOZ_alt_materials/README.md
@@ -14,7 +14,9 @@ Written against the glTF 2.0 spec.
 
 ## Overview
 
-This extension adds the ability to define alternate rendering techniques for a given material. A typical use-case for this extension would be defining a physically based material for high end platforms and an unlit material on low end platforms. It could also be used for defining rendering techniques for multiple engines.
+This extension adds the ability to define alternate rendering techniques for a given material.
+
+A typical use-case for this extension would be extending a material that uses `pbrMetallicRoughness` to also support `KHR_materials_unlit`. Implementors may choose to support this extension to allow for progressive enhancement of lighting techniques on different platforms. Alternate materials are still expected to have reasonable fallback support to their own `pbrMetallicRoughness` values, however they are not required to approximate the original material. For example a model may have a metallic `pbrMetallicRoughness` material and a flat `KHR_materials_unlit` alternate model. In this case a desktop user could be provided the PBR material and a mobile user, the unlit material.
 
 To minimize the cost of downloading the glTF asset, avoid packing all texture maps into a binary glTF. Loaders implementing this extension should conditionally download the texture maps for the specified rendering technique.
 
@@ -60,6 +62,8 @@ An example of defining an alternate unlit material using the `KHR_materials_unli
 ## glTF Schema Updates
 
 If a `material` contains an `extension` property and the `extension` defines its `MOZ_alt_materials` property then any of the materials, whose indices are defined as the values of the `MOZ_alt_materials` object, may be used instead of the `material`.
+
+The keys of the `MOZ_alt_materials` may include `KHR_materials_unlit`, `KHR_materials_pbrSpecularGlossiness` as well as any current or future material extension names or creator defined semantic variables (ex. "TOON_SHADING" or "MAT_CAP" which may point at a `KHR_techniques_webgl` material).
 
 ### JSON Schema
 

--- a/extensions/2.0/Vendor/MOZ_alt_materials/README.md
+++ b/extensions/2.0/Vendor/MOZ_alt_materials/README.md
@@ -1,0 +1,70 @@
+# MOZ_alt_materials
+
+## Contributors
+
+* Robert Long, Mozilla
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension adds the ability to define alternate rendering techniques for a given material. A typical use-case for this extension would be defining a physically based material for high end platforms and an unlit material on low end platforms. It could also be used for defining rendering techniques for multiple engines.
+
+To minimize the cost of downloading the glTF asset, avoid packing all texture maps into a binary glTF. Loaders implementing this extension should conditionally download the texture maps for the specified rendering technique.
+
+This extension should only be added to metallic roughness PBR materials. This PBR material will be used as the fallback material if the loader does not support this extension.
+
+An example of defining an alternate unlit material using the `KHR_materials_unlit` extension:
+
+```json
+"materials": [
+    {
+        "pbrMetallicRoughness": {
+            "baseColorTexture": {
+                "index": 0
+            },
+            "metallicFactor": 1,
+            "roughnessFactor": 1,
+        },
+        "normalTexture": {
+            "index": 1
+        },
+        "extensions": {
+            "MOZ_alt_materials": {
+                "KHR_materials_unlit": 1
+            }
+        }
+    },
+    {
+        "pbrMetallicRoughness": {
+            "baseColorFactor": [ 1.0, 1.0, 1.0, 1.0 ],
+            "baseColorTexture": {
+                "index": 2
+            },
+            "roughnessFactor": 0.9,
+            "metallicFactor": 0.0
+        },
+        "extensions": {
+            "KHR_materials_unlit": {}
+        }
+    }
+]
+```
+
+## glTF Schema Updates
+
+If a `material` contains an `extension` property and the `extension` defines its `MOZ_alt_materials` property then any of the materials, whose indices are defined as the values of the `MOZ_alt_materials` object, may be used instead of the `material`.
+
+### JSON Schema
+
+* **JSON schema**: [material.MOZ_alt_materials.schema.json](schema/material.MOZ_alt_materials.schema.json)
+
+## Known Implementations
+
+None

--- a/extensions/2.0/Vendor/MOZ_alt_materials/schema/material.MOZ_alt_materials.schema.json
+++ b/extensions/2.0/Vendor/MOZ_alt_materials/schema/material.MOZ_alt_materials.schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "MOZ_alt_materials glTF extension",
+    "type": "object",
+    "description": "glTF extension for specifying additionally available materials.",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "KHR_materials_pbrSpecularGlossiness": {
+          "allOf": [ { "$ref": "glTFid.schema.json" } ],
+          "description": "The index of the KHR_materials_pbrSpecularGlossiness material to use instead of this material."
+        },
+        "KHR_materials_unlit": {
+          "allOf": [ { "$ref": "glTFid.schema.json" } ],
+          "description": "The index of the KHR_materials_unlit material to use instead of this material."
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}

--- a/extensions/2.0/Vendor/MOZ_alt_materials/schema/material.MOZ_alt_materials.schema.json
+++ b/extensions/2.0/Vendor/MOZ_alt_materials/schema/material.MOZ_alt_materials.schema.json
@@ -6,12 +6,15 @@
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "KHR_materials_pbrSpecularGlossiness": {
-          "allOf": [ { "$ref": "glTFid.schema.json" } ],
-          "description": "The index of the KHR_materials_pbrSpecularGlossiness material to use instead of this material."
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
+            "description": "The index of the KHR_materials_pbrSpecularGlossiness material to use instead of this material."
         },
         "KHR_materials_unlit": {
-          "allOf": [ { "$ref": "glTFid.schema.json" } ],
-          "description": "The index of the KHR_materials_unlit material to use instead of this material."
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
+            "description": "The index of the KHR_materials_unlit material to use instead of this material."
+        },
+        "additionalProperties": {
+            "$ref": "glTFid.schema.json"
         },
         "extensions": { },
         "extras": { }


### PR DESCRIPTION
In [Mozilla Hubs](https://hubs.mozilla.com), we support a wide variety of hardware with vastly different specs. Publishing glTF content that can take advantage of high end hardware while still running well on low end platforms is tough. Also, hardware requirements for VR are more demanding than 2D. Currently if you want to ship a glTF asset that uses real time lighting on high end hardware and unlit lighting on low end hardware, you need to distribute two separate glTF files and the loader needs to know about the availability of those files in order to determine which asset it should load. This extension aims to solve this problem by defining alternate materials in a glTF file that can then be loaded conditionally based on the client's hardware.

This extension is similar in some regards to the [MSFT_lod](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/MSFT_lod) extension which we considered for a while, but ultimately we decided that we wanted the loader to request a material with a explicitly defined rendering technique rather than a LOD level that maps to an arbitrary material. However, the two extensions could be used in tandem (ex. MOZ_alt_materials used to specify PBR and Unlit geometry LOD groups).

We are currently using this extension in Mozilla Hubs and our [gltf-bundle](https://github.com/MozillaReality/gltf-bundle) pipeline. This includes [a tool](https://github.com/MozillaReality/gltf-unlit-generator) that automatically generates an unlit map from PBR glTF model. We have a reference implementation in our fork of the [THREE.GLTFLoader](https://github.com/mozilla/hubs/blob/master/src/vendor/GLTFLoader.js#L889) which we would like to move into the ThreeJS repository once we receive some feedback from the glTF community.