### PR TITLE
NormalTexture value should not be normalized

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -2937,7 +2937,7 @@ This integer value is used to construct a string in the format TEXCOORD_<set ind
 
 #### normalTextureInfo.scale
 
-The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((normalize(<sampled normal texture value>) * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear.
+The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear.
 
 * **Type**: `number`
 * **Required**: No, default: `1`

--- a/specification/2.0/schema/material.normalTextureInfo.schema.json
+++ b/specification/2.0/schema/material.normalTextureInfo.schema.json
@@ -10,7 +10,7 @@
             "type": "number",
             "description": "The scalar multiplier applied to each normal vector of the normal texture.",
             "default": 1.0,
-            "gltf_detailedDescription": "The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((normalize(<sampled normal texture value>) * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear."
+            "gltf_detailedDescription": "The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear."
         },
         "extensions": { },
         "extras": { }


### PR DESCRIPTION
In the section normalTextureInfo.scale, the formula is
```
scaledNormal =  normalize((normalize(<sampled normal texture value>) * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))
```

But it's not correct. 
e.g.: 
1. Assume that the original normal value is  (0, -1, 0)
1. In the texture it will be (0.5, 0, 0.5)
1. After the normalize it will be (0.7071, 0, 0.7071)
1. Finally it will be (0.4142, -1, 0.4142)，obviously, this is wrong.


Should the code be 
```
normalize((normalize(<sampled normal texture value> * 2.0 - 1.0)) * vec3(<normal scale>, <normal scale>, 1.0))
```
or just remove the normalize
``` 
normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))
```
