### PR TITLE
FB_geometry_metadata extension

### DIFF
--- a/extensions/2.0/Vendor/FB_geometry_metadata/README.md
+++ b/extensions/2.0/Vendor/FB_geometry_metadata/README.md
@@ -46,6 +46,9 @@ The summary data is defined as an optional extension to a glTF `scene`, by addin
 }
 ```
 
+## Limitations
+This extension completely disregards animation: the static transforms, as supplied on each `node`, are taken at face value. No skeletal animations are applied, nor any morph targets.
+
 ## Computing the data
 
 Conceptually, computing and gathering this information is very straight-forward. On a hypothetical glTF `node` object:

--- a/extensions/2.0/Vendor/FB_geometry_metadata/README.md
+++ b/extensions/2.0/Vendor/FB_geometry_metadata/README.md
@@ -15,7 +15,7 @@ Written against the glTF 2.0 spec.
 
 ## Overview
 
-This extension annotates glTF `scene` objects with a summary of the cumulative geometric complexity and world-space extents of the scene's associated scene graph. Each recursively referenced mesh is enumerated for total vertex and primitive count, and each individual vertex is transformed into world-space for a perfectly computed bounding box.
+This extension annotates glTF `scene` objects with a summary of the cumulative geometric complexity and scene-space extents of the scene's associated scene graph. Each recursively referenced mesh is enumerated for total vertex and primitive count, and each individual vertex is transformed into scene-space for a perfectly computed bounding box.
 
 Some proven real-world applications for this information:
 - When a viewer needs to make a quick, high-level decision which `scene` to display. This is perhaps most meaningful e.g. when `scenes` are used to represent different variants (e.g. LoD levels) of a model.
@@ -30,7 +30,7 @@ The summary data is defined as an optional extension to a glTF `scene`, by addin
     "FB_geometry_metadata" : {
         "vertexCount": 28727,
         "primitiveCount": 15451,
-        "worldBounds": {
+        "sceneBounds": {
             "min": [
                 -3.0651053919852,
                 0,
@@ -47,7 +47,7 @@ The summary data is defined as an optional extension to a glTF `scene`, by addin
 ```
 
 ## Limitations
-All these values should be computed with disregard for animation: an morph targets are inactive, all `node` transforms are in their static form, unaffected by any animation. Consequiently, any application that parses the model should interpret the values the same way.
+All these values should be computed with disregard for animation: all morph targets are inactive, all `node` transforms are in their static form and unaffected by any animation. Consequently, an application that parses the model should interpret the values the same way.
 
 ## Computing the data
 

