### PR TITLE
Draft: MESHOPT_compression

### DIFF
--- a/extensions/2.0/Vendor/MESHOPT_compression/README.md
+++ b/extensions/2.0/Vendor/MESHOPT_compression/README.md
@@ -87,7 +87,7 @@ Compression mode specifies the bitstream layout and the algorithm used to decomp
 
 In all three modes, the resulting compressed byte sequence is typically noticably smaller than the buffer view length, *and* can be additionally compressed by using a general purpose compression algorithm such as Deflate for the resulting glTF file (.glb/.bin).
 
-The format of the bitstream is specified in [supplementary specification](Bitstream.md).
+The format of the bitstream is specified in Bitstream section.
 
 When using attribute encoding, for some types of data exploiting the redundancy between consecutive elements is not enough to achieve good compression ratio; quantization can help but isn't always sufficient either. To that end, when using mode 0, this extension allows a further use of a compression filter, that transforms each element stored in the buffer view to make it more compressible with the attribute codec and often allows to trade precision for compressed size. Filters don't change the size of the output data, they merely improve the compressed size by reducing entropy; note that the use of a compression filter restricts `byteStride` which effectively prohibits storing interleaved data.
 
@@ -98,7 +98,7 @@ Filter specifies the algorithm used to transform the data after decompression, a
 - Filter 2: quaternion. Suitable for storing rotation data for animations or instancing as 8-byte values with variable precision max-component encoding.
 - Filter 3: exponential. Suitable for storing floating point data as 4-byte values with variable mantissa precision.
 
-The filters are detailed further in [supplementary specification](Bitstream.md).
+The filters are detailed further in Bitstream section.
 
 When using filters, the expectation is that the filter is applied after the attribute decoder on the contents of the resulting bufferView; the resulting data can then be used according to the referencing accessors without further modifications.
 
@@ -166,3 +166,31 @@ Additionally it's important to identify tracks with the same output value and us
 To reduce the size of each keyframe, rotation data should be quantized using 16-bit normalized components; for additional compression, the use of filter 2 (quaternion) is recommended. Translation/scale data can be compressed using filter 3 (exponential) with the same exponent used for all three vector components.
 
 After pre-processing, both input and output data should be stored using mode 0 (attributes).
+
+# Appendix: Bitstream
+
+The following sections specify the format of the bitstream for compressed data for various modes and filters.
+
+## Mode 0: attributes
+
+TODO
+
+## Mode 1: triangles
+
+TODO
+
+## Mode 2: indices
+
+TODO
+
+## Filter 1: octahedral
+
+TODO
+
+## Filter 2: quaternion
+
+TODO
+
+## Filter 3: exponential
+
+TODO

--- a/extensions/2.0/Vendor/MESHOPT_compression/README.md
+++ b/extensions/2.0/Vendor/MESHOPT_compression/README.md
@@ -22,7 +22,7 @@ This extension provides a different option for compressing binary data. Similarl
 
 The compressed format is designed to have two properties beyond optimizing compression ratio - very fast decoding (using WebAssembly SIMD, the decoders run at \~1 GB/sec on modern desktop hardware), and byte-wise storage compatible with general-purpose compression. That is, instead of reducing the encoded size as much as possible, the bitstream is constructed in such a way that general-purpose compressor can compress it further.
 
