### PR TITLE
glTF performance metrics

### DIFF
--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -1,10 +1,10 @@
-# Runtime Performance Metrics 
+# Runtime GLTF Metrics 
 
-The goal of these metrics is to assess the runtime performance needs of glTF assets.  
+The goal of these metrics is to assess the runtime needs of glTF assets.  
 By runtime we mean the cpu/gpu, bandwidth and memory resources needed to render the model in realtime.  
 These performance metrics are divided in two major categories - `complexity` and `memory`
 
-## Performance Metric Categories
+## Metric Categories
 
 ### Complexity  
 
@@ -60,7 +60,7 @@ It is possible to reference different meshes (nodes) using different scenes, thi
 Ie one model could have 3 different scenes, where the same accessors (position, uv) are used but different primitives that reference materials with varying number of texture channels.  
 
 [nodeCount]  
-This represent the number of traversed nodes in a scene.  
+This represent the total number of traversed nodes in a scene.  
 This is calculated by traversing nodes in each scene (depth or breadth first does not matter) - for each node increase the nodecount.  
 
 [drawCount]  
@@ -75,7 +75,9 @@ Each primitive references a material with 0 or more texture sources, has attribu
 [channels]  
 This value represents the texture source channels that are used by a scene.  
 This is the max value from the most 'complex' primitive that will be referenced by a Node in the scene.  
-The goal of this metric is to provide a worst case texture usage and processing cost for rendering a pixel.  
+The goal of this metric is to provide a worst case texture usage and processing cost for rendering a pixel. 
+Please note that the processing cost for the different channels will vary, for instance the EMISSIVE or  
+BASECOLOR channels are quite cheap but other channels may add a signification processing overhead.  
 
 **Note**  
 This value can not be used to know if texture channels are tightly packed according to uniform Sampler usage,  

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -1,31 +1,42 @@
 
---- Name -----------Property    ----- Description ----------------------------
-[vertexcount]       Scene       Total number of vertices used by a model in a scene
-[nodecount]         Scene       Max nodecount in scene (add upp all nodes in a scene)
-[primitivecount]    Scene       Total number of referenced primitives (per scene)
-                                This figure is the un-batched number of primitives, engines may optimize if primitives and meshes share textures.
-[textures]          Scene       Flags specifying presence of materials and it's texture usage, this is the aggregated max usage
-                                BASECOLOR, METALLICROUGHNESS, NORMAL, OCCLUSION, EMISSIVE, (SPECULARGLOSS)
+|                      |                           |                                           | 
+|----------------------|---------------------------|-------------------------------------------|
+| Name |Property   |Description  |
+|[vertexcount]       |Scene       |Total number of vertices used by a model in a scene|  
+|[nodecount]         |Scene       |Max nodecount in scene (add upp all nodes in a scene)|  
+|[primitivecount]    |Scene       |Total number of referenced primitives (per scene).  This figure is the un-batched number of primitives, engines may optimize if primitives and meshes share textures.  |  
+|[textures]          |Scene       |Flags specifying presence of materials and it's texture usage, this is the aggregated max usage. BASECOLOR, METALLICROUGHNESS, NORMAL, OCCLUSION, EMISSIVE, (SPECULARGLOSS)  
 
