### PR TITLE
Tighten the rules around bufferView.byteStride

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -469,7 +469,7 @@ The following example defines two buffer views: the first is an ELEMENT_ARRAY_BU
 }
 ```
 
-When a buffer view is used for vertex attribute data, it may have a `byteStride` property. This property defines the stride in bytes between each vertex.
+When a buffer view is used for vertex attribute data, it may have a `byteStride` property. This property defines the stride in bytes between each vertex. Buffer views with other types of data should not define `byteStride`.
 
 Buffers and buffer views do not contain type information. They simply define the raw data for retrieval from the file. Objects within the glTF file (meshes, skins, animations) access buffers or buffer views via *accessors*.
 
@@ -649,7 +649,7 @@ When neither `sparse` nor `bufferView` is defined, `min` and `max` properties co
 
 The offset of an `accessor` into a `bufferView` (i.e., `accessor.byteOffset`) and the offset of an `accessor` into a `buffer` (i.e., `accessor.byteOffset + bufferView.byteOffset`) must be a multiple of the size of the accessor's component type.
 
-When `byteStride` of referenced `bufferView` is not defined, it means that accessor elements are tightly packed, i.e., effective stride equals the size of the element. When `byteStride` is defined, it must be a multiple of the size of the accessor's component type. `byteStride` must be defined, when two or more accessors use the same `bufferView`.
+When `byteStride` of referenced `bufferView` is not defined, it means that accessor elements are tightly packed, i.e., effective stride equals the size of the element. When `byteStride` is defined, it must be a multiple of the size of the accessor's component type. `byteStride` must be defined, when two or more vertex data accessors use the same `bufferView`.
 
 Each `accessor` must fit its `bufferView`, i.e., `accessor.byteOffset + STRIDE * (accessor.count - 1) + SIZE_OF_ELEMENT` must be less than or equal to `bufferView.length`.
 
@@ -2125,7 +2125,7 @@ The length of the bufferView in bytes.
 
 #### bufferView.byteStride
 
-The stride, in bytes, between vertex attributes.  When this is not defined, data is tightly packed. When two or more accessors use the same bufferView, this field must be defined.
+The stride, in bytes, between vertex attributes.  When this is not defined, data is tightly packed. When two or more vertex data accessors use the same bufferView, this field must be defined.
 
 * **Type**: `integer`
 * **Required**: No

--- a/specification/2.0/schema/bufferView.schema.json
+++ b/specification/2.0/schema/bufferView.schema.json
@@ -26,7 +26,7 @@
             "minimum": 4,
             "maximum": 252,
             "multipleOf": 4,
-            "gltf_detailedDescription": "The stride, in bytes, between vertex attributes.  When this is not defined, data is tightly packed. When two or more accessors use the same bufferView, this field must be defined.",
+            "gltf_detailedDescription": "The stride, in bytes, between vertex attributes.  When this is not defined, data is tightly packed. When two or more vertex data accessors use the same bufferView, this field must be defined.",
             "gltf_webgl": "`vertexAttribPointer()` stride parameter"
         },
         "target": {


### PR DESCRIPTION
The intention of the spec has always been to only use byteStride for
buffer views with vertex data. However, the current language was lax in
a few places, which led to logical contradictions:

- When two accessors with non-vertex data used the same bufferView, it
could be interpreted as requiring byteStride on that view
- However, byteStride was only explicitly allowed for vertex attribute
data, making it seem as if it's not valid on non-vertex views.

glTF-Validator flags bufferViews that have a byteStride but store
non-vertex data as erroneous. Based on this and the above, this change
tightens the language to explicitly only allow byteStride on vertex data
views, and changes all references to it to say the same.

This would close #1864 by explicitly outlawing interleaved data that's
not vertex data, and also relates to #1537 (that is already closed, but this
change would provide an actual resolution there).