### PR TITLE
Explain why texture.source is not always required

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -3717,7 +3717,7 @@ A texture and its sampler.
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**sampler**|`integer`|The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.|No|
-|**source**|`integer`|The index of the image used by this texture. When undefined, an extension must supply an alternate texture source.|No|
+|**source**|`integer`|The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source.|No|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
@@ -3736,7 +3736,7 @@ The index of the sampler used by this texture. When undefined, a sampler with re
 
 #### texture.source
 
-The index of the image used by this texture. When undefined, an extension must supply an alternate texture source.
+The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source.
 
 * **Type**: `integer`
 * **Required**: No

--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -3717,7 +3717,7 @@ A texture and its sampler.
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**sampler**|`integer`|The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.|No|
-|**source**|`integer`|The index of the image used by this texture.|No|
+|**source**|`integer`|The index of the image used by this texture. When undefined, an extension must supply an alternate texture source.|No|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
@@ -3736,7 +3736,7 @@ The index of the sampler used by this texture. When undefined, a sampler with re
 
 #### texture.source
 
-The index of the image used by this texture.
+The index of the image used by this texture. When undefined, an extension must supply an alternate texture source.
 
 * **Type**: `integer`
 * **Required**: No

--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -3717,7 +3717,7 @@ A texture and its sampler.
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**sampler**|`integer`|The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.|No|
-|**source**|`integer`|The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source.|No|
+|**source**|`integer`|The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined.|No|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
@@ -3736,7 +3736,7 @@ The index of the sampler used by this texture. When undefined, a sampler with re
 
 #### texture.source
 
-The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source.
+The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined.
 
 * **Type**: `integer`
 * **Required**: No

--- a/specification/2.0/schema/texture.schema.json
+++ b/specification/2.0/schema/texture.schema.json
@@ -11,7 +11,7 @@
         },
         "source": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the image used by this texture."
+            "description": "The index of the image used by this texture. When undefined, an extension must supply an alternate texture source."
         },
         "name": { },
         "extensions": { },

--- a/specification/2.0/schema/texture.schema.json
+++ b/specification/2.0/schema/texture.schema.json
@@ -11,7 +11,7 @@
         },
         "source": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source."
+            "description": "The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined."
         },
         "name": { },
         "extensions": { },

--- a/specification/2.0/schema/texture.schema.json
+++ b/specification/2.0/schema/texture.schema.json
@@ -11,7 +11,7 @@
         },
         "source": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the image used by this texture. When undefined, an extension must supply an alternate texture source."
+            "description": "The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source."
         },
         "name": { },
         "extensions": { },


### PR DESCRIPTION
Fixes #1226.