### PR TITLE
Add explicit type descriptor to integer enums

### DIFF
--- a/specification/2.0/schema/accessor.schema.json
+++ b/specification/2.0/schema/accessor.schema.json
@@ -25,27 +25,33 @@
             "anyOf": [
                 {
                     "enum": [ 5120 ],
-                    "description": "BYTE"
+                    "description": "BYTE",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 5121 ],
-                    "description": "UNSIGNED_BYTE"
+                    "description": "UNSIGNED_BYTE",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 5122 ],
-                    "description": "SHORT"
+                    "description": "SHORT",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 5123 ],
-                    "description": "UNSIGNED_SHORT"
+                    "description": "UNSIGNED_SHORT",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 5125 ],
-                    "description": "UNSIGNED_INT"
+                    "description": "UNSIGNED_INT",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 5126 ],
-                    "description": "FLOAT"
+                    "description": "FLOAT",
+                    "type": "integer"
                 },
                 {
                     "type": "integer"

--- a/specification/2.0/schema/accessor.sparse.indices.schema.json
+++ b/specification/2.0/schema/accessor.sparse.indices.schema.json
@@ -21,15 +21,18 @@
             "anyOf": [
                 {
                     "enum": [ 5121 ],
-                    "description": "UNSIGNED_BYTE"
+                    "description": "UNSIGNED_BYTE",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 5123 ],
-                    "description": "UNSIGNED_SHORT"
+                    "description": "UNSIGNED_SHORT",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 5125 ],
-                    "description": "UNSIGNED_INT"
+                    "description": "UNSIGNED_INT",
+                    "type": "integer"
                 },
                 {
                     "type": "integer"

--- a/specification/2.0/schema/bufferView.schema.json
+++ b/specification/2.0/schema/bufferView.schema.json
@@ -35,11 +35,13 @@
             "anyOf": [
                 {
                     "enum": [ 34962 ],
-                    "description": "ARRAY_BUFFER"
+                    "description": "ARRAY_BUFFER",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 34963 ],
-                    "description": "ELEMENT_ARRAY_BUFFER"
+                    "description": "ELEMENT_ARRAY_BUFFER",
+                    "type": "integer"
                 },
                 {
                     "type": "integer"

--- a/specification/2.0/schema/mesh.primitive.schema.json
+++ b/specification/2.0/schema/mesh.primitive.schema.json
@@ -29,31 +29,38 @@
             "anyOf": [
                 {
                     "enum": [ 0 ],
-                    "description": "POINTS"
+                    "description": "POINTS",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 1 ],
-                    "description": "LINES"
+                    "description": "LINES",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 2 ],
-                    "description": "LINE_LOOP"
+                    "description": "LINE_LOOP",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 3 ],
-                    "description": "LINE_STRIP"
+                    "description": "LINE_STRIP",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 4 ],
-                    "description": "TRIANGLES"
+                    "description": "TRIANGLES",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 5 ],
-                    "description": "TRIANGLE_STRIP"
+                    "description": "TRIANGLE_STRIP",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 6 ],
-                    "description": "TRIANGLE_FAN"
+                    "description": "TRIANGLE_FAN",
+                    "type": "integer"
                 },
                 {
                     "type": "integer"

--- a/specification/2.0/schema/sampler.schema.json
+++ b/specification/2.0/schema/sampler.schema.json
@@ -12,11 +12,13 @@
             "anyOf": [
                 {
                     "enum": [ 9728 ],
-                    "description": "NEAREST"
+                    "description": "NEAREST",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 9729 ],
-                    "description": "LINEAR"
+                    "description": "LINEAR",
+                    "type": "integer"
                 },
                 {
                     "type": "integer"
@@ -30,27 +32,33 @@
             "anyOf": [
                 {
                     "enum": [ 9728 ],
-                    "description": "NEAREST"
+                    "description": "NEAREST",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 9729 ],
-                    "description": "LINEAR"
+                    "description": "LINEAR",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 9984 ],
-                    "description": "NEAREST_MIPMAP_NEAREST"
+                    "description": "NEAREST_MIPMAP_NEAREST",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 9985 ],
-                    "description": "LINEAR_MIPMAP_NEAREST"
+                    "description": "LINEAR_MIPMAP_NEAREST",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 9986 ],
-                    "description": "NEAREST_MIPMAP_LINEAR"
+                    "description": "NEAREST_MIPMAP_LINEAR",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 9987 ],
-                    "description": "LINEAR_MIPMAP_LINEAR"
+                    "description": "LINEAR_MIPMAP_LINEAR",
+                    "type": "integer"
                 },
                 {
                     "type": "integer"
@@ -65,15 +73,18 @@
             "anyOf": [
                 {
                     "enum": [ 33071 ],
-                    "description": "CLAMP_TO_EDGE"
+                    "description": "CLAMP_TO_EDGE",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 33648 ],
-                    "description": "MIRRORED_REPEAT"
+                    "description": "MIRRORED_REPEAT",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 10497 ],
-                    "description": "REPEAT"
+                    "description": "REPEAT",
+                    "type": "integer"
                 },
                 {
                     "type": "integer"
@@ -88,15 +99,18 @@
             "anyOf": [
                 {
                     "enum": [ 33071 ],
-                    "description": "CLAMP_TO_EDGE"
+                    "description": "CLAMP_TO_EDGE",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 33648 ],
-                    "description": "MIRRORED_REPEAT"
+                    "description": "MIRRORED_REPEAT",
+                    "type": "integer"
                 },
                 {
                     "enum": [ 10497 ],
-                    "description": "REPEAT"
+                    "description": "REPEAT",
+                    "type": "integer"
                 },
                 {
                     "type": "integer"


### PR DESCRIPTION
In [glTF-Blender-IO](https://github.com/KhronosGroup/glTF-Blender-IO) we are using [quicktype](https://github.com/quicktype/quicktype) to automatically generate python classes from the glTF JSON schema.

This commit adds explicit integer type specifiers to some enums, which prevents quicktype from wrongly deducing a type of float for these enum values ([refer to this warning in the JSON schema docs](https://json-schema.org/understanding-json-schema/reference/numeric.html#integer) for details).