### PR TITLE
Remove path from EXT_lights_image_based schema, update README.

### DIFF
--- a/extensions/2.0/Vendor/EXT_lights_image_based/schema/light.schema.json
+++ b/extensions/2.0/Vendor/EXT_lights_image_based/schema/light.schema.json
@@ -3,7 +3,7 @@
     "title": "light",
     "type": "object",
     "description": "An image-based lighting environment.",
-    "allOf" : [ { "$ref" : "../../../../specification/2.0/schema/glTFChildOfRootProperty.schema.json" } ],
+    "allOf" : [ { "$ref" : "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "rotation": {
             "type": "array",

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -14,6 +14,7 @@
 * [ADOBE_materials_thin_transparency](2.0/Vendor/ADOBE_materials_thin_transparency/README.md)
 * [AGI_articulations](2.0/Vendor/AGI_articulations/README.md)
 * [AGI_stk_metadata](2.0/Vendor/AGI_stk_metadata/README.md)
+* [EXT_lights_image_based](2.0/Vendor/EXT_lights_image_based/README.md)
 * [MSFT_lod](2.0/Vendor/MSFT_lod/README.md)
 * [MSFT_texture_dds](2.0/Vendor/MSFT_texture_dds/README.md)
 * [MSFT_packing_normalRoughnessMetallic](2.0/Vendor/MSFT_packing_normalRoughnessMetallic/README.md)
@@ -30,7 +31,6 @@ but may still change before they are complete._
 | [KHR_lights_punctual](2.0/Khronos/KHR_lights_punctual/README.md) | Feature-complete, seeking feedback. |
 | KHR_compressed_texture_transmission | In development. |
 | [KHR_blend](https://github.com/KhronosGroup/glTF/pull/1302) | In development. |
-| [EXT_lights_image_based](https://github.com/KhronosGroup/glTF/pull/1377) | In development. |
 | HDR textures ([#1220](https://github.com/KhronosGroup/glTF/issues/1220), [#1365](https://github.com/KhronosGroup/glTF/issues/1365)) | Planned. |
 | Advanced PBR materials ([#1221](https://github.com/KhronosGroup/glTF/issues/1221), [#1079](https://github.com/KhronosGroup/glTF/issues/1079), ...) | Planned. |
 


### PR DESCRIPTION
This is a follow-up to #1377.

None of our other extensions specify a long relative path in their schemas, so I've removed the path here for consistency.

Also, updated the README for the list of extensions.