+# Scene #
+Metrics that describe properties of a scene.  
+glTF models may contain multiple scenes, only one scene will be visible at a time.  
+To accomodate this the following metrics are calculated on a per-scene basis.  
+It is possible to reference different meshes (nodes) using different scenes, this makes it possible to have the same texture assets but reference different primitives that use alternative materials (textures).  
+Ie one model could have 3 different scenes, where the same accessors (position, uv) are used but different primitives that reference materials with varying number of texture channels.  
+
+[nodecount]  
+This represent the number of traversed nodes in a scene.  
+This is calculated by traversing nodes in each scene (depth or breadth first does not matter) - for each node increase the nodecount.  
+
+[verticecount]  
+This represents the number of drawn vertices for each scene in the model.  
+This is calculated by traversing the nodes in each scene.  
+For each mesh use the POSITION attribute in each primitive, get the Accessor and add up the count field.  
+
+[primitivecount]  
+This represents the number of primitives for each scene  
+Each primitive references a material with 0 or more texture sources, has attributes and accessors.  
+
+
+[textures]  
+This value represents the texture sources that are used by a scene.  
+This is the max value from the most 'complex' primitive that will be referenced by a Node in the scene.  
+The goal of this metric is to provide a worst case texture usage where texturecount and complexity is known.  
+Ie it is known if a texture is BASECOLOR or if part of PBR such as METALICROUGHNESS and now many texture sources that are used.  
+
+
+# JSON #  
+This is how the output would be formatted using JSON  
 
 "scene" : [ { "verticecount" : 4300, "nodecount" : 20, "primitivecount" : 50 ,
-              "textures" : ["BASECOLOR", "METALLICROUGHNESS"]} ]
-
-
-[nodecount]
-This represent the number of traversed nodes in a scene.
-This is calculated by traversing nodes in each scene (depth or breadth first does not matter) - for each node increase the nodecount.
-
-[verticecount]
-This represents the number of drawn vertices for each scene in the model.
-This is calculated by traversing the nodes in each scene.
-For each mesh use the POSITION attribute in each primitive, get the Accessor and add up the count field.
-
-[primitivecount]
-This represents the number of primitives for each scene
-
-[textures]
-This value represents the texture sources that are used by a scene.
-This is the max value from the most 'complex' primitive that will be referenced by a primitive in the scene.
-The goal of this metric is to provide a worst case texture usage where texturecount and complexity is known.
-Ie it is known if a texture is BASECOLOR or if part of PBR such as METALICROUGHNESS
+              "textures" : ["BASECOLOR", "METALLICROUGHNESS"]} ]  

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -11,6 +11,11 @@ These performance metrics are divided in two major categories - `complexity` and
 The `complexity`category provides metrics to calculate cpu/gpu and memory bandwidth target requirements - larger numbers will mean a more powerful target device is needed.  
 These metrics do not provide a mapping to target device performance, this mapping must be done by users of the metrics.  
 
+### Screen space coverage
+
+The metrics do not include screen space coverage, it is advised that clients shall know how large the render area will be before requesting a model (from the backend)  
+It is up to the backend to take screen coverage into account when providing a suitable model to the client, for instance by taking width + height as parameters.  
+
 ### Memory  
 
 The `memory` category provides metrics to calculate the runtime memory (size) needs of the model.  
@@ -25,6 +30,7 @@ Using these metrics an estimate of target memory can be calculated - however kee
 |[nodeCount]      | Integer     | Complexity  |Scene     |Max nodecount in scene (add upp all nodes in a scene)           |  
 |[primitiveCount] | Integer     | Complexity  |Scene     |Total number of referenced primitives (per scene).  This figure is the un-batched number of primitives, engines may optimize if primitives and meshes share textures. |  
 |[textures]       | Integer     | Complexity  |Scene     |Flags specifying presence of materials and it's texture usage, this is the aggregated max usage. BASECOLOR, METALLICROUGHNESS, NORMAL, OCCLUSION, EMISSIVE, (SPECULARGLOSS) |  
+|[maxNodeDepth]   | Integer     | Memory      | Scene    | The max node depth of the scene, ie the max number of parent/child relations. This number will represent the max stack depth needed when traversing the nodegraph |
 |[attributes]     | Integer     | Memory      | Asset    | The total memory footprint, in bytes, for the models attribute buffer storage |  
 |[textureSizes]  |Dimension    | Memory      | Asset    | The width and height of defined textures in the Asset. |  
 
@@ -79,7 +85,8 @@ This is how the output would be formatted using JSON
             "vertexCount" : 4300,
             "nodeCount" : 20,
             "primitiveCount" : 50,
