### PR TITLE
Update README to include trimesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Please provide spec feedback by submitting [issues](https://github.com/KhronosGr
         - [Ada](#ada)
         - [TypeScript](#typescript)
         - [Swift](#swift)
+        - [Python](#python)
     - [Utilities](#utilities)
     - [Resources](#resources)
 - [Formats Built on glTF](#formats-built-on-gltf)
@@ -357,6 +358,12 @@ To compare WebGL-based glTF loaders, see [gltf-test](https://github.com/cx20/glt
 | Tool | Status | Description |
 |------|--------|-------------|
 | [GLTFSceneKit](https://github.com/magicien/GLTFSceneKit) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | glTF loader for SceneKit |
+
+#### Python
+
+| Tool | Status | Description |
+|------|--------|-------------|
+| [trimesh](https://github.com/mikedh/trimesh) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Python library for importing and exporting glTF and numerous other triangular mesh formats. |
 
 ### Utilities
 


### PR DESCRIPTION
Updates README to include [`trimesh`](https://github.com/mikedh/trimesh/) in a new Python language section. Trimesh can currently import all the models in the `sample-models 2.0` corpus, and can export to glTF or GLB.  