### PR TITLE
Make source property required in texture

### DIFF
--- a/specification/2.0/schema/texture.schema.json
+++ b/specification/2.0/schema/texture.schema.json
@@ -17,5 +17,6 @@
         "extensions": { },
         "extras": { }
     },
-    "gltf_webgl": "`createTexture()`, `deleteTexture()`, `bindTexture()`, `texImage2D()`, and `texParameterf()`"
+    "gltf_webgl": "`createTexture()`, `deleteTexture()`, `bindTexture()`, `texImage2D()`, and `texParameterf()`",
+    "required": [ "source" ]
 }


### PR DESCRIPTION
Currently textures without an image source are valid glTF which leads to errors in some engines (e.g. Babylon.js, Cesium, Three.js). 

As it is unspecified how engines should display such 'empty' texures, the specification should probably be modified to prohibit them.

Example: 
[glTF.zip](https://github.com/KhronosGroup/glTF/files/2428149/glTF.zip)