-            "textures" : ["BASECOLOR", "METALLICROUGHNESS"]
+            "textures" : ["BASECOLOR", "METALLICROUGHNESS"],
+            "maxNodeDepth" : 7
         }
     ],
     "asset" : {

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -1,7 +1,7 @@
 # Runtime Performance Metrics 
 
 The goal of these metrics is to asses the runtime performance needs of glTF assets.  
-By runtime we mean the cpu/gp, bandwitdh and memory resources needed to render the model in realtime.  
+By runtime we mean the cpu/gpu, bandwidth and memory resources needed to render the model in realtime.  
 These performance metrics are divided in two major categories - `complexity` and `memory`
 
 ## Performance Metric Categories

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -96,7 +96,9 @@ This will include translation, meaning that the bounds will not be centered.
 
 
 [accessors]  
-This value represents the total vertex accessor usage of the asset, it is an indication of the memory requirements for the asset.  
+This value represents the total vertex accessors defined in the asset, it is an indication of the memory requirements for the asset.  
+These values does not take into account if an acessor is unused or only used in some scene.  
+
 Note that this value will not take into account if normal/tangent/bitangent values are defined or shall be runtime computed.  
 It is calculated by adding upp the accessors in the model, storing count, componentType and type.  
 This may give an indication of the runtime memory footprint of the buffers needed for the model.  

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -1,13 +1,36 @@
+# Runtime Performance Metrics 
 
-|                      |                           |                                           | 
-|----------------------|---------------------------|-------------------------------------------|
-| Name |Property   |Description  |
-|[vertexcount]       |Scene       |Total number of vertices used by a model in a scene|  
-|[nodecount]         |Scene       |Max nodecount in scene (add upp all nodes in a scene)|  
-|[primitivecount]    |Scene       |Total number of referenced primitives (per scene).  This figure is the un-batched number of primitives, engines may optimize if primitives and meshes share textures.  |  
-|[textures]          |Scene       |Flags specifying presence of materials and it's texture usage, this is the aggregated max usage. BASECOLOR, METALLICROUGHNESS, NORMAL, OCCLUSION, EMISSIVE, (SPECULARGLOSS)  
+The goal of these metrics is to asses the runtime performance needs of glTF assets.  
+By runtime we mean the cpu/gp, bandwitdh and memory resources needed to render the model in realtime.  
+These performance metrics are divided in two major categories - `complexity` and `memory`
 
-# Scene #
+## Performance Metric Categories
+
+### Complexity  
+
+The `complexity`category provides metrics to calculate cpu/gpu and memory bandwidth target requirements - larger numbers will mean a more powerful target device is needed.  
+These metrics do not provide a mapping to target device performance, this mapping must be done by users of the metrics.  
+
+### Memory  
+
+The `memory` category provides metrics to calculate the runtime memory (size) needs of the model.  
+Using these metrics an estimate of target memory can be calculated - however keep in mind that the exact memory requirements will vary with viewer implementations.  
+
+
+
+|                 |             |          |                                                                | 
+|-----------------|-------------|----------|----------------------------------------------------------------|
+| Name            | Category    | Property |Description                                                     |
+|[vertexcount]    | Complexity  |Scene     |Total number of vertices used by a model in a scene             |  
+|[nodecount]      | Complexity  |Scene     |Max nodecount in scene (add upp all nodes in a scene)           |  
+|[primitivecount] | Complexity  |Scene     |Total number of referenced primitives (per scene).  This figure is the un-batched number of primitives, engines may optimize if primitives and meshes share textures. |  
+|[textures]       | Complexity  |Scene     |Flags specifying presence of materials and it's texture usage, this is the aggregated max usage. BASECOLOR, METALLICROUGHNESS, NORMAL, OCCLUSION, EMISSIVE, (SPECULARGLOSS) |  
+|[attributes]     | Memory      | Asset    | The total memory footprint, in bytes, for the models attribute buffer storage |  
+|[texturesizes]  | Memory      | Asset    | The sizes of defined textures in the Asset. |  
+
+
+# Scene #  
+
 Metrics that describe properties of a scene.  
 glTF models may contain multiple scenes, only one scene will be visible at a time.  
 To accomodate this the following metrics are calculated on a per-scene basis.  
@@ -34,9 +57,21 @@ This is the max value from the most 'complex' primitive that will be referenced 
 The goal of this metric is to provide a worst case texture usage where texturecount and complexity is known.  
 Ie it is known if a texture is BASECOLOR or if part of PBR such as METALICROUGHNESS and now many texture sources that are used.  
 
+[attributes]  
+This value represent the total attribute buffer usage of the model. This value is calculated by adding up the size, in bytes, of all buffer objects in the Asset.  
+This may give an indication of the runtime memory footprint of the buffers needed for the model.  
+
+[texturesizes]
+The total size of textures, without mipmaps, that are defined in the Asset.  
+This is calculated by iterating the texture array and adding up the size of indexed images.  
+The max texture size can be determined from these values.  
+Some target devices may have a smaller (4096 * 4096) max texture size in which case the backend can choose to deliver another model.  
 
 # JSON #  
 This is how the output would be formatted using JSON  
 
 "scene" : [ { "verticecount" : 4300, "nodecount" : 20, "primitivecount" : 50 ,
-              "textures" : ["BASECOLOR", "METALLICROUGHNESS"]} ]  
+              "textures" : ["BASECOLOR", "METALLICROUGHNESS"]} ],  
+"asset" : { "attributes" : 345234 }, { "texturesizes" : ["2048 * 2048", "512 * 512", "128 * 100"] }  
+
+

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -45,7 +45,7 @@ Using these metrics an estimate of target memory can be calculated - however kee
 |[maxNodeDepth]   | Integer     | Memory      | Scene    | The max node depth of the scene, ie the max number of parent/child relations. This number will represent the max stack depth needed when traversing the nodegraph |
 |[accessors]     | Accessor     | Memory      | Asset    | Total number and format of vertex accessors, this can be used to calculate vertex buffer memory requirements |  
 |[buffers  ]     | Buffer       | Memory      | Asset    | Size and number of buffers in the Asset, memory needed to load model. For a .glb this will include textures |  
