### PR TITLE
Skin weights must be normalized.

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -910,8 +910,7 @@ The number of joints that influence one vertex is limited to 4, so referenced ac
 * **`JOINTS_0`**: `UNSIGNED_BYTE` or `UNSIGNED_SHORT`
 * **`WEIGHTS_0`**: `FLOAT`, or normalized `UNSIGNED_BYTE`, or normalized `UNSIGNED_SHORT`
 
-The joint weights for each vertex must be >= 0, sorted in descending order, and normalized to have
-a linear sum of one. No joint may have more than one non-zero weight for a given vertex.
+The joint weights for each vertex must be >= 0, and normalized to have a linear sum of one. No joint may have more than one non-zero weight for a given vertex.
 
 #### Joint Hierarchy
 


### PR DESCRIPTION
Fixes #1213.

Some concerns:

1. If we do decide >4 influences are allowed via `JOINTS_1...N`, clients that only support 4 influences (this is nearly every engine today) will not be able to assume that JOINTS_0 is normalized. So, practically, the implementation must still be robust against weights that do not sum to 1.
2. If you have a simple rig (say, 4 bones total) you might get better compression by putting the joints in the same order for all vertices. This change would disallow that.

I'm not too worried about (2), but would say (1) is worth discussion.