--- a/extensions/2.0/Vendor/FB_geometry_metadata/README.md
+++ b/extensions/2.0/Vendor/FB_geometry_metadata/README.md
@@ -1,0 +1,105 @@
+# FB\_geometry\_metadata
+
+## Contributors
+
+* Pär Winzell, Facebook, [@zellski](https://twitter.com/zellski)
+* Andrew Prasetyo Jo, Facebook
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension annotates glTF `scene` objects with a summary of the cumulative geometric complexity and world-space extents of the scene's associated scene graph. Each recursively referenced mesh is enumerated for total vertex and primitive count, and each individual vertex is transformed into world-space for a perfectly computed bounding box.
+
+Some proven real-world applications for this information:
+- When a viewer needs to make a quick, high-level decision which `scene` to display. This is perhaps most meaningful e.g. when `scenes` are used to represent different variants (e.g. LoD levels) of a model.
+- When server-side systems need to make decisions based on geometric complexity, and don't want to have to include their own complex matrix/vector code.
+
+## Specifying Geometry Data
+
+The summary data is defined as an optional extension to a glTF `scene`, by adding an `extensions` property and defining a `KHR_lights_punctual` property with a `lights` array inside it:
+
+```javascript
+"extensions": {
+    "FB_geometry_metadata" : {
+        "vertexCount": 28727,
+        "primitiveCount": 15451,
+        "worldBounds": {
+            "min": [
+                -3.0651053919852,
+                0,
+                -2.6551087079312
+            ],
+            "max": [
+                3.0651053919852,
+                9.8512265772065,
+                2.6538096091834
+            ]
+        }
+    }
+}
+```
+
+## Computing the data
+
+Conceptually, computing and gathering this information is very straight-forward. On a hypothetical glTF `node` object:
+
+```javascript
+  public function computeGeometryMetadata(
+    GltfMat44f $world_transform,
+    inout A3DGltfBounds $bounds,
+    inout int $vertex_count,
+    inout int $primitive_count,
+  ): void {
+    // compute world transform forward
+    $world_transform = A3DGltfMath::multiplyMatrices(
+      $world_transform,
+      $this->computeLocalTransform(),
+    );
+
+    // if this node references a mesh, traverse it
+    $this->mesh?->computeGeometryMetadata(
+      $world_transform,
+      inout $bounds,
+      inout $vertex_count,
+      inout $primitive_count,
+    );
+
+    // depth-first scene graph traversal
+    foreach ($this->getChildren() as $child) {
+      $child->computeGeometryMetadata(
+        $world_transform,
+        inout $bounds,
+        inout $vertex_count,
+        inout $primitive_count,
+      );
+    }
+  }
+```
+
+and on the `mesh` `primitive`, simply:
+
+```javascript
+  public function computeGeometryMetadata(
+    GltfMat44f $world_transform,
+    inout A3DGltfBounds $bounds,
+    inout int $vertex_count,
+    inout int $primitive_count,
+  ): void {
+    $vertex_count += $this->getVertexCount();
+    $primitive_count += $this->getPrimitiveCount();
+
+    // this is very expensive, and will one day move to native code
+    foreach ($this->positions as $position) {
+      $bounds->expandByVec(
+        A3DGltfMath::transformVec3($world_transform, $position),
+      );
+    }
+  }
+```

--- a/extensions/2.0/Vendor/FB_geometry_metadata/README.md
+++ b/extensions/2.0/Vendor/FB_geometry_metadata/README.md
@@ -47,7 +47,7 @@ The summary data is defined as an optional extension to a glTF `scene`, by addin
 ```
 
 ## Limitations
-This extension completely disregards animation: the static transforms, as supplied on each `node`, are taken at face value. No skeletal animations are applied, nor any morph targets.
+All these values should be computed with disregard for animation: an morph targets are inactive, all `node` transforms are in their static form, unaffected by any animation. Consequiently, any application that parses the model should interpret the values the same way.
 
 ## Computing the data
 

--- a/extensions/2.0/Vendor/FB_geometry_metadata/schema/scene.FB_geometry_metadata.schema.json
+++ b/extensions/2.0/Vendor/FB_geometry_metadata/schema/scene.FB_geometry_metadata.schema.json
@@ -2,27 +2,33 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "FB_geometry_metadata scene extension",
     "type": "object",
-    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
-    "properties" : {
-	"vertexCount": {
-            "type" : "number",
-            "description" : "The number of distinct vertices recursively contained in this scene.",
-            "default" : 0,
-            "minimum": 0,
-            "exclusiveMaximum": true
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "vertexCount": {
+            "type": "number",
+            "description": "The number of distinct vertices recursively contained in this scene.",
+            "default": 0,
+            "minimum": 0
         },
-	"primitiveCount": {
-            "type" : "number",
-            "description" : "The number of distinct primitives recursively contained in this scene.",
-            "default" : 0,
-            "minimum": 0,
-            "exclusiveMaximum": true
+        "primitiveCount": {
+            "type": "number",
+            "description": "The number of distinct primitives recursively contained in this scene.",
+            "default": 0,
+            "minimum": 0
         },
-	"worldBounds": {
-            "description" : "The bounding box of this scene, in static geometry world space coordinates.",
-            "allOf": [ { "$ref": "worldBounds.schema.json" } ],
+        "worldBounds": {
+            "description": "The bounding box of this scene, in static geometry world space coordinates.",
+            "allOf": [
+                {
+                    "$ref": "worldBounds.schema.json"
+                }
+            ]
         },
-        "extensions": { },
-        "extras": { }
+        "extensions": {},
+        "extras": {}
     }
 }

--- a/extensions/2.0/Vendor/FB_geometry_metadata/schema/scene.FB_geometry_metadata.schema.json
+++ b/extensions/2.0/Vendor/FB_geometry_metadata/schema/scene.FB_geometry_metadata.schema.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "FB_geometry_metadata scene extension",
+    "type": "object",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties" : {
+	"vertexCount": {
+            "type" : "number",
+            "description" : "The number of distinct vertices recursively contained in this scene.",
+            "default" : 0,
+            "minimum": 0,
+            "exclusiveMaximum": true
+        },
+	"primitiveCount": {
+            "type" : "number",
+            "description" : "The number of distinct primitives recursively contained in this scene.",
+            "default" : 0,
+            "minimum": 0,
+            "exclusiveMaximum": true
+        },
+	"worldBounds": {
+            "description" : "The bounding box of this scene, in static geometry world space coordinates.",
+            "allOf": [ { "$ref": "worldBounds.schema.json" } ],
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}

--- a/extensions/2.0/Vendor/FB_geometry_metadata/schema/scene.FB_geometry_metadata.schema.json
+++ b/extensions/2.0/Vendor/FB_geometry_metadata/schema/scene.FB_geometry_metadata.schema.json
@@ -20,11 +20,11 @@
             "default": 0,
             "minimum": 0
         },
-        "worldBounds": {
-            "description": "The bounding box of this scene, in static geometry world space coordinates.",
+        "sceneBounds": {
+            "description": "The bounding box of this scene, in static geometry scene-space coordinates.",
             "allOf": [
                 {
-                    "$ref": "worldBounds.schema.json"
+                    "$ref": "sceneBounds.schema.json"
                 }
             ]
         },

--- a/extensions/2.0/Vendor/FB_geometry_metadata/schema/sceneBounds.schema.json
+++ b/extensions/2.0/Vendor/FB_geometry_metadata/schema/sceneBounds.schema.json
@@ -13,7 +13,7 @@
             "items": {
                 "type": "number"
             },
-            "description": "The bounding box corner with the numerically lowest world-space coordinates",
+            "description": "The bounding box corner with the numerically lowest scene-space coordinates",
             "minItems": 3,
             "maxItems": 3
         },
@@ -22,7 +22,7 @@
             "items": {
                 "type": "number"
             },
-            "description": "The bounding box corner with the numerically highest world-space coordinates",
+            "description": "The bounding box corner with the numerically highest scene-space coordinates",
             "minItems": 3,
             "maxItems": 3
         },

--- a/extensions/2.0/Vendor/FB_geometry_metadata/schema/worldBounds.schema.json
+++ b/extensions/2.0/Vendor/FB_geometry_metadata/schema/worldBounds.schema.json
@@ -2,30 +2,35 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "minimum and maximum bounding box extent",
     "type": "object",
-    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
-    "properties" : {
-	"min": {
-            "type" : "array",
-	    "items" {
-		"type": "number",
-	    }
-            "description" : "The bounding box corner with the numerically lowest world-space coordinates",
-	    "minItems": 3,
-	    "maxItems": 3
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "min": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            },
+            "description": "The bounding box corner with the numerically lowest world-space coordinates",
+            "minItems": 3,
+            "maxItems": 3
         },
-	"max": {
-            "type" : "array",
-	    "items" {
-		"type": "number",
-	    }
-            "description" : "The bounding box corner with the numerically highest world-space coordinates",
-	    "minItems": 3,
-	    "maxItems": 3
+        "max": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            },
+            "description": "The bounding box corner with the numerically highest world-space coordinates",
+            "minItems": 3,
+            "maxItems": 3
         },
-        "extensions": { },
-        "extras": { }
+        "extensions": {},
+        "extras": {}
     },
     "required": [
-        "min", "max"
+        "min",
+        "max"
     ]
 }

--- a/extensions/2.0/Vendor/FB_geometry_metadata/schema/worldBounds.schema.json
+++ b/extensions/2.0/Vendor/FB_geometry_metadata/schema/worldBounds.schema.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "minimum and maximum bounding box extent",
+    "type": "object",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties" : {
+	"min": {
+            "type" : "array",
+	    "items" {
+		"type": "number",
+	    }
+            "description" : "The bounding box corner with the numerically lowest world-space coordinates",
+	    "minItems": 3,
+	    "maxItems": 3
+        },
+	"max": {
+            "type" : "array",
+	    "items" {
+		"type": "number",
+	    }
+            "description" : "The bounding box corner with the numerically highest world-space coordinates",
+	    "minItems": 3,
+	    "maxItems": 3
+        },
+        "extensions": { },
+        "extras": { }
+    },
+    "required": [
+        "min", "max"
+    ]
+}


### PR DESCRIPTION
This is a fairly rough write-up of an extension we use internally to provide some geometry-related summary information to parts of our system that can't or don't want to compute it themselves.

I'm not sure it has relevance for the rest of the world, but perhaps we can use this conversation thread to find out!

The schema files should be schematically valid JSON, but I'm not sure if they make semantic sense. In general, feedback is very welcome.