### PR TITLE
Add some missing types in json schema

### DIFF
--- a/specification/2.0/schema/accessor.schema.json
+++ b/specification/2.0/schema/accessor.schema.json
@@ -124,8 +124,8 @@
             "allOf": [ { "$ref": "accessor.sparse.schema.json" } ],
             "description": "Sparse storage of attributes that deviate from their initialization value."
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "dependencies": {

--- a/specification/2.0/schema/accessor.sparse.indices.schema.json
+++ b/specification/2.0/schema/accessor.sparse.indices.schema.json
@@ -39,7 +39,7 @@
                 }
             ]
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "bufferView", "componentType" ]

--- a/specification/2.0/schema/accessor.sparse.schema.json
+++ b/specification/2.0/schema/accessor.sparse.schema.json
@@ -19,7 +19,7 @@
             "allOf": [ { "$ref": "accessor.sparse.values.schema.json" } ],
             "description": "Array of size `count` times number of components, storing the displaced accessor attributes pointed by `indices`. Substituted values must have the same `componentType` and number of components as the base accessor."
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "count", "indices", "values" ]

--- a/specification/2.0/schema/animation.channel.schema.json
+++ b/specification/2.0/schema/animation.channel.schema.json
@@ -14,7 +14,7 @@
             "allOf": [ { "$ref": "animation.channel.target.schema.json" } ],
             "description": "The index of the node and TRS property to target."
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "sampler", "target" ]

--- a/specification/2.0/schema/animation.sampler.schema.json
+++ b/specification/2.0/schema/animation.sampler.schema.json
@@ -37,7 +37,7 @@
             "description": "The index of an accessor, containing keyframe output values.",
             "gltf_detailedDescription": "The index of an accessor containing keyframe output values. When targeting translation or scale paths, the `accessor.componentType` of the output values must be `FLOAT`. When targeting rotation or morph weights, the `accessor.componentType` of the output values must be `FLOAT` or normalized integer. For weights, each output element stores `SCALAR` values with a count equal to the number of morph targets."
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "input", "output" ]

--- a/specification/2.0/schema/animation.schema.json
+++ b/specification/2.0/schema/animation.schema.json
@@ -21,8 +21,8 @@
             },
             "minItems": 1
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "channels", "samplers" ]

--- a/specification/2.0/schema/asset.schema.json
+++ b/specification/2.0/schema/asset.schema.json
@@ -23,7 +23,7 @@
             "description": "The minimum glTF version that this asset targets.",
             "pattern": "^[0-9]+\\.[0-9]+$"
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "version" ]

--- a/specification/2.0/schema/buffer.schema.json
+++ b/specification/2.0/schema/buffer.schema.json
@@ -17,8 +17,8 @@
             "description": "The length of the buffer in bytes.",
             "minimum": 1
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "byteLength" ]

--- a/specification/2.0/schema/bufferView.schema.json
+++ b/specification/2.0/schema/bufferView.schema.json
@@ -48,8 +48,8 @@
                 }
             ]
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "buffer", "byteLength" ]

--- a/specification/2.0/schema/camera.orthographic.schema.json
+++ b/specification/2.0/schema/camera.orthographic.schema.json
@@ -24,7 +24,7 @@
             "description": "The floating-point distance to the near clipping plane.",
             "minimum": 0.0
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "xmag", "ymag", "zfar", "znear" ]

--- a/specification/2.0/schema/camera.perspective.schema.json
+++ b/specification/2.0/schema/camera.perspective.schema.json
@@ -32,7 +32,7 @@
             "exclusiveMinimum": true,
             "gltf_detailedDescription": "The floating-point distance to the near clipping plane."
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "yfov", "znear" ]

--- a/specification/2.0/schema/camera.schema.json
+++ b/specification/2.0/schema/camera.schema.json
@@ -28,8 +28,8 @@
                 }
             ]
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "type" ],

