### PR TITLE
Added note about IOR and roughness for transmission

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_transmission/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_transmission/README.md
@@ -148,6 +148,8 @@ We will now add an additional term for the transmitted light:
 
 where *T* is the transmission percentage defined by this extension's `transmission` and `transmissionTexture` properties and *D<sub>T</sub>* is the distribution function for the transmitted light. The distribution function is the same Trowbridge-Reitz model used by specular reflection except sampled along the view vector rather than the reflection. *G<sub>T</sub>* is the geometric occlusion function for transmission. The *baseColor* factor causes the transmitted light to be tinted by the surface.
 
+Note that unless otherwise specified by another extension, this transmissive surface is really two surfaces back-to-back, representing a thin material. As such there is no average refraction, but in the presence of roughness there is refraction at the microfacet level. This is because the distribution function is appled to both the front and back surface microfacets and they are uncorrelated to each other. These microfacet pairs form tiny prisms that cause the roughness map to blur the transmitted light, and as such this effect will be modulated by the material's index of refraction (IOR). Recall that the default IOR from the base spec is 1.5.
+
 Light that penetrates a surface and is transmitted will not be diffusely reflected so we also need to modify the diffuse calculation to account for this.
 *f*<sub>*diffuse*</sub> = (1 - *F*) * (1 - *T*) * *diffuse*
 


### PR DESCRIPTION
I don't consider this a spec change so much as increased clarity, as this is a natural conclusion to draw from the physics. However, calling it out is important as it might not be obvious that IOR would affect the amount of roughness blur. 

I purposefully put "unless otherwise specified by another extension" because this will be handled differently when using the volume extension since at that point the transmission surface becomes single-sided (entering the volume).