### PR TITLE
Add links to PDF and other forms of reference cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,15 @@ Please provide spec feedback and community updates by submitting [issues](https:
 
 <p align="center">
 <a href="specification/2.0/figures/gltfOverview-2.0.0b.png"><img src="specification/2.0/figures/gltfOverview-2.0.0b-small.png" /></a>
-  <sup>From <a href=https://github.com/javagl/gltfOverview/>github.com/javagl/gltfOverview/</a></sup><br>
-<a href=https://github.com/randall2835/gltfOverviewJapanese/releases/download/v0.1/gltfOverview2.0-Japanese.png>Japanese translation</a> by <a href=https://github.com/randall2835/gltfOverviewJapanese>Takuto Takahashi</a>
+  <sup>
+    From <a href=https://github.com/javagl/gltfOverview/>github.com/javagl/gltfOverview/</a> |
+    <a href="https://www.khronos.org/files/gltf20-reference-guide.pdf">PDF</a> |
+    <a href="https://www.lulu.com/shop/khronos-group/gltf-20-quick-reference/paperback/product-23977667.html">hardcopy</a> |
+    <a href="https://www.khronos.org/developers/reference-cards/">Khronos reference cards</a>
+  </sup><br>
+  <sup>
+    <a href=https://github.com/randall2835/gltfOverviewJapanese/releases/download/v0.1/gltfOverview2.0-Japanese.png>Japanese translation</a> by <a href=https://github.com/randall2835/gltfOverviewJapanese>Takuto Takahashi</a>
+  </sup>
 </p>
 
 


### PR DESCRIPTION
I knew these links existed somewhere, but I think it makes sense to gather them into the caption below the main overview card, for better discoverability.

via https://github.com/javagl/gltfOverview/issues/9

/cc @javagl 