### PR TITLE
Add the AGI prefix.

### DIFF
--- a/extensions/Prefixes.md
+++ b/extensions/Prefixes.md
@@ -2,6 +2,7 @@
 
 The following extension prefixes are reserved:
 
+* `AGI` - Analytical Graphics, Inc.
 * `ALI` - Alibaba
 * `AMZN` - Amazon
 * `AVR` - AltspaceVR
@@ -20,4 +21,4 @@ The following extension prefixes are reserved:
 * `SKFB` - Sketchfab
 * `WEB3D` - Web3D Consortium
 
-To request a prefix, submit a [GitHub issue](https://github.com/KhronosGroup/glTF/issues/new) with the name of the requested prefix and the vendor that will be using it. Assign the `extension` label to the issue.
+To request a prefix, submit a [GitHub issue](https://github.com/KhronosGroup/glTF/issues/new) with the name of the requested prefix and the vendor that will be using it. Maintainers, please assign the `extension` label to the issue.


### PR DESCRIPTION
This is for an upcoming vendor extension for AGI's desktop software, STK (Systems ToolKit).

Also, clean up wording about applying labels to issues.  Only the maintainers can adjust issue labels.
