### PR TITLE
Adobe_render_order extension proposal

### DIFF
--- a/extensions/2.0/Vendor/ADOBE_render_order/README.md
+++ b/extensions/2.0/Vendor/ADOBE_render_order/README.md
@@ -15,21 +15,35 @@ Written against the glTF 2.0 spec.
 
 ## Overview
 
-To avoid Z-fighting in two coplanar meshes render order is needed with depth writing and depth testing options. It could be helpful while drawing three-dimensional translucent objects to get different appeareances. If you want to render both opaque and translucent objects in the same scene, then you want to use the depth buffer to perform hidden-surface removal for any objects that lie behind the opaque objects. Therefore this extension adds four properties to node `group`, `renderOrder`, `depthTest` and `depthWrite`. `renderOrder` value allows the default rendering order of scene graph objects to be overridden although opaque and transparent objects remain sorted independently. When `group` property is set to true, all descendants nodes will be sorted and rendered together. Sorting is from lowest to highest renderOrder.
+To avoid Z-fighting in two coplanar meshes render order is needed with depth writing and depth testing options. It could be helpful while drawing three-dimensional translucent objects to get different appeareances. If you want to render both opaque and translucent objects in the same scene, then you want to use the depth buffer to perform hidden-surface removal for any objects that lie behind the opaque objects. Therefore this extension adds these properties to node `group`, `renderOrder`, `depthTest`, `depthFunc`, `depthWrite` and `colorWrite`. `renderOrder` value allows the default rendering order of scene graph objects to be overridden although opaque and transparent objects remain sorted independently. When `group` property is set to true, all descendants nodes will be sorted and rendered together. Sorting is from lowest to highest renderOrder.
 
 ## glTF Schema Updates
 
 It may contain the following properties:
 
-| Name       | Type       | Default      | Description |
-|----------|------------|--------------|--------------------------------- |
-| `group`   | `boolean` | `false` | specifies whether node is a group or not. |
-| `renderOrder`   | `integer` | `0` | The render order of the node in the parent group. |
-| `depthTest` | `boolean`   | `true`        | specifies whether to perform depth test or not. |
-| `depthWrite`    | `boolean` | `true` | specifies whether to perform depth write or not. |
+| Name          | Type      | Default       | Description                                       |
+|---------------|-----------|---------------|---------------------------------------------------|
+| `group`       | `boolean` | `false`       | specifies whether node is a group or not.         |
+| `renderOrder` | `integer` | `0`           | The render order of the node in the parent group. |
+| `depthTest`   | `boolean` | `true`        | specifies whether to perform depth test or not.   |
+| `depthFunc`   | `string`  | `"LESS"`      | specifies depth function to use.                  |
+| `depthWrite`  | `boolean` | `true`        | specifies whether to perform depth write or not.  |
+| `colorWrite`  | `boolean` | `true`        | specifes Whether to render the material's color.  |
 
+if none of the parent is specified as group and renderOrder is provided then scene node is considered as group. Marking leaf nodes as group will have no impact. If renderOrder is not provided it's default value is 0 i.e. will be rendered before others.
 
-if none of the parent is specified as group and renderOrder is provided then scene node is considered as group. Marking leaf nodes as group will have no impact.
+`depthFunc` can have following values:
+
+| Function      |                               Description                                                 |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| `"ALWAYS"`    | The depth test always passes.                                                             |
+| `"NEVER"`     | The depth test never passes.                                                              |
+| `"LESS"`      | Passes if the fragment's depth value is less than the stored depth value.                 |
+| `"EQUAL"`     | Passes if the fragment's depth value is equal to the stored depth value.                  |
+| `"LEQUAL"`    | Passes if the fragment's depth value is less than or equal to the stored depth value.     |
+| `"GREATER"`   | Passes if the fragment's depth value is greater than the stored depth value.              |
+| `"NOTEQUAL"`  | Passes if the fragment's depth value is not equal to the stored depth value.              |
+| `"GEQUAL"`    | Passes if the fragment's depth value is greater than or equal to the stored depth value.  |
 
 ### Example JSON
 

--- a/extensions/2.0/Vendor/ADOBE_render_order/README.md
+++ b/extensions/2.0/Vendor/ADOBE_render_order/README.md
@@ -83,6 +83,7 @@ if none of the parent is specified as group and renderOrder is provided then sce
                 "ADOBE_render_order": {
                 "renderOrder": 1,
                 "depthTest" : true,
+                "depthFunc" : "LESS",
                 "depthWrite" : false
                 }
             }
@@ -93,7 +94,9 @@ if none of the parent is specified as group and renderOrder is provided then sce
                 "ADOBE_render_order": {
                 "renderOrder": 1,
                 "depthTest" : true,
-                "depthWrite" : false
+                "depthFunc" : "LESS",
+                "depthWrite" : false,
+                "colorWrite" : false
                 }
             }
         }

--- a/extensions/2.0/Vendor/ADOBE_render_order/README.md
+++ b/extensions/2.0/Vendor/ADOBE_render_order/README.md
@@ -3,6 +3,7 @@
 ## Contributors
 
 * Jaswant Singh Ranawat, Adobe(ranawat@adobe.com)
