### PR TITLE
Fix description of animation output accessor

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -1927,7 +1927,7 @@ Interpolation algorithm.
 
 #### animation sampler.output :white_check_mark: 
 
-The index of an accessor containing keyframe output values. When targeting TRS target, the `accessor.componentType` of the output values must be `FLOAT`. When targeting morph weights, the `accessor.componentType` of the output values must be `FLOAT` or normalized integer where each output element stores values with a count equal to the number of morph targets.
+The index of an accessor containing keyframe output values. When targeting translation or scale paths, the `accessor.componentType` of the output values must be `FLOAT`. When targeting rotation or morph weights, the `accessor.componentType` of the output values must be `FLOAT` or normalized integer. For weights, each output element stores `SCALAR` values with a count equal to the number of morph targets.
 
 * **Type**: `integer`
 * **Required**: Yes


### PR DESCRIPTION
The description of the output accessor was omitting the possibility that
rotation track is using normalized integers. This was fixed in #1187
however the change didn't propagate to the specification; the intention
is for the property reference to be generated but for now just fix it
directly.

Fixes #1622.