### PR TITLE
Add section to README.md for formats built on glTF

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ To compare WebGL-based glTF loaders, see [gltf-test](https://github.com/cx20/glt
 
 * [glTF-Generator-Registry](https://github.com/KhronosGroup/glTF-Generator-Registry/) - An open registry of tools that create glTF assets, along with structured metadata such as links to documentation and bug trackers.
 
-## Fomats built on glTF
+## Formats built on glTF
 
 * [3D Tiles](https://github.com/AnalyticalGraphicsInc/3d-tiles) - An open standard for streaming and rendering massive heterogenous 3D content.
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,10 @@ To compare WebGL-based glTF loaders, see [gltf-test](https://github.com/cx20/glt
 
 * [glTF-Generator-Registry](https://github.com/KhronosGroup/glTF-Generator-Registry/) - An open registry of tools that create glTF assets, along with structured metadata such as links to documentation and bug trackers.
 
+## Fomats built on glTF
+
+* [3D Tiles](https://github.com/AnalyticalGraphicsInc/3d-tiles) - An open standard for streaming and rendering massive heterogenous 3D content.
+
 ## Stack Overflow
 
 * [glTF tagged](http://stackoverflow.com/questions/tagged/gltf) questions

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ To compare WebGL-based glTF loaders, see [gltf-test](https://github.com/cx20/glt
 
 * [glTF-Generator-Registry](https://github.com/KhronosGroup/glTF-Generator-Registry/) - An open registry of tools that create glTF assets, along with structured metadata such as links to documentation and bug trackers.
 
-## Formats built on glTF
+## Formats Built on glTF
 
 * [3D Tiles](https://github.com/AnalyticalGraphicsInc/3d-tiles) - An open standard for streaming and rendering massive heterogenous 3D content.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Please provide spec feedback and community updates by submitting [issues](https:
         - [Swift](#swift)
     - [Utilities](#utilities)
     - [Resources](#resources)
+- [Formats Built on glTF](#formats-built-on-gltf)
 - [Stack Overflow](#stack-overflow)
 - [Presentations and Articles](#presentations-and-articles)
     - [Intros](#intros)


### PR DESCRIPTION
Adds a new section to `README.md` for formats built on glTF.

Following [the announced OGC and Khronos Liaison](https://www.khronos.org/news/press/ogc-and-khronos-form-a-liaison-to-improve-interoperability-within-the-geospatial-and-3d-graphics-communities), this seeks to promote glTF as standard foundation which can be referenced by other formats. To support that, should we include [Web3D's SRC format](http://www.web3d.org/src-and-gltf) and the [VRM format (still draft)](https://dwango.github.io/en/vrm/)?