### PR TITLE
Remove `name` from technique.uniform

### DIFF
--- a/extensions/2.0/Khronos/KHR_techniques_webgl/schema/technique.uniform.schema.json
+++ b/extensions/2.0/Khronos/KHR_techniques_webgl/schema/technique.uniform.schema.json
@@ -33,7 +33,6 @@
             "description" : "The value of the uniform.",
             "gltf_detailedDescription" : "The value of the uniform. The length is determined by the values of the `type` and `count` (if present) properties.  A material uniform value with the same name, when specified, overrides this value."
         },
-        "name" : {},
         "extensions" : {},
         "extras" : {}
     },


### PR DESCRIPTION
The schema for `technique.uniform.schema.json` inherits from `glTFProperty` so it shouldn't have `name` property. Uniform names come from `technique.uniforms` keys.