-This is beneficial for typical Web delivery scenarios, where all files are usually using gzip compression - instead of completely replacing it, the codecs here augment it, while still reducing the size (which is valuable to optimize delivery size when gzip compression isn't available, and additionally reduces the performance impact of gzip decompression which is typically *slower* than decoders proposed here).
+This is beneficial for typical Web delivery scenarios, where all files are usually using gzip compression - instead of completely replacing it, the codecs here augment it, while still reducing the size (which is valuable to optimize delivery size when gzip compression isn't available, and additionally reduces the performance impact of gzip decompression which is typically *much slower* than decoders proposed here).
 
 ## Specifying compressed views
 

--- a/extensions/2.0/Vendor/MESHOPT_compression/README.md
+++ b/extensions/2.0/Vendor/MESHOPT_compression/README.md
@@ -339,8 +339,6 @@ Vertex a is pushed to vertex FIFO.
 Vertex b is pushed to vertex FIFO if `Z == 0` or `Z == 0xf`.
 Vertex c is pushed to vertex FIFO if `W == 0` or `W == 0xf`.
 
-The triangle (a, b, c) is emitted to the output.
-
 At the end of the decoding, `data` is expected to be fully read by all the triangle codes and not contain any extra bytes.
 
 ## Mode 2: indices

--- a/extensions/2.0/Vendor/MESHOPT_compression/README.md
+++ b/extensions/2.0/Vendor/MESHOPT_compression/README.md
@@ -87,7 +87,7 @@ Compression mode specifies the bitstream layout and the algorithm used to decomp
 
 In all three modes, the resulting compressed byte sequence is typically noticably smaller than the buffer view length, *and* can be additionally compressed by using a general purpose compression algorithm such as Deflate for the resulting glTF file (.glb/.bin).
 
-The format of the bitstream is specified in Bitstream section.
+The format of the bitstream is specified in Appendix A (Bitstream).
 
 When using attribute encoding, for some types of data exploiting the redundancy between consecutive elements is not enough to achieve good compression ratio; quantization can help but isn't always sufficient either. To that end, when using mode 0, this extension allows a further use of a compression filter, that transforms each element stored in the buffer view to make it more compressible with the attribute codec and often allows to trade precision for compressed size. Filters don't change the size of the output data, they merely improve the compressed size by reducing entropy; note that the use of a compression filter restricts `byteStride` which effectively prohibits storing interleaved data.
 
@@ -98,7 +98,7 @@ Filter specifies the algorithm used to transform the data after decompression, a
 - Filter 2: quaternion. Suitable for storing rotation data for animations or instancing as 8-byte values with variable precision max-component encoding.
 - Filter 3: exponential. Suitable for storing floating point data as 4-byte values with variable mantissa precision.
 
-The filters are detailed further in Bitstream section.
+The filters are detailed further in Appendix B (Filters).
 
 When using filters, the expectation is that the filter is applied after the attribute decoder on the contents of the resulting bufferView; the resulting data can then be used according to the referencing accessors without further modifications.
 
@@ -167,9 +167,9 @@ To reduce the size of each keyframe, rotation data should be quantized using 16-
 
 After pre-processing, both input and output data should be stored using mode 0 (attributes).
 
-# Appendix: Bitstream
+# Appendix A: Bitstream
 
-The following sections specify the format of the bitstream for compressed data for various modes and filters.
+The following sections specify the format of the bitstream for compressed data for various modes.
 
 ## Mode 0: attributes
 
@@ -182,6 +182,10 @@ TODO
 ## Mode 2: indices
 
 TODO
+
+# Appendix B: Filters
+
+Filters are functions that transform each encoded attribute. For each filter, this document specifies the transformation used for decoding the data; it's up to the encoder to pick the parameters of the encoding for each element to balance quality and precision.
 
 ## Filter 1: octahedral
 

--- a/extensions/2.0/Vendor/MESHOPT_compression/README.md
+++ b/extensions/2.0/Vendor/MESHOPT_compression/README.md
@@ -26,7 +26,7 @@ This is beneficial for typical Web delivery scenarios, where all files are usual
 
 ## Specifying compressed views
 
-As explained in the overview, this extension operates on bufferViews. This allows the loaders to directly decompress data into GPU memory and minimizes the JSON size impact of specifying compressed data. To specify the compressed representation, `MESHOPT_compression` extension section overrides the source buffer index as well as specifying the buffer parameters and a compression mode (detailed later in the specification):
+As explained in the overview, this extension operates on bufferViews. This allows the loaders to directly decompress data into GPU memory and minimizes the JSON size impact of specifying compressed data. To specify the compressed representation, `MESHOPT_compression` extension section overrides the source buffer index as well as specifying the buffer parameters and a compression mode/filter (detailed later in the specification):
 
 ```json
 {
@@ -48,16 +48,47 @@ As explained in the overview, this extension operates on bufferViews. This allow
 }
 ```
 
-In this example, the uncompressed buffer contents is stored in buffer 1 (this can be used by loaders that don't implement this extension). The compressed data is stored in a separate buffer, specifying a separate byte range (with compressed data). Note that for compressors to work, they need to know the compression `mode`, and additionally the layout of the encoded data - `count` elements with `byteStride` bytes each. This data is specified in the extension JSON; while in some cases `byteStride` is available on the parent `bufferView` declaration, JSON schema prohibits specifying this for some types of storage such as index data.
+In this example, the uncompressed buffer contents is stored in buffer 1 (this can be used by loaders that don't implement this extension). The compressed data is stored in a separate buffer, specifying a separate byte range (with compressed data). Note that for compressors to work, they need to know the compression `mode`, `filter` (for `mode 0`), and additionally the layout of the encoded data - `count` elements with `byteStride` bytes each. This data is specified in the extension JSON; while in some cases `byteStride` is available on the parent `bufferView` declaration, JSON schema prohibits specifying this for some types of storage such as index data.
 
 For the extension JSON to be valid, the following must hold:
 
 - When parent `bufferView` has `byteStride` defined, it matches `byteStride` in the extension JSON
 - Buffer view length is equal to `byteStride` times `count`
 - When `mode` is 0 (attributes), `byteStride` must be divisible by 4
-- When `mode` is 1 (indices), `byteStride` must be equal to 2 or 4
+- When `mode` is 1 (triangles), `count` must be divisible by 3
+- When `mode` is 1 (triangles) or 2 (indices), `byteStride` must be equal to 2 or 4
+- When `mode` is 1 (triangles) or 2 (indices), `filter` must be equal to `0` or omitted
+- When `filter` is 1 (octahedral), `byteStride` must be equal to 4 or 8
+- When `filter` is 2 (quaternion), `byteStride` must be equal to 8
 
 The type of compressed data must match the bitstream specification (note that each `mode` specifies a different bitstream format).
+
+## Compression modes and filters
+
+Compression mode specifies the bitstream layout and the algorithm used to decompress the data, and can be one of:
+
+- Mode 0: attributes. Suitable for storing sequences of values of arbitrary size, relies on exploiting similarity between bytes of consecutive elements to reduce the size.
+- Mode 1: triangles. Suitable for storing indices that represent triangle lists, relies on exploiting topological redundancy of consecutive triangles.
+- Mode 2: indices. Suitable for storing indices that don't represent triangle lists, relies on exploiting similarity between consecutive elements.
+
+In all three modes, the resulting compressed byte sequence is typically noticably smaller than the buffer view length, *and* can be additionally compressed by using a general purpose compression algorithm such as Deflate for the resulting glTF file (.glb/.bin).
+
+The format of the bitstream is specified in [supplementary specification](Bitstream.md).
+
+When using attribute encoding, for some types of data exploiting the redundancy between consecutive elements is not enough to achieve good compression ratio; quantization can help but isn't always sufficient either. To that end, when using mode 0, this extension allows a further use of a compression filter, that transforms each element stored in the buffer view to make it more compressible with the attribute codec and often allows to trade precision for compressed size. Filters don't change the size of the output data, they merely improve the compressed size by reducing entropy; note that the use of a compression filter restricts `byteStride` which effectively prohibits storing interleaved data.
+
+Filter specifies the algorithm used to transform the data after decompression, and can be one of:
+
+- Filter 0: none. Attribute data is used as is.
+- Filter 1: octahedral. Suitable for storing unit length vectors (normals/tangents) as 4-byte or 8-byte values with variable precision octahedral encoding.
+- Filter 2: quaternion. Suitable for storing rotation data for animations or instancing as 8-byte values with variable precision max-component encoding.
+- Filter 3: exponential. Suitable for storing floating point data as 4-byte values with variable mantissa precision.
+
+The filters are detailed further in [supplementary specification](Bitstream.md).
+
+When using filters, the expectation is that the filter is applied after the attribute decoder on the contents of the resulting bufferView; the resulting data can then be used according to the referencing accessors without further modifications.
+
+**Non-normative** To decompress the data, [meshoptimizer](https://github.com/zeux/meshoptimizer) library may be used; it supports efficient decompression using C++ and/or WebAssembly, including fast SIMD implementation for attribute decoding.
 
 ## Fallback buffers
 
@@ -100,33 +131,24 @@ To get optimal compression, encoders should optimize vertex and index data for l
 - Triangle order should be optimized to maximize the recency of previously encountered vertices; this is similar to optimizing meshes for vertex reuse aka post-transform cache in GPU hardware.
 - Vertex order should be linearized in the order that vertices appear in the index stream to get optimal index compression
 
-When index data is not available (e.g. point data sets) or represents topology with a lot of seams (e.g. each triangle has unique vertex indices because it specifies flat-shaded normal), encoders should additionally optimize vertex data for spatial locality, so that vertices close together in the vertex stream are close together in space.
+When index data is not available (e.g. point data sets) or represents topology with a lot of seams (e.g. each triangle has unique vertex indices because it specifies flat-shaded normal), encoders could additionally optimize vertex data for spatial locality, so that vertices close together in the vertex stream are close together in space.
 
-Vertex data should be quantized using the appropriate representation; this extension cleanly interacts with KHR\_quantized\_geometry by compressing already quantized data.
+Vertex data should be quantized using the appropriate representation; this extension cleanly interacts with KHR\_mesh\_quantization by compressing already quantized data.
 
 Morph targets can be treated identically to other vertex attributes, as long as vertex order optimization is performed on all target streams at the same time. It is recommended to use quantized storage for morph target deltas, possibly with a narrower type than that used for baseline values.
 
-When storing vertex data, mode 0 (attributes) should be used; for index data, mode 1 (indices) should be used instead. Mode 1 only supports triangle list storage; indices of other topology types can be stored uncompressed or using mode 0 (attributes). The use of triangle strip topology is not recommended since it's more efficient to store triangle lists using mode 1.
+When storing vertex data, mode 0 (attributes) should be used; for index data, mode 1 (triangles) or mode 2 (indices) should be used instead. Mode 1 only supports triangle list storage; indices of other topology types can be stored using mode 2. The use of triangle strip topology is not recommended since it's more efficient to store triangle lists using mode 1.
 
-TODO: normal & tangent unit filters
+Using filter 1 (octahedral) for normal/tangent data may improve compression ratio further.
 
 ## Compressing animation data
 
-To minimize the size of animation data, it is recommended that encoders resample animations before compression. This serves two purposes:
+To minimize the size of animation data, it is important to reduce the number of stored keyframes and reduce the size of each keyframe.
 
-- After resampling, all animation channels can share the same input accessor that carries the time data once
-- Varying sample frequency allows one to trade off quality of animations for size
+To reduce the number of keyframes, encoders can either selectively remove keyframes that don't contribute to the resulting movement, resulting in sparse input/output data, or resample the keyframes uniformly, resulting in uniformly dense data. Resampling can be beneficial since it means that all animation channels in the same animation can share the same input accessor, and provides a convenient quality vs size tradeoff, but it's up to the encoder to pick the optimal strategy.
 
-After resampling, rotation data should be additionally quantized for maximum efficiency - using 16-bit components should provide enough precision to store most rotations.
+Additionally it's important to identify tracks with the same output value and use a single keyframe for these.
+
+To reduce the size of each keyframe, rotation data should be quantized using 16-bit normalized components; for additional compression, the use of filter 2 (quaternion) is recommended. Translation/scale data can be compressed using filter 3 (exponent) with the same exponent used for all three vector components.
 
 After pre-processing, both input and output data should be stored using mode 0 (attributes).
-
-TODO: quaternion unit filter
-
-## Bitstream mode 0 - attributes
-
-TODO
-
-## Bitstream mode 1 - indices
-
-TODO

--- a/extensions/2.0/Vendor/MESHOPT_compression/README.md
+++ b/extensions/2.0/Vendor/MESHOPT_compression/README.md
@@ -1,0 +1,25 @@
+# MESHOPT\_compression
+
+## Contributors
+
+* Arseny Kapoulkine, [@zeuxcg](https://twitter.com/zeuxcg)
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+TODO
+
+## Compression mode 0 - attributes
+
+TODO
+
+## Compression mode 1 - indices
+
+TODO

--- a/extensions/2.0/Vendor/MESHOPT_compression/README.md
+++ b/extensions/2.0/Vendor/MESHOPT_compression/README.md
@@ -230,7 +230,7 @@ void decode(intN_t input[4], intN_t output[4]) {
 
 Quaternion filter allows to encode unit length quaternions using normalized 16-bit integers for all components, but allows control over the precision used for the components and provides better quality compared to naively encoding each component one by one.
 
-The input to the filter is three quaternion components, excluding the component with the largest magnitude, encoded as signed normalized K-bit integers (K <= 16), and an index of the largest component that is omitted in the encoding. The largest component is assumed to always be positive (which is possible due to quaternion double-cover). To allow per-element control over K, the last input element explicitly encodes 1.0 as a K-bit integer, except for the least significant 2 bits that store the index of the maximum component.
+The input to the filter is three quaternion components, excluding the component with the largest magnitude, encoded as signed normalized K-bit integers (4 <= K <= 16), and an index of the largest component that is omitted in the encoding. The largest component is assumed to always be positive (which is possible due to quaternion double-cover). To allow per-element control over K, the last input element explicitly encodes 1.0 as a K-bit integer, except for the least significant 2 bits that store the index of the maximum component.
 
 The output of the filter is four decoded quaternion components, stored as 16-bit normalized integers.
 
@@ -247,15 +247,15 @@ void decode(int16_t input[4], int16_t output[4]) {
 	float32_t y = input[1] / one * range;
 	float32_t z = input[2] / one * range;
 
-	float32_t w = sqrt(max(0, 1 - x * x - y * y - z * z));
+	float32_t w = sqrt(max(0.0, 1.0 - x * x - y * y - z * z));
 
 	int maxcomp = input[3] & 3;
 
 	// maxcomp specifies a cyclic rotation of the quaternion components
-	output[(maxcomp + 1) % 4] = round(x * 32767);
-	output[(maxcomp + 2) % 4] = round(y * 32767);
-	output[(maxcomp + 3) % 4] = round(z * 32767);
-	output[ maxcomp         ] = round(w * 32767);
+	output[(maxcomp + 1) % 4] = round(x * 32767.0);
+	output[(maxcomp + 2) % 4] = round(y * 32767.0);
+	output[(maxcomp + 3) % 4] = round(z * 32767.0);
+	output[(maxcomp + 0) % 4] = round(w * 32767.0);
 }
 ```
 

--- a/extensions/2.0/Vendor/MESHOPT_compression/README.md
+++ b/extensions/2.0/Vendor/MESHOPT_compression/README.md
@@ -50,7 +50,21 @@ As explained in the overview, this extension operates on bufferViews. This allow
 
 In this example, the uncompressed buffer contents is stored in buffer 1 (this can be used by loaders that don't implement this extension). The compressed data is stored in a separate buffer, specifying a separate byte range (with compressed data). Note that for compressors to work, they need to know the compression `mode`, `filter` (for `mode 0`), and additionally the layout of the encoded data - `count` elements with `byteStride` bytes each. This data is specified in the extension JSON; while in some cases `byteStride` is available on the parent `bufferView` declaration, JSON schema prohibits specifying this for some types of storage such as index data.
 
-For the extension JSON to be valid, the following must hold:
+## JSON schema updates
+
+Each `bufferView` can contain an extension object with the following properties:
+
+| Property | Type | Description | Required |
+|:---------|:--------------|:------------------------------------------| :--------------------------|
+| `buffer` | `integer` | The index of the buffer with compressed data. | :white_check_mark: Yes |
+| `byteOffset` | `integer` | The offset into the buffer in bytes. | No, default: `0` |
+| `byteLength` | `integer` | The length of the compressed data in bytes. | :white_check_mark: Yes |
+| `byteStride` | `integer` | The stride, in bytes. | :white_check_mark: Yes |
+| `count` | `integer` | The number of elements. | :white_check_mark: Yes |
+| `mode` | `integer` | The compression mode. | :white_check_mark: Yes |
+| `filter` | `integer` | The compression filter. | No, default: `0` |
+
+For the extension object to be valid, the following must hold:
 
 - When parent `bufferView` has `byteStride` defined, it matches `byteStride` in the extension JSON
 - Buffer view length is equal to `byteStride` times `count`
@@ -149,6 +163,6 @@ To reduce the number of keyframes, encoders can either selectively remove keyfra
 
 Additionally it's important to identify tracks with the same output value and use a single keyframe for these.
 
-To reduce the size of each keyframe, rotation data should be quantized using 16-bit normalized components; for additional compression, the use of filter 2 (quaternion) is recommended. Translation/scale data can be compressed using filter 3 (exponent) with the same exponent used for all three vector components.
+To reduce the size of each keyframe, rotation data should be quantized using 16-bit normalized components; for additional compression, the use of filter 2 (quaternion) is recommended. Translation/scale data can be compressed using filter 3 (exponential) with the same exponent used for all three vector components.
 
 After pre-processing, both input and output data should be stored using mode 0 (attributes).

--- a/extensions/2.0/Vendor/MESHOPT_compression/README.md
+++ b/extensions/2.0/Vendor/MESHOPT_compression/README.md
@@ -14,12 +14,95 @@ Written against the glTF 2.0 spec.
 
 ## Overview
 
+glTF files come with a variety of binary data - vertex attribute data, index data, morph target deltas, animation inputs/outputs - that can be a substantial fraction of the overall transmission size. To optimize for delivery size, general-purpose compression such as gzip can be used - however, it often doesn't capture some common types of redundancy in glTF binary data.
+
+To achieve optimal compression rates for mesh geometry data, glTF supports Draco mesh compression through KHR\_draco\_mesh\_compression extension. However, this comes at a cost of decoding performance (Draco decoding takes an appreciable time which can start offsetting the loading time for faster connections) and inability to directly upload buffer view data to GPU storage or, for most implementations, use quantized storage in the output. Additionally, animation and morph target data isn't supported.
+
+This extension provides a different option for compressing binary data. Similarly to supercompressed textures (see KHR\_image\_ktx2), this extension assumes that the buffer view data is optimized for GPU efficiency - using quantization and using optimal data order for GPU rendering - and provides a compression layer on top of bufferView data. Each bufferView is compressed in isolation which allows the loaders to maximally efficiently decompress the data directly into GPU storage.
+
+The compressed format is designed to have two properties beyond optimizing compression ratio - very fast decoding (using WebAssembly SIMD, the decoders run at \~1 GB/sec on modern desktop hardware), and byte-wise storage compatible with general-purpose compression. That is, instead of reducing the encoded size as much as possible, the bitstream is constructed in such a way that general-purpose compressor can compress it further.
+
+This is beneficial for typical Web delivery scenarios, where all files are usually using gzip compression - instead of completely replacing it, the codecs here augment it, while still reducing the size (which is valuable to optimize delivery size when gzip compression isn't available, and additionally reduces the performance impact of gzip decompression which is typically *slower* than decoders proposed here).
+
+## Specifying compressed views
+
+As explained in the overview, this extension operates on bufferViews. This allows the loaders to directly decompress data into GPU memory and minimizes the JSON size impact of specifying compressed data. To specify the compressed representation, `MESHOPT_compression` extension section overrides the source buffer index as well as specifying the buffer parameters and a compression mode (detailed later in the specification):
+
+```json
+{
+	"buffer": 1,
+	"byteOffset": 0,
+	"byteLength": 2368,
+	"byteStride": 16,
+	"target": 34962,
+	"extensions": {
+		"MESHOPT_compression": {
+			"buffer": 0,
+			"byteOffset": 1024,
+			"byteLength": 347,
+			"byteStride": 16,
+			"mode": 0,
+			"count": 148
+		}
+	}
+}
+```
+
+In this example, the uncompressed buffer contents is stored in buffer 1 (this can be used by loaders that don't implement this extension). The compressed data is stored in a separate buffer, specifying a separate byte range (with compressed data). Note that for compressors to work, they need to know the compression `mode`, and additionally the layout of the encoded data - `count` elements with `byteStride` bytes each. This data is specified in the extension JSON; while in some cases `byteStride` is available on the parent `bufferView` declaration, JSON schema prohibits specifying this for some types of storage such as index data.
+
+For the extension JSON to be valid, the following must hold:
+
+- When parent `bufferView` has `byteStride` defined, it matches `byteStride` in the extension JSON
+- Buffer view length is equal to `byteStride` times `count`
+- When `mode` is 0 (attributes), `byteStride` must be divisible by 4
+- When `mode` is 1 (indices), `byteStride` must be equal to 2 or 4
+
+The type of compressed data must match the bitstream specification (note that each `mode` specifies a different bitstream format).
+
+## Fallback buffers
+
+While the extension JSON specifies a separate buffer to source compressed data from, the parent `bufferView` must also have a valid `buffer` reference as per glTF 2.0 spec requirement. To produce glTF files that *require* support for this extension and don't have uncompressed data, the referenced buffer can contain no URI as follows:
+
+```json
+{ "byteLength": 1432878 }
+```
+
+When stored in a GLB file, the dummy buffer should have index 1 or above, to avoid conflicts with GLB binary buffer.
+
+This extension allows buffers to be tagged as fallback by using the `fallback` attribute as follows:
+
+```json
+{
+	"byteLength": 1432878,
+	"extensions": {
+		"MESHOPT_compression": {
+			"fallback": true
+		}
+	}
+}
+```
+
+This is useful to avoid confusion, and can also be used by loaders that support the extension to skip loading of these buffers.
+
+When a buffer is marked as a fallback buffer, the following must hold:
+
+- All references to the buffer must come from `bufferView`s that have a `MESHOPT_compression` extension specified
+- No references to the buffer may come from `MESHOPT_compression` extension JSON
+
+If a fallback buffer doesn't have a URI and doesn't refer to the GLB binary chunk, it follows that `MESHOPT_compression` must be a required extension.
+
+## Compressing geometry data
+
 TODO
 
-## Compression mode 0 - attributes
+## Compressing animation data
 
 TODO
 
-## Compression mode 1 - indices
+## Bitstream mode 0 - attributes
+
+TODO
+
+## Bitstream mode 1 - indices
 
 TODO

--- a/extensions/2.0/Vendor/MESHOPT_compression/schema/bufferView.MESHOPT_compression.schema.json
+++ b/extensions/2.0/Vendor/MESHOPT_compression/schema/bufferView.MESHOPT_compression.schema.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "MESHOPT_compression bufferView extension",
+    "type": "object",
+    "description": "Compressed data for bufferView.",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "buffer": {
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
+            "description": "The index of the buffer with compressed data."
+        },
+        "byteOffset": {
+            "type": "integer",
+            "description": "The offset into the buffer in bytes.",
+            "minimum": 0,
+            "default": 0
+        },
+        "byteLength": {
+            "type": "integer",
+            "description": "The length of the compressed data in bytes.",
+            "minimum": 1
+        },
+        "byteStride": {
+            "type": "integer",
+            "description": "The stride, in bytes.",
+            "minimum": 4,
+            "maximum": 252,
+            "multipleOf": 4,
+        },
+        "count": {
+            "type": "integer",
+            "description": "The number of elements.",
+            "minimum": 1,
+        },
+        "mode": {
+            "description": "The compression mode.",
+            "anyOf": [
+                {
+                    "enum": [ 0 ],
+                    "description": "attributes",
+                    "type": "integer"
+                },
+                {
+                    "enum": [ 1 ],
+                    "description": "triangles",
+                    "type": "integer"
+                },
+                {
+                    "enum": [ 2 ],
+                    "description": "indices",
+                    "type": "integer"
+                }
+            ]
+        },
+        "filter": {
+            "description": "The compression filter.",
+            "anyOf": [
+                {
+                    "enum": [ 0 ],
+                    "description": "none",
+                    "type": "integer"
+                },
+                {
+                    "enum": [ 1 ],
+                    "description": "octahedral",
+                    "type": "integer"
+                },
+                {
+                    "enum": [ 2 ],
+                    "description": "quaternion",
+                    "type": "integer"
+                },
+                {
+                    "enum": [ 3 ],
+                    "description": "exponential",
+                    "type": "integer"
+                }
+            ]
+        },
+        "extras": { }
+    },
+    "required": [
+        "buffer", "byteLength", "byteStride", "count", "mode"
+    ]
+}


### PR DESCRIPTION
This is a draft of MESHOPT_compression extension. I'm sharing this early to get feedback that might drastically change the JSON structure here or get extra input on the rest of the proposal.

[Rendered version](https://github.com/KhronosGroup/glTF/blob/0ab6547de9216d3094f7673904b06e274705fb1d/extensions/2.0/Vendor/MESHOPT_compression/README.md) (Updated 4/15/2020)

This extension is used by gltfpack to implement a substantially different type of compressor vs existing offering. Some of this is covered in the overview, but briefly:

- Compression is performed on a buffer view level - this makes it easy to support all types of glTF data (this includes geometry, morph targets and animation) with minimal JSON complexity
- Compressed buffer views can be decompressed directly into GPU/CPU target memory - this makes decoding faster and makes implementations of this extension very simple, here's a Babylon.JS example https://github.com/zeux/meshoptimizer/blob/master/demo/babylon.MESHOPT_compression.js
- Decompression is very fast - with WASM SIMD it runs at ~1 GB/s on modern desktop CPUs. Native implementations run at ~2+ GB/s.
- Decompression code is small. WASM decoder is 5-7 KB binary; two WASM decoders bundled into a .js file and gzip-compressed are a 7 KB download.
- Encoding is gzip-friendly. The compression method provides a moderate size gain over uncompressed storage, with further size gains possible when the binary is gzip-compressed.

Quick examples: (please note that this just two files, I will need to build a larger comparison table later)

BrainStem.glb, original: 3.1 MB
BrainStem.glb, quantized: 1.1 MB (this also does other types of optimization on the file) 
BrainStem.glb, quantized + deflate: 560 KB
BrainStem.glb, with this extension: 440 KB
BrainStem.glb, with this extension + deflate: 330 KB
BrainStem.glb, with Draco: 1.4 MB (animations aren't compressed, unfair example)

Corset.glb, original: 660 KB
Corset.glb, quantized: 340 KB
Corset.glb, quantized + deflate: 180 KB
Corset.glb, with this extension: 145 KB
Corset.glb, with this extension + deflate: 103 KB
Corset.glb, Draco: 112 KB

The BrainStem model above has animation data; the Corset.glb is just a static mesh but it has PBR-ready data set. In my experience, Draco tends to win noticeably on very large meshes with just position + normal data - I'm working on making my codec stronger in this case.

However, all comparisons above are unfair in one way or another to Draco - for example I am not matching quantization settings here and using whatever Draco model comes with glTF-Sample-Models - and in general Draco *will* win vs this extension in terms of pure size comparison when Draco fully supports the models. So the examples above are intended to highlight the wins that come from this extension, and Draco numbers are just ballpark because I know the question will come up. This extension is designed to complement Draco by providing a full compression solution aimed at high decoding speeds and specification simplicity, not to replace Draco fully in cases where mesh compression ratio is the only important criteria.

Note that the details of the bitstream are still in flux. It is my intention to update this extension with the bitstream encoding as it gets finalized; alternatively, the bitstream can be hosted in a separate document. It's much simpler than Draco's but a formal definition may still take significant space? Unsure.

I am hoping to be able to finalize the bitstream details either by the end of the year, or early next year. Any and all feedback welcome.