-|[textureSize]  |Integer    | Memory      | Asset    | The size and format of textures |  
+|[textureSize]   |Integer       | Memory      | Asset    | The size and number of components of textures |  
 
 Dimension is an Integer[2] containing width and height  
 Accessor is an object containing count, componentType and type, componentType and type is taken from glTF Accessor  
@@ -133,12 +133,18 @@ For a .gltf the textures are usually supplied separately.
 Size in bytes of the buffer.
 
 [textureSize]  
-The size and format of textures, without mipmaps, that are defined in the Asset.  
-This is calculated by iterating the texture array and adding the size and format of indexed images.  
-Formats are as follows [4, 3, 2, 1] :
-4 component, eg (RGBA)    
-3 component, eg (RGB)    
-2 component, eg (MR)    
+The size and number of components of textures, without mipmaps, that are defined in the Asset.  
+This is calculated by iterating the texture array and adding the size and components of indexed images.  
+
+`dimension`  
+Width and height, in pixels of the texture.  
+
+`components`
+The texture component count, currently only supports 8 bit per component.  
+Components are as follows [4, 3, 2, 1] :  
+4 components, eg (RGBA)    
+3 components, eg (RGB) - this is likely to occupy 32 bits on modern hw.  
+2 components, eg (MR)    
 1 component, eg (O)  
 
 It is up to the client to calculate the actual memory requirements on the target device as this may vary depending on hardware and (future) compressed format support.
