### PR TITLE
KHR_materials_ior

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -76,9 +76,11 @@ dielectricSpecular = ((ior - 1)/(ior + 1))^2
 
 ## Interaction with other extensions
 
-If `KHR_materials_ior` is used in combination with `KHR_materials_specular`, f0 computed from IOR is multiplied by f0 computed from the specular parameters. See [`KHR_materials_specular`](../KHR_materials_specular/README.md) for more details.
+If `KHR_materials_specular` is used in combination with `KHR_materials_ior`, f0 computed from IOR is multiplied by f0 computed from the specular parameters. See [`KHR_materials_specular`](../KHR_materials_specular/README.md) for more information.
 
 If `KHR_materials_volume` is used in combination with `KHR_materials_ior`, the `ior` affects not only the Fresnel term, but also determines the refractive index of the volume below the surface. Light rays passing through the transmissive surface are bent according to the index of refraction of the outside and inside medium (refraction). As the volume cannot be parametrized with a 2-dimensional texture in UV space, the index of refraction (IOR) is a scalar, uniform value (`ior`).
+
+If `KHR_materials_volume` is used in combination with `KHR_materials_ior`, the `ior` affects the refraction effect. See [`KHR_materials_volume`](../KHR_materials_volume/README.md) for more information.
 
 ## Schema
 

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -78,7 +78,7 @@ dielectricSpecular = ((ior - 1)/(ior + 1))^2
 
 If `KHR_materials_specular` is used in combination with `KHR_materials_ior`, f0 computed from IOR is multiplied by f0 computed from the specular parameters. See [`KHR_materials_specular`](../KHR_materials_specular/README.md) for more information.
 
-If `KHR_materials_volume` is used in combination with `KHR_materials_ior`, the `ior` affects not only the Fresnel term, but also determines the refractive index of the volume below the surface. Light rays passing through the transmissive surface are bent according to the index of refraction of the outside and inside medium (refraction). As the volume cannot be parametrized with a 2-dimensional texture in UV space, the index of refraction (IOR) is a scalar, uniform value (`ior`).
+If `KHR_materials_transmission` is used in combination with `KHR_materials_ior`, the `ior` affects the strength of the transmission effect according to the Fresnel term. See [`KHR_materials_transmission`](../KHR_materials_transmission/README.md) for more information. If `KHR_materials_specular` is used in addition, the rules for multiplying f0 from `ior` and f0 from the specular parameters apply as defined in `KHR_materials_specular`.
 
 If `KHR_materials_volume` is used in combination with `KHR_materials_ior`, the `ior` affects the refraction effect. See [`KHR_materials_volume`](../KHR_materials_volume/README.md) for more information.
 

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -88,7 +88,7 @@ If `KHR_materials_volume` is used in combination with `KHR_materials_ior`, the `
 
 ## Schema
 
-- [glTF.KHR_materials_specular.schema.json](schema/glTF.KHR_materials_specular.schema.json)
+- [glTF.KHR_materials_ior.schema.json](schema/glTF.KHR_materials_ior.schema.json)
 
 ## Appendix: Full Khronos Copyright Statement
 

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -76,17 +76,7 @@ dielectricSpecular = ((ior - 1)/(ior + 1))^2
 
 ## Interaction with other extensions
 
-If `KHR_materials_ior` is used in combination with `KHR_materials_specular`, f0 computed from IOR is multiplied by f0 computed from the specular parameters.
-
-```
-dielectricSpecularF0 = ((ior - outside_ior) / (ior + outside_ior))^2 * specularFactor * specularTexture.a * specularColorFactor * specularColorTexture.rgb
-dielectricSpecularF90 = specularFactor * specularTexture.a
-
-F0  = lerp(dielectricSpecularF0, baseColor.rgb, metallic)
-F90 = lerp(dielectricSpecularF90, 1, metallic)
-
-F = F0 + (F90 - F0) * (1 - VdotH)^5
-```
+If `KHR_materials_ior` is used in combination with `KHR_materials_specular`, f0 computed from IOR is multiplied by f0 computed from the specular parameters. See [`KHR_materials_specular`](../KHR_materials_specular/README.md) for more details.
 
 If `KHR_materials_volume` is used in combination with `KHR_materials_ior`, the `ior` affects not only the Fresnel term, but also determines the refractive index of the volume below the surface. Light rays passing through the transmissive surface are bent according to the index of refraction of the outside and inside medium (refraction). As the volume cannot be parametrized with a 2-dimensional texture in UV space, the index of refraction (IOR) is a scalar, uniform value (`ior`).
 

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -89,3 +89,7 @@ F = F0 + (F90 - F0) * (1 - VdotH)^5
 ```
 
 If `KHR_materials_volume` is used in combination with `KHR_materials_ior`, the `ior` affects not only the Fresnel term, but also determines the refractive index of the volume below the surface. Light rays passing through the transmissive surface are bent according to the index of refraction of the outside and inside medium (refraction). As the volume cannot be parametrized with a 2-dimensional texture in UV space, the index of refraction (IOR) is a scalar, uniform value (`ior`).
