### PR TITLE
add python library pygltflib to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ To compare WebGL-based glTF loaders, see [gltf-test](https://github.com/cx20/glt
 | Tool | Status | Description |
 |------|--------|-------------|
 | [trimesh](https://github.com/mikedh/trimesh) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Python library for importing and exporting glTF and numerous other triangular mesh formats. |
+| [pygltflib](https://gitlab.com/dodgyville/pygltflib) | ![status](https://img.shields.io/badge/glTF-2%2E0-green.svg?style=flat) | Python library for reading, writing and converting glTF 2.0 files. |
 
 ### Utilities
 


### PR DESCRIPTION
Hi, I have a python library for GLTF2 that people seem to like using, so thought I'd add it to your list. Hope it's useful and thanks for creating such an accessible and open format!