### PR TITLE
Fix Draco loader links.

### DIFF
--- a/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md
+++ b/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md
@@ -28,7 +28,7 @@ The [conformance](#conformance) section specifies what an implementation must do
 
 If a `primitive` contains an `extension` property and the `extension` property defines its `KHR_draco_mesh_compression` property, then the Draco geometry compression must be used.
 
-The following picture shows the structure of the schema update. 
+The following picture shows the structure of the schema update.
 
 **Figure 1**: Structure of geometry compression extension.
 ![](figures/structure.png)
@@ -44,7 +44,7 @@ If the uncompressed version of the asset is not provided, then `KHR_draco_mesh_c
 If the `KHR_draco_mesh_compression` property is set in `extensionsRequired` then the primitive must only contain the Draco compressed data.
 If a Draco compressed version of the asset is provided then `KHR_draco_mesh_compression` must be added to `extensionsUsed`.
 
-Usage of the extension must be listed in the `extensionsUsed`. 
+Usage of the extension must be listed in the `extensionsUsed`.
 
 ```javascript
 "extensionsUsed" : [
@@ -115,7 +115,7 @@ For full details on the `KHR_draco_mesh_compression` extension properties, see t
 
 * [extension property (the entirety of this specification is normative and included in Scope)](schema/node.KHR_draco_mesh_compression.schema.json)
 
-## Conformance 
+## Conformance
 
 Below is the recommended process when a loader encounters a glTF asset with the Draco extension set:
 
@@ -124,7 +124,7 @@ Below is the recommended process when a loader encounters a glTF asset with the 
 * If the loader does support the Draco extension, but will not process `KHR_draco_mesh_compression`, then the loader must load the glTF asset ignoring `KHR_draco_mesh_compression` in `primitive`.
 * If the loader does support the Draco extension, and will process `KHR_draco_mesh_compression` then:
     * The loader must process `KHR_draco_mesh_compression` first. The loader must get the data from `KHR_draco_mesh_compression`'s `bufferView` property and decompress the data using a Draco decoder to a Draco geometry.
-    * Then the loader must process `attributes` and `indices` properties of the `primitive`. When loading each `accessor`, you must ignore the `bufferView` and `byteOffset` of the `accessor` and go to the previously decoded Draco geometry in the `primitive` to get the data of indices and attributes. A loader must use the decompressed data to fill the `accessors` or render the decompressed Draco geometry directly (e.g. [ThreeJS (non-normative)](https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/draco/DRACOLoader.js)).
+    * Then the loader must process `attributes` and `indices` properties of the `primitive`. When loading each `accessor`, you must ignore the `bufferView` and `byteOffset` of the `accessor` and go to the previously decoded Draco geometry in the `primitive` to get the data of indices and attributes. A loader must use the decompressed data to fill the `accessors` or render the decompressed Draco geometry directly (e.g. [ThreeJS (non-normative)](https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/DRACOLoader.js)).
     * If additional attributes are defined in `primitive`'s `attributes`, but not defined in `KHR_draco_mesh_compression`'s `attributes`, then the loader must process the additional attributes as usual.
 
 ## Implementation note
@@ -141,59 +141,59 @@ Draco compression may change the order and number of vertices in a mesh. To sati
 
 * [Draco Open Source Library](https://github.com/google/draco)
 * [ThreeJS
-  Loader](https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/draco/DRACOLoader.js)
+  Loader](https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/DRACOLoader.js)
   and
   [example](https://github.com/mrdoob/three.js/blob/dev/examples/webgl_loader_draco.html)
 
 ## Appendix: Full Khronos Copyright Statement
 
-Copyright 2013-2017 The Khronos Group Inc. 
+Copyright 2013-2017 The Khronos Group Inc.
 
 Some parts of this Specification are purely informative and do not define requirements
 necessary for compliance and so are outside the Scope of this Specification. These
-parts of the Specification are marked as being non-normative, or identified as 
+parts of the Specification are marked as being non-normative, or identified as
 **Implementation Notes**.
- 
+
 Where this Specification includes normative references to external documents, only the
 specifically identified sections and functionality of those external documents are in
 Scope. Requirements defined by external documents not created by Khronos may contain
 contributions from non-members of Khronos not covered by the Khronos Intellectual
 Property Rights Policy.
 
-This specification is protected by copyright laws and contains material proprietary 
-to Khronos. Except as described by these terms, it or any components 
-may not be reproduced, republished, distributed, transmitted, displayed, broadcast 
-or otherwise exploited in any manner without the express prior written permission 
-of Khronos. 
+This specification is protected by copyright laws and contains material proprietary
+to Khronos. Except as described by these terms, it or any components
+may not be reproduced, republished, distributed, transmitted, displayed, broadcast
+or otherwise exploited in any manner without the express prior written permission
+of Khronos.
 
-This specification has been created under the Khronos Intellectual Property Rights 
+This specification has been created under the Khronos Intellectual Property Rights
 Policy, which is Attachment A of the Khronos Group Membership Agreement available at
-www.khronos.org/files/member_agreement.pdf. Khronos grants a conditional 
-copyright license to use and reproduce the unmodified specification for any purpose, 
-without fee or royalty, EXCEPT no licenses to any patent, trademark or other 
-intellectual property rights are granted under these terms. Parties desiring to 
-implement the specification and make use of Khronos trademarks in relation to that 
-implementation, and receive reciprocal patent license protection under the Khronos 
-IP Policy must become Adopters and confirm the implementation as conformant under 
-the process defined by Khronos for this specification; 
+www.khronos.org/files/member_agreement.pdf. Khronos grants a conditional
+copyright license to use and reproduce the unmodified specification for any purpose,
+without fee or royalty, EXCEPT no licenses to any patent, trademark or other
+intellectual property rights are granted under these terms. Parties desiring to
+implement the specification and make use of Khronos trademarks in relation to that
+implementation, and receive reciprocal patent license protection under the Khronos
+IP Policy must become Adopters and confirm the implementation as conformant under
+the process defined by Khronos for this specification;
 see https://www.khronos.org/adopters.
 
-Khronos makes no, and expressly disclaims any, representations or warranties, 
-express or implied, regarding this specification, including, without limitation: 
-merchantability, fitness for a particular purpose, non-infringement of any 
-intellectual property, correctness, accuracy, completeness, timeliness, and 
-reliability. Under no circumstances will Khronos, or any of its Promoters, 
-Contributors or Members, or their respective partners, officers, directors, 
-employees, agents or representatives be liable for any damages, whether direct, 
-indirect, special or consequential damages for lost revenues, lost profits, or 
+Khronos makes no, and expressly disclaims any, representations or warranties,
+express or implied, regarding this specification, including, without limitation:
+merchantability, fitness for a particular purpose, non-infringement of any
+intellectual property, correctness, accuracy, completeness, timeliness, and
+reliability. Under no circumstances will Khronos, or any of its Promoters,
+Contributors or Members, or their respective partners, officers, directors,
+employees, agents or representatives be liable for any damages, whether direct,
+indirect, special or consequential damages for lost revenues, lost profits, or
 otherwise, arising from or in connection with these materials.
 
-Vulkan is a registered trademark and Khronos, OpenXR, SPIR, SPIR-V, SYCL, WebGL, 
-WebCL, OpenVX, OpenVG, EGL, COLLADA, glTF, NNEF, OpenKODE, OpenKCAM, StreamInput, 
-OpenWF, OpenSL ES, OpenMAX, OpenMAX AL, OpenMAX IL, OpenMAX DL, OpenML and DevU are 
-trademarks of The Khronos Group Inc. ASTC is a trademark of ARM Holdings PLC, 
-OpenCL is a trademark of Apple Inc. and OpenGL and OpenML are registered trademarks 
-and the OpenGL ES and OpenGL SC logos are trademarks of Silicon Graphics 
-International used under license by Khronos. All other product names, trademarks, 
-and/or company names are used solely for identification and belong to their 
+Vulkan is a registered trademark and Khronos, OpenXR, SPIR, SPIR-V, SYCL, WebGL,
+WebCL, OpenVX, OpenVG, EGL, COLLADA, glTF, NNEF, OpenKODE, OpenKCAM, StreamInput,
+OpenWF, OpenSL ES, OpenMAX, OpenMAX AL, OpenMAX IL, OpenMAX DL, OpenML and DevU are
+trademarks of The Khronos Group Inc. ASTC is a trademark of ARM Holdings PLC,
+OpenCL is a trademark of Apple Inc. and OpenGL and OpenML are registered trademarks
+and the OpenGL ES and OpenGL SC logos are trademarks of Silicon Graphics
+International used under license by Khronos. All other product names, trademarks,
+and/or company names are used solely for identification and belong to their
 respective owners.


### PR DESCRIPTION
The ThreeJS Draco links were 404 errors, so I updated them.  Looks like VSCode pulled out some trailing spaces as well.