+
+## Schema
+
+- [glTF.KHR_materials_specular.schema.json](schema/glTF.KHR_materials_specular.schema.json)

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -31,7 +31,6 @@ The index of refraction of a material is configured by adding the `KHR_materials
             "extensions": {
                 "KHR_materials_ior": {
                     "ior": 1.4,
-                    "iorTexture": 0
                 }
             }
         }
@@ -39,12 +38,35 @@ The index of refraction of a material is configured by adding the `KHR_materials
 }
 ```
 
-The index of refraction typically is a value between 1 and 2, in rare cases it may be larger than 2. In contrast to other texturable values in glTF, `ior` and `iorTexture` are not multiplied: if no texture is given, `ior` is used, otherwise the texture overrides it.
+Typical values for the index of refraction range from 1 to 2. In rare cases values greater than 2 are possible. The following table shows some materials and their index of refraction:
+
+| Material     | Index of Refraction |
+|--------------|---------------------|
+| Air          | 1.0                 |
+| Water        | 1.33                |
+| Eyes         | 1.38                |
+| Window Glass | 1.52                |
+| Sapphire     | 1.76                |
+| Diamond      | 2.42                |
+
+The index of refraction (IOR) can be defined either as a scalar value (`ior`) or as a texture (`f0Texture`). If both are given at the same time, `f0Texture` overrides `ior`.
 
 | |Type|Description|Required|
 |-|----|-----------|--------|
 | **ior** | `number` | The index of refraction. | No, default: `1.5`|
-| **iorTexture** | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo) | A greyscale texture that defines the index of refraction as 1/ior. | No |
+| **f0Texture** | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo) | A 1-channel luminance texture that defines the index of refraction in terms of the reflectance at normal incidence f0. | No |
+| **maxF0** | `number` | When using `f0Texture`, a texture value of 1.0 is interpret as `maxF0`. Values between 0 and 1 are linearly scaled between 0 and `maxF0`. | No, default: `0.08` |
+
+The texture stores the IOR in terms of the reflectance at normal incidence, a value in the range 0..1. The mapping works as follows:
+
+```
+f0 = ((ior - 1) / (ior + 1))^2
+ior = 2 / (1 - sqrt(f0)) - 1
+```
+
+As f0 usually is a small value (IOR in range 1..2 corresponds to f0 in range 0..0.08), an optional scale factor can be applied to the texture via `maxF0`.
+
+In case `KHR_materials_volume` is enabled, the `ior` affects the bending of light rays (refraction) passing through the transparent surface and it determines the refractive index of the volume below the surface. As the volume cannot be parametrized with a 2-dimensional texture in UV space, `f0Texture` and `maxF0` are ignored.
 
 ## Implementation
 
@@ -58,4 +80,20 @@ dielectric_brdf =
     ior)
 ```
 
-In case `KHR_materials_transmission` is enabled, the index of refraction also affects the refraction of light rays passing through the transparent surface.
+[Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation) defines the `fresnel_mix` operation as
+
+```
+fresnel_mix(base, layer, ior) = base * (1 - fr(ior)) + layer * fr(ior)
+fr(ior) = f0 + (1 - f0) * (1 - cos)^5
+f0 = ((ior - 1) / (ior + 1))^2
+```
+
+with `ior = 1.5`, corresponding to `f0 = 0.04`. The following pseudo-code shows how to compute `f0` from `ior`, `f0Texture` and `maxF0`:
+
+```
+if (f0Texture is enabled) {
+  f0 = fetch(f0Texture, uv) * maxF0;
+} else {
+  f0 = ((ior - 1) / (ior + 1))^2
+}
+```

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -20,6 +20,11 @@ Experimental
 
 Written against the glTF 2.0 spec.
 
