### PR TITLE
Fix label in Contents table

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Preview tools:
   * [Loaders and Viewers](#loaders-and-viewers)
     * [WebGL Engines](#webgl-engines)
     * [WebGL Sample Code](#webgl-sample-code)
-    * [Game Engines](#game-engines)
+    * [Game and Rendering Engines](#game-and-rendering-engines)
   * [Languages](#languages)
   * [Utilities](#utilities)
 * [Stack Overflow](#stack-overflow)


### PR DESCRIPTION
After PR #1392 the `Game Engines` heading was changed to `Game and Rendering Engines`. But I forgot to update the `Contents` table. This commit and PR fixes this