### PR TITLE
Update KHR_lights_punctual to use glTF-style enum.

### DIFF
--- a/extensions/2.0/Khronos/KHR_lights_punctual/schema/light.schema.json
+++ b/extensions/2.0/Khronos/KHR_lights_punctual/schema/light.schema.json
@@ -19,7 +19,7 @@
         },
         "intensity": {
             "type": "number",
-            "description": "Intensity of the light source. \"point\" and \"spot\" lights use luminous intensity in candela (lm/sr) while \"directional\" lights use illuminance in lux (lm/m^2)",
+            "description": "Intensity of the light source. `point` and `spot` lights use luminous intensity in candela (lm/sr) while `directional` lights use illuminance in lux (lm/m^2)",
             "default": 1.0,
             "minimum": 0
         },

--- a/extensions/2.0/Khronos/KHR_lights_punctual/schema/light.schema.json
+++ b/extensions/2.0/Khronos/KHR_lights_punctual/schema/light.schema.json
@@ -19,7 +19,7 @@
         },
         "intensity": {
             "type": "number",
-            "description": "Intensity of the light source. `point` and `spot` lights use luminous intensity in candela (lm/sr) while `directional` lights use illuminance in lux (lm/m^2)",
+            "description": "Intensity of the light source. \"point\" and \"spot\" lights use luminous intensity in candela (lm/sr) while \"directional\" lights use illuminance in lux (lm/m^2)",
             "default": 1.0,
             "minimum": 0
         },
@@ -30,10 +30,22 @@
         "type": {
             "type": "string",
             "description": "Specifies the light type.",
-            "enum": [
-                "directional",
-                "point",
-                "spot"
+            "anyOf": [
+                {
+                    "enum": [ "directional" ],
+                    "description": "Directional lights act as though they are infinitely far away and emit light in the direction of the local -z axis. This light type inherits the orientation of the node that it belongs to; position and scale are ignored except for their effect on the inherited node orientation. Because it is at an infinite distance, the light is not attenuated. Its intensity is defined in lumens per metre squared, or lux (lm/m^2)."
+                },
+                {
+                    "enum": [ "point" ],
+                    "description": "Point lights emit light in all directions from their position in space; rotation and scale are ignored except for their effect on the inherited node position. The brightness of the light attenuates in a physically correct manner as distance increases from the light's position (i.e. brightness goes like the inverse square of the distance). Point light intensity is defined in candela, which is lumens per square radian (lm/sr)."
+                },
+                {
+                    "enum": [ "spot" ],
+                    "description": "Spot lights emit light in a cone in the direction of the local -z axis. The angle and falloff of the cone is defined using two numbers, the innerConeAngle and outerConeAngle. As with point lights, the brightness also attenuates in a physically correct manner as distance increases from the light's position (i.e. brightness goes like the inverse square of the distance). Spot light intensity refers to the brightness inside the innerConeAngle (and at the location of the light) and is defined in candela, which is lumens per square radian (lm/sr). Engines that don't support two angles for spotlights should use outerConeAngle as the spotlight angle (leaving innerConeAngle to implicitly be 0)."
+                },
+                {
+                    "type": "string"
+                }
             ]
         },
         "range": {


### PR DESCRIPTION
This updates `KHR_lights_punctual` to use the same style of enums as the rest of the glTF schemas.  The new enum descriptions are just copy/paste from the main README.

/cc @donmccurdy @MiiBond 