### PR TITLE
Change three vendor extensions from "Draft" to "Complete"

### DIFF
--- a/extensions/2.0/Vendor/AGI_articulations/README.md
+++ b/extensions/2.0/Vendor/AGI_articulations/README.md
@@ -8,7 +8,7 @@
 
 ## Status
 
-Draft
+Complete
 
 ## Dependencies
 

--- a/extensions/2.0/Vendor/AGI_stk_metadata/README.md
+++ b/extensions/2.0/Vendor/AGI_stk_metadata/README.md
@@ -8,7 +8,7 @@
 
 ## Status
 
-Draft
+Complete
 
 ## Dependencies
 

--- a/extensions/2.0/Vendor/EXT_texture_webp/README.md
+++ b/extensions/2.0/Vendor/EXT_texture_webp/README.md
@@ -7,7 +7,7 @@
 
 ## Status
 
-Draft
+Complete
 
 ## Dependencies
 


### PR DESCRIPTION
* `EXT_texture_webp`
* `AGI_articulations`
* `AGI_stk_metadata`

These three extensions had status `Draft`, and should now be considered `Complete` as they have shipped (or soon be shipped) with production software.

/cc @OmarShehata 