### PR TITLE
KHR_materials_clearcoat - Mark BRDF implementation section as non-normative

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md
@@ -62,6 +62,10 @@ All implementations should use the same calculations for the BRDF inputs. Implem
 |**clearcoatRoughnessTexture**     | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo)             | The clearcoat layer roughness texture. | No                   |
 |**clearcoatNormalTexture**        | [`normalTextureInfo`](/specification/2.0/README.md#reference-normaltextureinfo) | The clearcoat normal map texture.      | No                   |
   
+### BRDF implementation  
+
+*This section is non-normative.*  
+
 The clearcoat formula `f_clearcoat` is computed using the specular term from the glTF 2.0 Metallic-Roughness material, defined in [Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation).  Use specular F0 equal `0.04`, base color black `0.0, 0.0, 0.0`, metallic value `0.0`, and the clearcoat roughness value defined in this extension as follows:
 
 ```


### PR DESCRIPTION
In order to be consistent with the current non normative BRDF implementation ([Appendix B in glTF spec](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#appendix-b-brdf-implementation))  
The BRDF implementation of clearcoat should be marked as non-normative.

This is also an important distinction between 3D Formats and 3D Commerce-Certification, we provide the data parameters needed to visualize PBR models, not normative BRDF implementation.  
The Certification group will standardise and specify how to become a certified viewer.

From a glTF perspective it is fine for implementers to use glTF as needed and any way they see fit- we do suggest how to implement and provide an opensource sample implementation.