--- a/specification/2.0/schema/glTF.schema.json
+++ b/specification/2.0/schema/glTF.schema.json
@@ -144,7 +144,7 @@
             },
             "minItems": 1
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "dependencies": {

--- a/specification/2.0/schema/image.schema.json
+++ b/specification/2.0/schema/image.schema.json
@@ -30,8 +30,8 @@
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of the bufferView that contains the image. Use this instead of the image's uri property."
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "dependencies": {

--- a/specification/2.0/schema/material.normalTextureInfo.schema.json
+++ b/specification/2.0/schema/material.normalTextureInfo.schema.json
@@ -12,7 +12,7 @@
             "default": 1.0,
             "gltf_detailedDescription": "The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear."
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     }
 }

--- a/specification/2.0/schema/material.occlusionTextureInfo.schema.json
+++ b/specification/2.0/schema/material.occlusionTextureInfo.schema.json
@@ -14,7 +14,7 @@
             "maximum": 1.0,
             "gltf_detailedDescription": "A scalar multiplier controlling the amount of occlusion applied. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion. This value affects the resulting color using the formula: `occludedColor = lerp(color, color * <sampled occlusion texture value>, <occlusion strength>)`. This value is ignored if the corresponding texture is not specified. This value is linear."
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     }
 }

--- a/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
+++ b/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
@@ -44,7 +44,7 @@
             "description": "The metallic-roughness texture.",
             "gltf_detailedDescription": "The metallic-roughness texture. The metalness values are sampled from the B channel. The roughness values are sampled from the G channel. These values are linear. If other channels are present (R or A), they are ignored for metallic-roughness calculations."
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     }
 }

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -5,8 +5,8 @@
     "description": "The material appearance of a primitive.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { },
         "pbrMetallicRoughness": {
             "allOf": [ { "$ref": "material.pbrMetallicRoughness.schema.json" } ],

--- a/specification/2.0/schema/mesh.primitive.schema.json
+++ b/specification/2.0/schema/mesh.primitive.schema.json
@@ -80,7 +80,7 @@
             },
             "minItems": 1
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "gltf_webgl": "`drawElements()` and `drawArrays()`",

--- a/specification/2.0/schema/mesh.schema.json
+++ b/specification/2.0/schema/mesh.schema.json
@@ -21,8 +21,8 @@
             },
             "minItems": 1
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "primitives" ]

--- a/specification/2.0/schema/node.schema.json
+++ b/specification/2.0/schema/node.schema.json
@@ -79,8 +79,8 @@
                 "type": "number"
             }
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "dependencies": {

--- a/specification/2.0/schema/sampler.schema.json
+++ b/specification/2.0/schema/sampler.schema.json
@@ -117,8 +117,8 @@
                 }
             ]
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "gltf_webgl": "`texParameterf()`"

--- a/specification/2.0/schema/scene.schema.json
+++ b/specification/2.0/schema/scene.schema.json
@@ -14,8 +14,8 @@
             "uniqueItems": true,
             "minItems": 1
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     }
 }

--- a/specification/2.0/schema/skin.schema.json
+++ b/specification/2.0/schema/skin.schema.json
@@ -24,8 +24,8 @@
             "minItems": 1,
             "gltf_detailedDescription": "Indices of skeleton nodes, used as joints in this skin.  The array length must be the same as the `count` property of the `inverseBindMatrices` accessor (when defined)."
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "joints" ]

--- a/specification/2.0/schema/texture.schema.json
+++ b/specification/2.0/schema/texture.schema.json
@@ -13,8 +13,8 @@
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined."
         },
-        "name": { },
-        "extensions": { },
+        "name": { "type": "string" },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "gltf_webgl": "`createTexture()`, `deleteTexture()`, `bindTexture()`, `texImage2D()`, and `texParameterf()`"

--- a/specification/2.0/schema/textureInfo.schema.json
+++ b/specification/2.0/schema/textureInfo.schema.json
@@ -16,7 +16,7 @@
             "minimum": 0,
             "gltf_detailedDescription": "This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it."
         },
-        "extensions": { },
+        "extensions": { "type": "object" },
         "extras": { }
     },
     "required": [ "index" ]


### PR DESCRIPTION
This should fix #1584 
I tried to look at how to specify "any" types for the "extras" property on the JSON Schema docs (https://cswr.github.io/JsonSchema/spec/multiple_types/). We could use "anyOf" and list everything possible, but it seems a bit silly, so I haven't filled in this one.