+## Exclusions
+
+* This extension must not be used on a material that also uses `KHR_materials_pbrSpecularGlossiness`.
+* This extension must not be used on a material that also uses `KHR_materials_unlit`.
+
 ## Overview
 
 The dielectric BRDF of the metallic-roughness material in glTF uses a fixed value of 1.5 for the index of refraction. This is a good fit for many plastics and glass, but not for other materials like water or asphalt, sapphire or diamond. This extensions allows users to set the index of refraction to a certain value.

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -76,7 +76,7 @@ dielectricSpecular = ((ior - 1)/(ior + 1))^2
 
 ## Interaction with other extensions
 
-If `KHR_materials_ior` is used in combination with `KHR_materials_specular`, the constant `0.04` is replaced by the value computed from the IOR.
+If `KHR_materials_ior` is used in combination with `KHR_materials_specular`, f0 computed from IOR is multiplied by f0 computed from the specular parameters.
 
 ```
 dielectricSpecularF0 = ((ior - outside_ior) / (ior + outside_ior))^2 * specularFactor * specularTexture.a * specularColorFactor * specularColorTexture.rgb

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -1,12 +1,16 @@
 # KHR\_materials\_ior
 
-## Khronos 3D Formats Working Group
+## Contributors
 
-* TODO
+* Tobias Haeussler, Dassault Systemes [@proog128](https://github.com/proog128)
+* Bastian Sdorra, Dassault Systemes [@bsdorra](https://github.com/bsdorra)
+* Ben Houston, ThreeKit [@bhouston](https://github.com/bhouston)
+* Richard Sahlin, IKEA [@rsahlin](https://github.com/rsahlin)
+* Norbert Nopper, UX3D [@UX3DGpuSoftware](https://twitter.com/UX3DGpuSoftware)
+* Ed Mackey, AGI [@emackey](https://twitter.com/emackey)
 
-## Acknowledgments
-
-* TODO
+Copyright (C) 2018-2020 The Khronos Group Inc. All Rights Reserved. glTF is a trademark of The Khronos Group Inc.
+See [Appendix](#appendix-full-khronos-copyright-statement) for full Khronos Copyright Statement.
 
 ## Status
 
@@ -85,3 +89,56 @@ If `KHR_materials_volume` is used in combination with `KHR_materials_ior`, the `
 ## Schema
 
 - [glTF.KHR_materials_specular.schema.json](schema/glTF.KHR_materials_specular.schema.json)
