### PR TITLE
Add Hilo3d glTF viewer to viewers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Please provide spec feedback and community updates by submitting [issues](https:
 | [glTF Viewer](https://www.8thwall.com/gltf/) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Android and iOS apps for glTF 2.0 viewing and link sharing: supports embedded glTF 2.0 files and links |
 | [DirectX glTF Viewer](https://github.com/Microsoft/glTF-DXViewer) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | DirectX11, C++ desktop app for loading and rendering glTF files |
 | [glTFShowcase](https://www.vispolygon.com/) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Android app for viewing glTF 2.0 asset from local files (gltf/glb): supports environment lighting change. |
+| [Hilo3d glTF Viewer](https://hiloteam.github.io/Hilo3d/examples/glTFViewer/index.html) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Drag-and-drop glTF2.0 viewer for model preview, using Hilo3d |
 ### Applications
 
 | Application | Status | Description |


### PR DESCRIPTION
Hilo3d glTF viewer is an online tool that previews the glTF models, supporting file dragging or links. It also can shares the model through links.
e.g.
* viewer: https://hiloteam.github.io/Hilo3d/examples/glTFViewer/index.html
* modelShare: https://hiloteam.github.io/Hilo3d/examples/glTFViewer/index.html?url=https://cx20.github.io/gltf-test/tutorialModels/Suzanne/glTF/Suzanne.gltf