### PR TITLE
Small fixes for EXT_lights_image_based schemas

### DIFF
--- a/extensions/2.0/Vendor/EXT_lights_image_based/schema/glTF.EXT_lights_image_based.schema.json
+++ b/extensions/2.0/Vendor/EXT_lights_image_based/schema/glTF.EXT_lights_image_based.schema.json
@@ -2,6 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "EXT_lights_image_based glTF extension",
     "type": "object",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "lights": {
             "type": "array",
@@ -10,10 +11,11 @@
                 "$ref": "light.schema.json"
             },
             "minItems": 1
-        }
+        },
+        "extensions": { },
+        "extras": { }
     },
     "required":[
         "lights"
-    ],
-    "additionalProperties": false
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_lights_image_based/schema/light.schema.json
+++ b/extensions/2.0/Vendor/EXT_lights_image_based/schema/light.schema.json
@@ -20,7 +20,8 @@
         "intensity": {
             "type": "number",
             "description": "Brightness multiplier for environment.",
-            "default": 1.0
+            "default": 1.0,
+            "minimum": 0.0
         },
         "irradianceCoefficients": {
             "description": "Declares spherical harmonic coefficients for irradiance up to l=2. This is a 9x3 array.",

--- a/extensions/2.0/Vendor/EXT_lights_image_based/schema/light.schema.json
+++ b/extensions/2.0/Vendor/EXT_lights_image_based/schema/light.schema.json
@@ -53,8 +53,7 @@
         "specularImageSize": {
             "type": "integer",
             "description": "The dimension (in pixels) of the first specular mip. This is needed to determine, pre-load, the total number of mips needed.",
-            "minimum": 0,
-            "exclusiveMinimum": true
+            "minimum": 1
         },
         "name": { },
         "extensions": { },

--- a/extensions/2.0/Vendor/EXT_lights_image_based/schema/light.schema.json
+++ b/extensions/2.0/Vendor/EXT_lights_image_based/schema/light.schema.json
@@ -51,15 +51,15 @@
             "minItems": 1
         },
         "specularImageSize": {
-            "type": "number",
-            "description": "The maximum dimension (in pixels) of the first specular mip. This is needed to determine, pre-load, the total number of mips needed.",
-            "minimum": 0
+            "type": "integer",
+            "description": "The dimension (in pixels) of the first specular mip. This is needed to determine, pre-load, the total number of mips needed.",
+            "minimum": 0,
+            "exclusiveMinimum": true
         },
         "name": { },
         "extensions": { },
         "extras": { }
     },
-    "additionalProperties": false,
     "required": [
         "irradianceCoefficients",
         "specularImages",

--- a/extensions/2.0/Vendor/EXT_lights_image_based/schema/scene.EXT_lights_image_based.schema.json
+++ b/extensions/2.0/Vendor/EXT_lights_image_based/schema/scene.EXT_lights_image_based.schema.json
@@ -2,6 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "EXT_lights_imageBased scene extension",
     "type": "object",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "light": {
             "allOf": [
@@ -10,10 +11,11 @@
                 }
             ],
             "description": "The id of the light referenced by this scene."
-        }
+        },
+        "extensions": { },
+        "extras": { }
     },
     "required":[
         "light"
-    ],
-    "additionalProperties": false
+    ]
 }


### PR DESCRIPTION
- Addresses #1491 
- Updates for `specularImageSize`:
  - description to match the spec;
  - enforcing integer type;
  - disallowing `0`.

Should we also disallow negative `intensity`?