### PR TITLE
KHR_skin_strict

### DIFF
--- a/extensions/2.0/Khronos/KHR_skin_strict/README.md
+++ b/extensions/2.0/Khronos/KHR_skin_strict/README.md
@@ -34,3 +34,14 @@ Client implementations may choose to require that glTF assets containing one or 
 * A joint node *must not* define any other functional role, such as `node.mesh`, `node.camera`, `node.weights`, or `node.skin`.
 
 > **NOTE:** A node is considered a joint for a skin if and only if the node is included in the skin's `joints` list.
+
+## Extending assets
+
+The `KHR_skin_strict` extension is listed in `extensionsUsed`, but has no other explicit presence in the schema.
+
+```json
+{
+    "extensionsUsed": ["KHR_skin_strict"],
+    ...
+}
+```

--- a/extensions/2.0/Khronos/KHR_skin_strict/README.md
+++ b/extensions/2.0/Khronos/KHR_skin_strict/README.md
@@ -1,0 +1,36 @@
+# KHR\_skin\_strict
+
+## Contributors
+
+* TBD
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+`KHR_skin_strict` introduces no new features or schema to the glTF file format. Instead, it defines a strict subset of the existing skinning specification, and imposes requirements — beyond those of the original specification — on tools creating glTF assets with a `skins` entry.
+
+Implementations of skinned mesh animation vary between engines, for historical and performance reasons. This stricter skinning definition increases portability and simplicity for client implementations, at the cost of some flexibility and increased responsibilities for authoring tools.
+
+When used, `KHR_skin_strict` must be an *optional* extension. Because it is a subset of the original specification, clients that do not recognize the extension can always safely read files that include the extension, so inclusion in the `extensionsRequired` list is neither necessary nor allowed. Presence of the `KHR_skin_strict` extension acts as a hint, for clients that recognize it, that the safer/stricter skinning requirements have been met.
+
+Client implementations may choose to require that glTF assets containing one or more skins include the `KHR_skin_strict` extension, and reject assets that do not. Authoring tools are advised to include the extension whenever possible.
+
+## Requirements
+
+* All skins *must* define the `skeleton` property.
+* The `skeleton` node for a skin *must* be a joint, and the direct parent of the entire joint subtree for that skin.
+* All joints in a skin *must* define a single fully-connected subtree, sharing a single root joint.
+* A non-joint node *must not* be both an ancestor and a descendant of a joint node.
+    * `node ⊃ joint ⊃ joint ⊃ node` is valid.
+    * `node ⊃ joint ⊃ node ⊃ joint` is invalid, regardless of whether the two joints are part of the same skin.
+* A joint node *must* belong only to a single skin.
+* A joint node *must not* define any other functional role, such as `node.mesh`, `node.camera`, `node.weights`, or `node.skin`.
+
+> **NOTE:** A node is considered a joint for a skin if and only if the node is included in the skin's `joints` list.

--- a/extensions/2.0/Khronos/KHR_skin_strict/README.md
+++ b/extensions/2.0/Khronos/KHR_skin_strict/README.md
@@ -26,12 +26,9 @@ Client implementations may choose to require that glTF assets containing one or 
 
 * All skins *must* define the `skeleton` property.
 * The `skeleton` node for a skin *must* be a joint, and the direct parent of the entire joint subtree for that skin.
-* All joints in a skin *must* define a single fully-connected subtree, sharing a single root joint.
-* A non-joint node *must not* be both an ancestor and a descendant of a joint node.
-    * `node ⊃ joint ⊃ joint ⊃ node` is valid.
-    * `node ⊃ joint ⊃ node ⊃ joint` is invalid, regardless of whether the two joints are part of the same skin.
+* All joints in a skin *must* define a single fully-connected subtree, sharing a single root joint, with no non-joint nodes coming between the joints of the tree.
 * A joint node *must* belong only to a single skin.
-* A joint node *must not* define any other functional role, such as `node.mesh`, `node.camera`, `node.weights`, or `node.skin`.
+* A joint node *must not* define any other functional role, such as `node.mesh`, `node.camera`, or `node.skin`. Likewise, joint nodes cannot use extensions that instantiate resources in the scene (like `KHR_lights_punctual`).
 
 > **NOTE:** A node is considered a joint for a skin if and only if the node is included in the skin's `joints` list.
 


### PR DESCRIPTION
- Fixes: https://github.com/KhronosGroup/glTF/issues/1665 (*Stricter Skinning Requirements*)
- Alternative 1: https://github.com/KhronosGroup/glTF/pull/1669 (*Stricter Skin Definitions*)
- Alternative 2: https://github.com/KhronosGroup/glTF/pull/1695 (*Extension Proposal regarding Skeleton Definitions in glTF*)

Extension introduces no new features or schema to the glTF file format. Instead, it defines a strict subset of the existing skinning specification, and imposes requirements — beyond those of the original specification — on tools creating glTF assets with a `skins` entry.

This proposal is quite close to #1695 (by @marstaik), but omits the new skeleton-centric schema, in favor of strictly limiting existing features. My hope is that by requiring the `skeleton` property and enforcing a 1:1 relationship between a skin and a skeleton root, engines will be able to load skinned meshes reliably even if their internal representation is centered around skeletons rather than skins.