+
+## Appendix: Full Khronos Copyright Statement
+
+Copyright 2018-2020 The Khronos Group Inc.
+
+Some parts of this Specification are purely informative and do not define requirements
+necessary for compliance and so are outside the Scope of this Specification. These
+parts of the Specification are marked as being non-normative, or identified as
+**Implementation Notes**.
+
+Where this Specification includes normative references to external documents, only the
+specifically identified sections and functionality of those external documents are in
+Scope. Requirements defined by external documents not created by Khronos may contain
+contributions from non-members of Khronos not covered by the Khronos Intellectual
+Property Rights Policy.
+
+This specification is protected by copyright laws and contains material proprietary
+to Khronos. Except as described by these terms, it or any components
+may not be reproduced, republished, distributed, transmitted, displayed, broadcast
+or otherwise exploited in any manner without the express prior written permission
+of Khronos.
+
+This specification has been created under the Khronos Intellectual Property Rights
+Policy, which is Attachment A of the Khronos Group Membership Agreement available at
+www.khronos.org/files/member_agreement.pdf. Khronos grants a conditional
+copyright license to use and reproduce the unmodified specification for any purpose,
+without fee or royalty, EXCEPT no licenses to any patent, trademark or other
+intellectual property rights are granted under these terms. Parties desiring to
+implement the specification and make use of Khronos trademarks in relation to that
+implementation, and receive reciprocal patent license protection under the Khronos
+IP Policy must become Adopters and confirm the implementation as conformant under
+the process defined by Khronos for this specification;
+see https://www.khronos.org/adopters.
+
+Khronos makes no, and expressly disclaims any, representations or warranties,
+express or implied, regarding this specification, including, without limitation:
+merchantability, fitness for a particular purpose, non-infringement of any
+intellectual property, correctness, accuracy, completeness, timeliness, and
+reliability. Under no circumstances will Khronos, or any of its Promoters,
+Contributors or Members, or their respective partners, officers, directors,
+employees, agents or representatives be liable for any damages, whether direct,
+indirect, special or consequential damages for lost revenues, lost profits, or
+otherwise, arising from or in connection with these materials.
+
+Vulkan is a registered trademark and Khronos, OpenXR, SPIR, SPIR-V, SYCL, WebGL,
+WebCL, OpenVX, OpenVG, EGL, COLLADA, glTF, NNEF, OpenKODE, OpenKCAM, StreamInput,
+OpenWF, OpenSL ES, OpenMAX, OpenMAX AL, OpenMAX IL, OpenMAX DL, OpenML and DevU are
+trademarks of The Khronos Group Inc. ASTC is a trademark of ARM Holdings PLC,
+OpenCL is a trademark of Apple Inc. and OpenGL and OpenML are registered trademarks
+and the OpenGL ES and OpenGL SC logos are trademarks of Silicon Graphics
+International used under license by Khronos. All other product names, trademarks,
+and/or company names are used solely for identification and belong to their
+respective owners.

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -1,0 +1,61 @@
+# KHR\_materials\_ior
+
+## Khronos 3D Formats Working Group
+
+* TODO
+
+## Acknowledgments
+
+* TODO
+
+## Status
+
+Experimental
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+The dielectric BRDF of the metallic-roughness material in glTF uses a fixed value of 1.5 for the index of refraction. This is a good fit for many plastics and glass, but not for other materials like water or asphalt, sapphire or diamond. This extensions allows users to set the index of refraction to a certain value.
+
+## Extending Materials
+
+The index of refraction of a material is configured by adding the `KHR_materials_ior` extension to any glTF material. 
+
+```json
+{
+    "materials": [
+        {
+            "extensions": {
+                "KHR_materials_ior": {
+                    "ior": 1.4,
+                    "iorTexture": 0
+                }
+            }
+        }
+    ]
+}
+```
+
+The index of refraction typically is a value between 1 and 2, in rare cases it may be larger than 2. In contrast to other texturable values in glTF, `ior` and `iorTexture` are not multiplied: if no texture is given, `ior` is used, otherwise the texture overrides it.
+
+| |Type|Description|Required|
+|-|----|-----------|--------|
+| **ior** | `number` | The index of refraction. | No, default: `1.5`|
+| **iorTexture** | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo) | A greyscale texture that defines the index of refraction as 1/ior. | No |
+
+## Implementation
+
+The index of refraction affects the Fresnel term in the dielectric BRDF:
+
+```
+dielectric_brdf =
+  fresnel_mix(
+    diffuse_brdf(baseColor),
+    microfacet_brdf(roughness^2),
+    ior)
+```
+
+In case `KHR_materials_transmission` is enabled, the index of refraction also affects the refraction of light rays passing through the transparent surface.

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -74,6 +74,8 @@ dielectric_brdf =
       α = roughness^2))
 ```
 
+Valid values for `ior` are numbers greater than or equal to 1. In addition, a value of 0 is allowed. This value gives full weight to `layer`, i.e., the Fresnel term evaluates to 1 independent of the view or light direction. It is useful in combination with `KHR_materials_specular` to seamlessly support the specular-glossiness workflow.
+
 ## Implementation
 
 *This section is non-normative*

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -13,6 +13,14 @@
 * Ben Houston, ThreeKit [@bhouston](https://github.com/bhouston)
 * Gary Hsu, Microsoft [@bghgary](https://twitter.com/bghgary)
 * Sebastien Vandenberghe, Microsoft [@sebavanjs](https://twitter.com/sebavanjs)
+* Nicholas Barlow, Microsoft
+* Nicolas Savva, Autodesk [@nicolassavva-autodesk](https://github.com/nicolassavva-autodesk)
+* Henrik Edstrom, Autodesk
+* Bruce Cherniak, Intel
+* Adam Morris, Target [@weegeekps](https://github.com/weegeekps)
+* Sandra Voelker, Target
+* Alex Jamerson, Amazon
+* Thomas Dideriksen, Amazon
 * Alex Wood, AGI [@abwood](https://twitter.com/abwood)
 * Ed Mackey, AGI [@emackey](https://twitter.com/emackey)
 

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -4,12 +4,19 @@
 
 * Tobias Haeussler, Dassault Systemes [@proog128](https://github.com/proog128)
 * Bastian Sdorra, Dassault Systemes [@bsdorra](https://github.com/bsdorra)
-* Ben Houston, ThreeKit [@bhouston](https://github.com/bhouston)
-* Richard Sahlin, IKEA [@rsahlin](https://github.com/rsahlin)
+* Mike Bond, Adobe, [@miibond](https://github.com/MiiBond)
+* Emmett Lalish, Google [@elalish](https://github.com/elalish)
+* Don McCurdy, Google [@donrmccurdy](https://twitter.com/donrmccurdy)
 * Norbert Nopper, UX3D [@UX3DGpuSoftware](https://twitter.com/UX3DGpuSoftware)
+* Richard Sahlin, IKEA [@rsahlin](https://github.com/rsahlin)
+* Eric Chadwick, Wayfair [echadwick-wayfair](https://github.com/echadwick-wayfair)
+* Ben Houston, ThreeKit [@bhouston](https://github.com/bhouston)
+* Gary Hsu, Microsoft [@bghgary](https://twitter.com/bghgary)
+* Sebastien Vandenberghe, Microsoft [@sebavanjs](https://twitter.com/sebavanjs)
+* Alex Wood, AGI [@abwood](https://twitter.com/abwood)
 * Ed Mackey, AGI [@emackey](https://twitter.com/emackey)
 
-Copyright (C) 2018-2020 The Khronos Group Inc. All Rights Reserved. glTF is a trademark of The Khronos Group Inc.
+Copyright (C) 2018-2021 The Khronos Group Inc. All Rights Reserved. glTF is a trademark of The Khronos Group Inc.
 See [Appendix](#appendix-full-khronos-copyright-statement) for full Khronos Copyright Statement.
 
 ## Status
@@ -102,7 +109,7 @@ If `KHR_materials_volume` is used in combination with `KHR_materials_ior`, the `
 
 ## Appendix: Full Khronos Copyright Statement
 
