### PR TITLE
Align KHR_materials_variants schemas with the core spec

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_variants/schema/glTF.KHR_materials_variants.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_variants/schema/glTF.KHR_materials_variants.schema.json
@@ -9,6 +9,7 @@
             "type": "array",
             "items": {
                 "type": "object",
+                "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
                 "description": "An object defining a valid material variant",
                 "gltf_detailedDescription": "An object defining a valid material variant",
                 "properties": {
@@ -19,11 +20,15 @@
                     },
                     "extras": {
                         "type": "object"
-                    }
+                    },
+                    "extensions": { }
                 },
                 "required": [ "name" ]
-            }
-        }
+            },
+            "minItems": 1
+        },
+        "extensions": { },
+        "extras": { }
     },
     "required": [ "variants" ]
 }

--- a/extensions/2.0/Khronos/KHR_materials_variants/schema/mesh.primitive.KHR_materials_variants.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_variants/schema/mesh.primitive.KHR_materials_variants.schema.json
@@ -10,6 +10,7 @@
             "gltf_detailedDescription": "An array of object values that associate an indexed material to a set of variants.",
             "items": {
                 "type": "object",
+                "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
                 "properties": {
                     "variants": {
                         "uniqueItems": true,
@@ -37,8 +38,11 @@
                     "extensions": { }
                 },
                 "required": [ "variants", "material" ]
-            }
-        }
+            },
+            "minItems": 1
+        },
+        "extensions": { },
+        "extras": { }
     },
     "required": [ "mappings" ]
 }


### PR DESCRIPTION
This is a technical update to align `KHR_materials_variants` schemas with the core glTF design principles.

- All objects should inherit from `glTFProperty`.
  - `extras` and `extensions` need to be mentioned explicitly.
- Elements of a top-level array inherit from `glTFChildOfRootProperty`.
- Empty arrays are not allowed.


/cc @jercytryn @sleroux