@@ -181,15 +187,15 @@ This is how the output would be formatted using JSON
         "textureSize" : [
             {
                 "dimension" : [2048,2048],
-                "format" : 4
+                "components" : 4
             },
             {
                 "dimension" : [512,512],
-                "format" : 1
+                "components" : 1
             },
             {
                 "dimension" : [256,200],
-                "format" : 3
+                "components" : 3
             }
         ]
     }

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -1,0 +1,31 @@
+
+--- Name -----------Property    ----- Description ----------------------------
+[verticecount]      Scene       Total number of vertices used by a model in a scene
+[nodecount]         Scene       Max nodecount in scene (add upp all nodes in a scene)
+[primitivecount]    Scene       Total number of referenced primitives (per scene)
+                                This figure is the un-batched number of primitives, engines may optimize if primitives and meshes share textures.
+[textures]          Scene       Flags specifying presence of materials and it's texture usage, this is the aggregated max usage
+                                BASECOLOR, METALLICROUGHNESS, NORMAL, OCCLUSION, EMISSIVE, (SPECULARGLOSS)
+
+
+"scene" : [ { "verticecount" : 4300, "nodecount" : 20, "primitivecount" : 50 ,
+              "textures" : ["BASECOLOR", "METALLICROUGHNESS"]} ]
+
+
+[nodecount]
+This represent the number of traversed nodes in a scene.
+This is calculated by traversing nodes in each scene (depth or breadth first does not matter) - for each node increase the nodecount.
+
+[verticecount]
+This represents the number of drawn vertices for each scene in the model.
+This is calculated by traversing the nodes in each scene.
+For each mesh use the POSITION attribute in each primitive, get the Accessor and add up the count field.
+
+[primitivecount]
+This represents the number of primitives for each scene
+
+[textures]
+This value represents the texture sources that are used by a scene.
+This is the max value from the most 'complex' primitive that will be referenced by a primitive in the scene.
+The goal of this metric is to provide a worst case texture usage where texturecount and complexity is known.
+Ie it is known if a texture is BASECOLOR or if part of PBR such as METALICROUGHNESS

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -1,6 +1,6 @@
 
 --- Name -----------Property    ----- Description ----------------------------
-[verticecount]      Scene       Total number of vertices used by a model in a scene
+[vertexcount]       Scene       Total number of vertices used by a model in a scene
 [nodecount]         Scene       Max nodecount in scene (add upp all nodes in a scene)
 [primitivecount]    Scene       Total number of referenced primitives (per scene)
                                 This figure is the un-batched number of primitives, engines may optimize if primitives and meshes share textures.

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -40,8 +40,7 @@ Using these metrics an estimate of target memory can be calculated - however kee
 |[vertexCount]    | Integer     | Complexity  |Scene     |Total number of vertices used by the Nodes in a scene           |  
 |[nodeCount]      | Integer     | Complexity  |Scene     |Max nodecount in scene (add upp all nodes in a scene)           |  
 |[primitiveCount] | Integer     | Complexity  |Scene     |Total number of referenced primitives (per scene).  This figure is the un-batched number of primitives, engines may optimize if primitives and meshes share textures. |  
-|[textures]       | Integer     | Complexity  |Scene     |Flags specifying presence of materials texture usage, this is the aggregated most complex usage. BASECOLOR, METALLICROUGHNESS, NORMAL, OCCLUSION, EMISSIVE, SPECULARGLOSS, DIFFUSE, CLEARCOAT |  
-|[materials]      | Integer     | Complexity  |Scene     | Flags specifying presence of materials, this is the aggregated most complex usage.  |
+|[channels]       | Integer     | Complexity  |Scene     |Flags specifying presence of materials texture usage, this is the aggregated most complex usage. BASECOLOR, METALLICROUGHNESS, NORMAL, OCCLUSION, EMISSIVE, SPECULARGLOSS, DIFFUSE, CLEARCOAT |  
 |[bounds]         | Bounds      | Complexity  | Scene    | The static 3D bounds for each scene, can be used to estimate world space size of model. |
 |[maxNodeDepth]   | Integer     | Memory      | Scene    | The max node depth of the scene, ie the max number of parent/child relations. This number will represent the max stack depth needed when traversing the nodegraph |
 |[accessors]     | Accessor     | Memory      | Asset    | Total number and format of vertex accessors, this can be used to calculate vertex buffer memory requirements |  
@@ -88,16 +87,6 @@ just the shader texel lookup and processing needed to calculate a pixel on scree
 4 OCCLUSION  
 5 EMISSIVE  
 6 SPECULARGLOSS  
-
-[materials]  
-This value represents the materials used by a scene.  
-This is the max value from the most 'complex' primitive that will be referenced by a Node in the scene.  
-The goal of this metric is to provide a worst case computational cost for rendering a pixel.  
-  
-1 PBR
-2 SPECULARGLOSS (KHR_materials_pbrSpecularGlossiness)
-2 UNLIT (KHR_materials_unlit) 
-
 
 [bounds]  
 This value represents the static (non animated) bounding volume for the scene.  