-Copyright 2018-2020 The Khronos Group Inc.
+Copyright 2018-2021 The Khronos Group Inc.
 
 Some parts of this Specification are purely informative and do not define requirements
 necessary for compliance and so are outside the Scope of this Specification. These

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -21,7 +21,7 @@ See [Appendix](#appendix-full-khronos-copyright-statement) for full Khronos Copy
 
 ## Status
 
-Experimental
+Draft
 
 ## Dependencies
 

--- a/extensions/2.0/Khronos/KHR_materials_ior/schema/glTF.KHR_materials_ior.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_ior/schema/glTF.KHR_materials_ior.schema.json
@@ -12,19 +12,6 @@
             "minimum": 1.0,
             "gltf_detailedDescription": "The index of refraction (IOR) is a measured physical number usually in the range between 1 and 2 that determines how much the path of light is bent, or refracted, when entering a material. It also influences the ratio between reflected and transmitted light, calculated from the Fresnel equations."
         },
-        "f0Texture": {
-            "allOf": [ { "$ref": "textureInfo.schema.json" } ],
-            "description": "A 1-channel luminance texture that defines the index of refraction in terms of the reflectance at normal incidence f0.",
-            "gltf_detailedDescription": "The texture stores the index of refraction in terms of the reflectance at normal incidence, a value in the range 0..1: f0 = ((ior - 1) / (ior + 1))^2. If the texture is enabeld, the ior property is ignored."
-        },
-        "maxF0": {
-            "type": "number",
-            "description": "Maximum F0 value, corresponds to a texture value of 1.0.",
-            "default": 0.08,
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "gltf_detailedDescription": "The maximum F0 value acts as a multiplier for the value fetched from the f0 texture. The default of 0.08 maps the texture value 0.5 (128) to an index of refraction of 1.5."
-        },
         "extensions": { },
         "extras": { }
     }