+* Mike Bond, Adobe, @miibond
 
 ## Status
 

--- a/extensions/2.0/Vendor/ADOBE_render_order/README.md
+++ b/extensions/2.0/Vendor/ADOBE_render_order/README.md
@@ -1,0 +1,97 @@
+# ADOBE_render_order
+
+## Contributors
+
+* Jaswant Singh Ranawat, Adobe(ranawat@adobe.com)
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+To avoid Z-fighting in two coplanar meshes render order is needed with depth writing and depth testing options. It could be helpful while drawing three-dimensional translucent objects to get different appeareances. If you want to render both opaque and translucent objects in the same scene, then you want to use the depth buffer to perform hidden-surface removal for any objects that lie behind the opaque objects. Therefore this extension adds four properties to node `group`, `renderOrder`, `depthTest` and `depthWrite`. `renderOrder` value allows the default rendering order of scene graph objects to be overridden although opaque and transparent objects remain sorted independently. When `group` property is set to true, all descendants nodes will be sorted and rendered together. Sorting is from lowest to highest renderOrder.
+
+## glTF Schema Updates
+
+It may contain the following properties:
+| Name       | Type       | Default      | Description
+|------------|------------|--------------|---------------------------------
+| `group`   | `boolean` | `false` | specifies whether node is a group or not.
+| `renderOrder`   | `integer` | `0` | The render order of the node in the parent group.
+| `depthTest` | `boolean`   | `true`        | specifies whether to perform depth test or not.
+| `depthWrite`    | `boolean` | `true` | specifies whether to perform depth write or not.
+
+if none of the parent is specified as group and renderOrder is provided then scene node is considered as group. Marking leaf nodes as group will have no impact.
+
+### Example JSON
+
+```json
+{
+    "nodes": [
+        {
+            "children" : [ 1,4 ],
+            "extensions": {
+                "ADOBE_render_order": {
+                "group" : true
+                }
+            }
+        },
+        {
+            "children": [ 2,3 ],
+            "extensions": {
+                "ADOBE_render_order": {
+                "group" : true,
+                "renderOrder": 0,
+                }
+            }
+        },
+        {
+            "mesh": 0,
+            "extensions": {
+                "ADOBE_render_order": {
+                "renderOrder": 0,
+                "depthTest" : true,
+                "depthWrite" : false
+                }
+            }
+        },
+        {
+            "mesh": 1,
+            "extensions": {
+                "ADOBE_render_order": {
+                "renderOrder": 1,
+                "depthTest" : true,
+                "depthWrite" : false
+                }
+            }
+        },
+        {
+            "mesh": 2,
+            "extensions": {
+                "ADOBE_render_order": {
+                "renderOrder": 1,
+                "depthTest" : true,
+                "depthWrite" : false
+                }
+            }
+        }
+    ]
+}
+```
+
+### JSON Schema
+
+TODO: Links to the JSON schema for the new extension properties.
+
+## Known Implementations
+
+* TODO: List of known implementations, with links to each if available.
+
+## Resources
+
+* TODO: Resources, if any.

--- a/extensions/2.0/Vendor/ADOBE_render_order/README.md
+++ b/extensions/2.0/Vendor/ADOBE_render_order/README.md
@@ -19,12 +19,14 @@ To avoid Z-fighting in two coplanar meshes render order is needed with depth wri
 ## glTF Schema Updates
 
 It may contain the following properties:
-| Name       | Type       | Default      | Description
-|------------|------------|--------------|---------------------------------
-| `group`   | `boolean` | `false` | specifies whether node is a group or not.
-| `renderOrder`   | `integer` | `0` | The render order of the node in the parent group.
-| `depthTest` | `boolean`   | `true`        | specifies whether to perform depth test or not.
-| `depthWrite`    | `boolean` | `true` | specifies whether to perform depth write or not.
+
+| Name       | Type       | Default      | Description |
+|----------|------------|--------------|--------------------------------- |
+| `group`   | `boolean` | `false` | specifies whether node is a group or not. |
+| `renderOrder`   | `integer` | `0` | The render order of the node in the parent group. |
+| `depthTest` | `boolean`   | `true`        | specifies whether to perform depth test or not. |
+| `depthWrite`    | `boolean` | `true` | specifies whether to perform depth write or not. |
+
 
 if none of the parent is specified as group and renderOrder is provided then scene node is considered as group. Marking leaf nodes as group will have no impact.
 

--- a/extensions/2.0/Vendor/ADOBE_render_order/README.md
+++ b/extensions/2.0/Vendor/ADOBE_render_order/README.md
@@ -3,7 +3,7 @@
 ## Contributors
 
 * Jaswant Singh Ranawat, Adobe(ranawat@adobe.com)
-* Mike Bond, Adobe, @miibond
+* Mike Bond, Adobe, [@miibond](https://twitter.com/miibond)
 
 ## Status
 


### PR DESCRIPTION
I'd like to propose an extension to leverage various applications of render order, depthTest, depthWrite and colorWrite. To avoid Z-fighting in two coplanar meshes render order is needed with depth writing and depth testing options. It could be helpful while drawing three-dimensional translucent objects to get different appearances. 