@@ -154,7 +143,6 @@ This is how the output would be formatted using JSON
             "nodeCount" : 20,
             "primitiveCount" : 50,
             "channels" : ["BASECOLOR", "METALLICROUGHNESS"],
-            "materials" : ["PBR", "SPECULARGLOSS"],
             "bounds" : "min": [
                 -0.9999999403953552,
                 -1.0,

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -13,8 +13,10 @@ These metrics do not provide a mapping to target device performance, this mappin
 
 ### Screen space coverage
 
-The metrics do not include screen space coverage, it is advised that clients shall know how large the render area will be before requesting a model (from the backend)  
-It is up to the backend to take screen coverage into account when providing a suitable model to the client, for instance by taking width + height as parameters.  
+The metrics do not include screen space coverage.  
+However, implementations should generally consider the size of the render area in addition to performance metrics of the model.  
+A higher performance budget may be acceptable when screen space coverage is higher.
+
 
 ### Memory  
 

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -1,6 +1,6 @@
 # Runtime Performance Metrics 
 
-The goal of these metrics is to asses the runtime performance needs of glTF assets.  
+The goal of these metrics is to assess the runtime performance needs of glTF assets.  
 By runtime we mean the cpu/gpu, bandwidth and memory resources needed to render the model in realtime.  
 These performance metrics are divided in two major categories - `complexity` and `memory`
 
@@ -18,15 +18,17 @@ Using these metrics an estimate of target memory can be calculated - however kee
 
 
 
-|                 |             |          |                                                                | 
-|-----------------|-------------|----------|----------------------------------------------------------------|
-| Name            | Category    | Property |Description                                                     |
-|[vertexcount]    | Complexity  |Scene     |Total number of vertices used by a model in a scene             |  
-|[nodecount]      | Complexity  |Scene     |Max nodecount in scene (add upp all nodes in a scene)           |  
-|[primitivecount] | Complexity  |Scene     |Total number of referenced primitives (per scene).  This figure is the un-batched number of primitives, engines may optimize if primitives and meshes share textures. |  
-|[textures]       | Complexity  |Scene     |Flags specifying presence of materials and it's texture usage, this is the aggregated max usage. BASECOLOR, METALLICROUGHNESS, NORMAL, OCCLUSION, EMISSIVE, (SPECULARGLOSS) |  
-|[attributes]     | Memory      | Asset    | The total memory footprint, in bytes, for the models attribute buffer storage |  
-|[texturesizes]  | Memory      | Asset    | The sizes of defined textures in the Asset. |  
+|                 |             |          |                                                                |             |
+|-----------------|-------------|-------------|----------|----------------------------------------------------------------|
+| Name            | Type        | Category    | Property |Description                                                     |
+|[vertexCount]    | Integer     | Complexity  |Scene     |Total number of vertices used by the Nodes in a scene           |  
+|[nodeCount]      | Integer     | Complexity  |Scene     |Max nodecount in scene (add upp all nodes in a scene)           |  
+|[primitiveCount] | Integer     | Complexity  |Scene     |Total number of referenced primitives (per scene).  This figure is the un-batched number of primitives, engines may optimize if primitives and meshes share textures. |  
+|[textures]       | Integer     | Complexity  |Scene     |Flags specifying presence of materials and it's texture usage, this is the aggregated max usage. BASECOLOR, METALLICROUGHNESS, NORMAL, OCCLUSION, EMISSIVE, (SPECULARGLOSS) |  
+|[attributes]     | Integer     | Memory      | Asset    | The total memory footprint, in bytes, for the models attribute buffer storage |  
+|[textureSizes]  |Dimension    | Memory      | Asset    | The width and height of defined textures in the Asset. |  
+
+Dimension is an Integer[2] containing width and height  
 
 
 # Scene #  
@@ -37,16 +39,16 @@ To accomodate this the following metrics are calculated on a per-scene basis.
 It is possible to reference different meshes (nodes) using different scenes, this makes it possible to have the same texture assets but reference different primitives that use alternative materials (textures).  
 Ie one model could have 3 different scenes, where the same accessors (position, uv) are used but different primitives that reference materials with varying number of texture channels.  
 
-[nodecount]  
+[nodeCount]  
 This represent the number of traversed nodes in a scene.  
 This is calculated by traversing nodes in each scene (depth or breadth first does not matter) - for each node increase the nodecount.  
 
-[verticecount]  
+[vertexCount]  
 This represents the number of drawn vertices for each scene in the model.  
 This is calculated by traversing the nodes in each scene.  
 For each mesh use the POSITION attribute in each primitive, get the Accessor and add up the count field.  
 
-[primitivecount]  
+[primitiveCount]  
 This represents the number of primitives for each scene  
 Each primitive references a material with 0 or more texture sources, has attributes and accessors.  
 
@@ -61,7 +63,7 @@ Ie it is known if a texture is BASECOLOR or if part of PBR such as METALICROUGHN
 This value represent the total attribute buffer usage of the model. This value is calculated by adding up the size, in bytes, of all buffer objects in the Asset.  
 This may give an indication of the runtime memory footprint of the buffers needed for the model.  
 
-[texturesizes]
+[textureSizes]
 The total size of textures, without mipmaps, that are defined in the Asset.  
 This is calculated by iterating the texture array and adding up the size of indexed images.  
 The max texture size can be determined from these values.  
@@ -70,8 +72,8 @@ Some target devices may have a smaller (4096 * 4096) max texture size in which c
 # JSON #  
 This is how the output would be formatted using JSON  
 
-"scene" : [ { "verticecount" : 4300, "nodecount" : 20, "primitivecount" : 50 ,
+`"scene" : [ { "verticeCount" : 4300, "nodecount" : 20, "primitiveCount" : 50 ,
               "textures" : ["BASECOLOR", "METALLICROUGHNESS"]} ],  
-"asset" : { "attributes" : 345234 }, { "texturesizes" : ["2048 * 2048", "512 * 512", "128 * 100"] }  
+"asset" : { "attributes" : 345234 }, { "textureSizes" : [{ "dimension" : [2048,2048]}, { "dimension" : [512,512]}, { "dimension" : [256,200]}] } ` 
 
 

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -72,21 +72,22 @@ For each mesh use the POSITION attribute in each primitive, get the Accessor and
 This represents the number of primitives for each scene  
 Each primitive references a material with 0 or more texture sources, has attributes and accessors.  
 
-[textures]  
-This value represents the texture sources that are used by a scene.  
+[channels]  
+This value represents the texture source channels that are used by a scene.  
 This is the max value from the most 'complex' primitive that will be referenced by a Node in the scene.  
-The goal of this metric is to provide a worst case texture usage cost for rendering a pixel.  
+The goal of this metric is to provide a worst case texture usage and processing cost for rendering a pixel.  
 
-`textures`  
+**Note**  
+This value can not be used to know if texture channels are tightly packed according to uniform Sampler usage,  
+just the shader texel lookup and processing needed to calculate a pixel on screen.   
+
+`channels`  
 1 BASECOLOR
 2 METALLICROUGHNESS  
 3 NORMAL  
 4 OCCLUSION  
 5 EMISSIVE  
 6 SPECULARGLOSS  
-7 DIFFUSE  
-8 CLEARCOAT  
-
 
 [materials]  
 This value represents the materials used by a scene.  
@@ -152,7 +153,7 @@ This is how the output would be formatted using JSON
             "vertexCount" : 4300,
             "nodeCount" : 20,
             "primitiveCount" : 50,
-            "textures" : ["BASECOLOR", "METALLICROUGHNESS"],
+            "channels" : ["BASECOLOR", "METALLICROUGHNESS"],
             "materials" : ["PBR", "SPECULARGLOSS"],
             "bounds" : "min": [
                 -0.9999999403953552,

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -44,6 +44,7 @@ Using these metrics an estimate of target memory can be calculated - however kee
 |[bounds]         | Bounds      | Complexity  | Scene    | The static 3D bounds for each scene, can be used to estimate world space size of model. |
 |[maxNodeDepth]   | Integer     | Memory      | Scene    | The max node depth of the scene, ie the max number of parent/child relations. This number will represent the max stack depth needed when traversing the nodegraph |
 |[accessors]     | Accessor     | Memory      | Asset    | Total number and format of vertex accessors, this can be used to calculate vertex buffer memory requirements |  
+|[buffers  ]     | Buffer       | Memory      | Asset    | Size and number of buffers in the Asset, memory needed to load model. For a .glb this will include textures |  
 |[textureSize]  |Integer    | Memory      | Asset    | The size and format of textures |  
 
 Dimension is an Integer[2] containing width and height  
@@ -123,6 +124,13 @@ Number of components, ie 4 VEC3 FLOATs will require 4 * 3 * 4 bytes of memory (o
 "MAT3"  
 "MAT4"  
 
+[buffers]  
+This represents the .glb buffer or the .bin buffers referenced by a .gltf file.  
+To load a model, at least this much memory is required.  
+For a .gltf the textures are usually supplied separately.  
+
+`sizeInBytes`
+Size in bytes of the buffer.
 
 [textureSize]  
 The size and format of textures, without mipmaps, that are defined in the Asset.  

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -37,7 +37,7 @@ Using these metrics an estimate of target memory can be calculated - however kee
 |                 |             |          |                                                                |             |
 |-----------------|-------------|-------------|----------|----------------------------------------------------------------|
 | Name            | Type        | Category    | Property |Description                                                     |
-|[vertexCount]    | Integer     | Complexity  |Scene     |Total number of vertices used by the Nodes in a scene           |  
+|[drawCount]      | Integer     | Complexity  |Scene     |Total number of vertices drawn in a scene                       |  
 |[nodeCount]      | Integer     | Complexity  |Scene     |Max nodecount in scene (add upp all nodes in a scene)           |  
 |[primitiveCount] | Integer     | Complexity  |Scene     |Total number of referenced primitives (per scene).  This figure is the un-batched number of primitives, engines may optimize if primitives and meshes share textures. |  
 |[channels]       | Integer     | Complexity  |Scene     |Flags specifying presence of materials texture usage, this is the aggregated most complex usage. BASECOLOR, METALLICROUGHNESS, NORMAL, OCCLUSION, EMISSIVE, SPECULARGLOSS, DIFFUSE, CLEARCOAT |  
@@ -62,7 +62,7 @@ Ie one model could have 3 different scenes, where the same accessors (position, 
 This represent the number of traversed nodes in a scene.  
 This is calculated by traversing nodes in each scene (depth or breadth first does not matter) - for each node increase the nodecount.  
 
-[vertexCount]  
+[drawCount]  
 This represents the number of drawn vertices for each scene in the model.  
 This is calculated by traversing the nodes in each scene.  
 For each mesh use the POSITION attribute in each primitive, get the Accessor and add up the count field.  

--- a/specification/2.0/appendix/performance-metrics/README.md
+++ b/specification/2.0/appendix/performance-metrics/README.md
@@ -96,10 +96,14 @@ This will include translation, meaning that the bounds will not be centered.
 
 
 [accessors]  
-This value represent the total vertex accessor usage of the model.  
+This value represents the total vertex accessor usage of the asset, it is an indication of the memory requirements for the asset.  
+Note that this value will not take into account if normal/tangent/bitangent values are defined or shall be runtime computed.  
 It is calculated by adding upp the accessors in the model, storing count, componentType and type.  
 This may give an indication of the runtime memory footprint of the buffers needed for the model.  
 componentType and type are taken from glTF specification for Accessor object.  
+`count`
+Number of components, ie 4 VEC3 FLOATs will require 4 * 3 * 4 bytes of memory (on most devices)
+
 `componentType`  
 5120 BYTE  
 5121 UNSIGNED_BYTE  


### PR DESCRIPTION
This is the inital commit to get discussion started.
The goal of this PR is to provide:
* Standalone performance metrics - not part of glTF spec
* Command line tool to produce performance metrics

Performance metrics can be used for instance by backend to choose the most suitable model to deliver to a client based on usecase and target capabilitites. 
Backends should have access to the necessary data so that a selection from different LoD's is possible.

The goal is not to provide one number for the complexity but rather to break down usage in terms of data, then provide this data without glTF dependencies.
It is up to the consumer to decide what the metrics mean.

This is non-normative and should not be part of glTF spec.