--- a/extensions/2.0/Khronos/KHR_materials_ior/schema/glTF.KHR_materials_ior.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_ior/schema/glTF.KHR_materials_ior.schema.json
@@ -12,10 +12,18 @@
             "minimum": 1.0,
             "gltf_detailedDescription": "The index of refraction (IOR) is a measured physical number usually in the range between 1 and 2 that determines how much the path of light is bent, or refracted, when entering a material. It also influences the ratio between reflected and transmitted light, calculated from the Fresnel equations."
         },
-        "iorTexture": {
+        "f0Texture": {
             "allOf": [ { "$ref": "textureInfo.schema.json" } ],
-            "description": "A greyscale texture that defines the index of refraction.",
-            "gltf_detailedDescription": "The texture stores the inverse of the index of refraction (1/ior) to keep the values in the range 0 to 1."
+            "description": "A 1-channel luminance texture that defines the index of refraction in terms of the reflectance at normal incidence f0.",
+            "gltf_detailedDescription": "The texture stores the index of refraction in terms of the reflectance at normal incidence, a value in the range 0..1: f0 = ((ior - 1) / (ior + 1))^2. If the texture is enabeld, the ior property is ignored."
+        },
+        "maxF0": {
+            "type": "number",
+            "description": "Maximum F0 value, corresponds to a texture value of 1.0.",
+            "default": 0.08,
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "gltf_detailedDescription": "The maximum F0 value acts as a multiplier for the value fetched from the f0 texture. The default of 0.08 maps the texture value 0.5 (128) to an index of refraction of 1.5."
         },
         "extensions": { },
         "extras": { }

--- a/extensions/2.0/Khronos/KHR_materials_ior/schema/glTF.KHR_materials_ior.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_ior/schema/glTF.KHR_materials_ior.schema.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_materials_ior glTF extension",
+    "type": "object",
+    "description": "glTF extension that defines the index of refraction of a material.",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "ior": {
+            "type": "number",
+            "description": "The index of refraction.",
+            "default": 1.5,
+            "minimum": 1.0,
+            "gltf_detailedDescription": "The index of refraction (IOR) is a measured physical number usually in the range between 1 and 2 that determines how much the path of light is bent, or refracted, when entering a material. It also influences the ratio between reflected and transmitted light, calculated from the Fresnel equations."
+        },
+        "iorTexture": {
+            "allOf": [ { "$ref": "textureInfo.schema.json" } ],
+            "description": "A greyscale texture that defines the index of refraction.",
+            "gltf_detailedDescription": "The texture stores the inverse of the index of refraction (1/ior) to keep the values in the range 0 to 1."
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}

--- a/extensions/2.0/Khronos/KHR_materials_ior/schema/glTF.KHR_materials_ior.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_ior/schema/glTF.KHR_materials_ior.schema.json
@@ -9,7 +9,15 @@
             "type": "number",
             "description": "The index of refraction.",
             "default": 1.5,
-            "minimum": 1.0,
+            "oneOf": [
+                {
+                    "minimum": 0.0,
+                    "maximum": 0.0
+                },
+                {
+                    "minimum": 1.0
+                }
+            ],
             "gltf_detailedDescription": "The index of refraction (IOR) is a measured physical number usually in the range between 1 and 2 that determines how much the path of light is bent, or refracted, when entering a material. It also influences the ratio between reflected and transmitted light, calculated from the Fresnel equations."
         },
         "extensions": { },


### PR DESCRIPTION
An extension for the metallic-roughness material that makes the index of refraction configurable. At the moment, there is a fixed value of 1.5, corresponding to F0 = 0.04.

This extension is similar to KHR_materials_specular proposed in #1677, but should work better in combination with KHR_materials_transmission (#1698). It allows to set IOR>2, which is not uncommon for transparent materials.

The extension uses some notation introduced in #1717.