### PR TITLE
Update prefixes list

### DIFF
--- a/extensions/Prefixes.md
+++ b/extensions/Prefixes.md
@@ -1,36 +1,42 @@
-# glTF Extension Reserved Prefixes
+# glTF Extension Prefixes
 
-The following extension prefixes are reserved:
+The following extension prefixes are reserved by the spec maintainers:
 
-* `ADOBE` - Adobe Systems Inc.
-* `AGI` - Analytical Graphics, Inc.
-* `AGT` - Augment
-* `ALCM` - Alchemisten AG
-* `ALI` - Alibaba
-* `AMZN` - Amazon
-* `AVR` - AltspaceVR
-* `BLENDER` - Blender
-* `CESIUM` - Cesium
-* `CVTOOLS` - Canvas Tools
-* `EXT` - Multi-vendor
-* `FB` - Facebook
-* `FOXIT` - Foxit Software
-* `GOOGLE` - Google
-* `KDAB` - The KDAB Group
-* `KHR` - Ratified or intended-to-be-ratified Khronos
-* `LLQ` - Lifeliqe
-* `MESHOPT` - Meshoptimizer
-* `MOZ` - Mozilla
-* `MSFT` - Microsoft
-* `NV` - NVIDIA Corporation
-* `OWLII` - Owlii
-* `POLUTROPON` - Polutropon Games
-* `S8S` - Soft8Soft
-* `SI` - Smithsonian Institution
-* `SKFB` - Sketchfab
-* `SKYLINE` - Skyline Software Systems, Inc.
-* `WEB3D` - Web3D Consortium
+* `KHR` - Ratified or intended-to-be-ratified by Khronos Group
+* `EXT` - Prefix for extensions proposed by multiple vendors
 
 To request a prefix, submit a [GitHub issue](https://github.com/KhronosGroup/glTF/issues/new) with the name of the requested prefix and the vendor that will be using it. Maintainers, please assign the `extension` label to the issue.
 
 Once a prefix is approved, it should be added to the [glTF Validator's list of known prefixes](https://github.com/KhronosGroup/glTF-Validator/blob/master/lib/src/ext/extensions.dart).
+
+## Registered Vendor Prefixes
+
+| Prefix | Company or Project Name | Contacts | Request |
+|--------------|--------------------------------|---------------------------------------------------------------|-----------|
+| `ADOBE` | Adobe, Inc. | https://adobe.com | [#1431](https://github.com/KhronosGroup/glTF/issues/1431) |
+| `AGI` | Analytical Graphics, Inc. | https://agi.com | [#1405](https://github.com/KhronosGroup/glTF/pull/1405) |
+| `AGT` | Augment SAS | https://www.augment.com | [#1571](https://github.com/KhronosGroup/glTF/issues/1571) |
+| `ALCM` | Alchemisten AG | https://alchemisten.ag/<br>`viktor.spadi at alchemisten.ag` | [#1708](https://github.com/KhronosGroup/glTF/issues/1708) |
+| `ALI` | Alibaba Group | https://www.alibaba.com/ | [#1160](https://github.com/KhronosGroup/glTF/pull/1160) |
+| `AMZN` | Amazon | https://www.amazon.com/<br>`jasoncan at amazon.com` | [#1233](https://github.com/KhronosGroup/glTF/issues/1233) |
+| `AVR` | AltspaceVR, Inc. | https://altvr.com/ | [#1009](https://github.com/KhronosGroup/glTF/issues/1009) |
+| `BLENDER` | Blender Foundation | https://www.blender.org/ | [#865](https://github.com/KhronosGroup/glTF/issues/865) |
+| `CAPTURE` | Capture Visualisation AB | https://www.capture.se/ | [#1732](https://github.com/KhronosGroup/glTF/issues/1732) |
+| `CESIUM` | Cesium GS, Inc. | https://cesium.com |  |
+| `CVTOOLS` | Canvas Tools | https://github.com/MackeyK24/CanvasTools | [#1389](https://github.com/KhronosGroup/glTF/issues/1389) |
+| `FB` | Facebook, Inc. | https://www.facebook.com/ | [#1139](https://github.com/KhronosGroup/glTF/pull/1139) |
+| `FOXIT` | Foxit Software, Inc. | https://foxitsoftware.com<br>`liqian_mu at foxitsoftware.com` | [#1712](https://github.com/KhronosGroup/glTF/issues/1712) |
+| `GOOGLE` | Google, LLC | https://www.google.com/ | [#1123](https://github.com/KhronosGroup/glTF/issues/1123) |
+| `KDAB` | The KDAB Group | https://www.kdab.com/ | [#1728](https://github.com/KhronosGroup/glTF/pull/1728) |
+| `LLQ` | Lifeliqe, Inc. | https://www.lifeliqe.com/ | [#1414](https://github.com/KhronosGroup/glTF/issues/1414) |
+| `MESHOPT` | meshoptimizer | https://meshoptimizer.org/ | [#1634](https://github.com/KhronosGroup/glTF/issues/1634) |
+| `MOZ` | Mozilla Corporation | https://www.mozilla.org/ | [#1349](https://github.com/KhronosGroup/glTF/issues/1349) |
+| `MSFT` | Microsoft Corporation | https://www.microsoft.com/ | [#1164](https://github.com/KhronosGroup/glTF/pull/1164) |
+| `NV` | NVIDIA Corporation | https://www.nvidia.com | [#1211](https://github.com/KhronosGroup/glTF/issues/1211) |
+| `OWLII` | Owlii, Inc. | https://www.owlii.com/ | [#1093](https://github.com/KhronosGroup/glTF/issues/1093) |
+| `POLUTROPON` | Polutropon Games | https://polutropon.games/<br>`ybalrid at polutropon.games` | [#1632](https://github.com/KhronosGroup/glTF/issues/1632) |
+| `S8S` | Soft8Soft | https://www.soft8soft.com/ | [#1240](https://github.com/KhronosGroup/glTF/issues/1240) |
+| `SI` | Smithsonian Institution | https://www.si.edu/ | [#1410](https://github.com/KhronosGroup/glTF/issues/1410) |
+| `SKFB` | Sketchfab, Inc. | https://sketchfab.com/ | [#1239](https://github.com/KhronosGroup/glTF/issues/1239) |
+| `SKYLINE` | Skyline Software Systems, Inc. | https://www.skylinesoft.com/ | [#1704](https://github.com/KhronosGroup/glTF/issues/1704) |
+| `WEB3D` | The Web3D Consortium, Inc. | https://www.web3d.org/ |  |


### PR DESCRIPTION
For better transparency, I have updated the list of registered vendor prefixes with full company names (where applicable), websites, and contact information (when it was provided with the original request).

Also fixes #1732.