### PR TITLE
Clarify descriptions of rotation direction in KHR_texture_transform

### DIFF
--- a/extensions/2.0/Khronos/KHR_texture_transform/schema/KHR_texture_transform.textureInfo.schema.json
+++ b/extensions/2.0/Khronos/KHR_texture_transform/schema/KHR_texture_transform.textureInfo.schema.json
@@ -17,7 +17,7 @@
         },
         "rotation": {
             "type": "number",
-            "description": "Rotate the UVs by this many radians counter-clockwise around the origin.",
+            "description": "Rotate the UV coordinates counter-clockwise (in U-right, V-down space) by this many radians around the origin. This is equivalent to a similar rotation of the image clockwise.",
             "default": 0.0
         },
         "scale": {


### PR DESCRIPTION
I've tried to clarify the wording about what "counter-clockwise" means in a space where the vertical axis points down instead of up.

Fixes #1563, see detailed discussions there and in linked issues.

/cc @andreasplesch @scurest

