### PR TITLE
Testing wetzel automated reference output.  DO NOT MERGE

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -1657,21 +1657,18 @@ This chunk must be padded with trailing zeros (`0x00`) to satisfy alignment requ
       * [`indices`](#reference-accessor-sparse-indices)
       * [`values`](#reference-accessor-sparse-values)
 * [`animation`](#reference-animation)
+   * [`animation_sampler`](#reference-animation-sampler)
    * [`channel`](#reference-animation-channel)
       * [`target`](#reference-animation-channel-target)
-   * [`sampler`](#reference-animation-sampler)
 * [`asset`](#reference-asset)
 * [`buffer`](#reference-buffer)
 * [`bufferView`](#reference-bufferview)
 * [`camera`](#reference-camera)
    * [`orthographic`](#reference-camera-orthographic)
    * [`perspective`](#reference-camera-perspective)
-* [`Child of a glTF root property`](#reference-gltfchildofrootproperty)
 * [`extension`](#reference-extension)
 * [`extras`](#reference-extras)
-* [`glTF`](#reference-gltfproperty) (root object)
-* [`glTF element index`](#reference-gltfid)
-* [`glTF property`](#reference-gltfproperty)
+* [`glTF`](#reference-gltf) (root object)
 * [`image`](#reference-image)
 * [`material`](#reference-material)
    * [`normalTextureInfo`](#reference-material-normaltextureinfo)
@@ -1697,7 +1694,7 @@ A typed view into a bufferView.  A bufferView contains raw binary data.  An acce
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView.|No|
+|**bufferView**|`integer`|The index of the bufferView.|No|
 |**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes.|No, default: `0`|
 |**componentType**|`integer`|The datatype of components in the attribute.| :white_check_mark: Yes|
 |**normalized**|`boolean`|Specifies whether integer data values should be normalized.|No, default: `false`|
@@ -1718,7 +1715,7 @@ Additional properties are allowed.
 
 The index of the bufferView. When not defined, accessor must be initialized with zeros; [`sparse`](#reference-sparse) property or extensions could override zeros with actual values.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -1887,6 +1884,71 @@ Application-specific data.
 
 
 ---------------------------------------
+<a name="reference-animation-sampler"></a>
+### animation_sampler
+
+Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**input**|`integer`|The index of an accessor containing keyframe input values, e.g., time.| :white_check_mark: Yes|
+|**interpolation**|`string`|Interpolation algorithm.|No, default: `"LINEAR"`|
+|**output**|`integer`|The index of an accessor, containing keyframe output values.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
+
+#### animation.sampler.input :white_check_mark: 
+
+The index of an accessor containing keyframe input values, e.g., time. That accessor must have componentType `FLOAT`. The values represent time in seconds with `time[0] >= 0.0`, and strictly increasing values, i.e., `time[n + 1] > time[n]`.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### animation.sampler.interpolation
+
+Interpolation algorithm.
+
+* **Type**: `string`
+* **Required**: No, default: `"LINEAR"`
+* **Allowed values**:
+   * `"LINEAR"` The animated values are linearly interpolated between keyframes. When targeting a rotation, spherical linear interpolation (slerp) should be used to interpolate quaternions. The number output of elements must equal the number of input elements.
+   * `"STEP"` The animated values remain constant to the output of the first keyframe, until the next keyframe. The number of output elements must equal the number of input elements.
+   * `"CUBICSPLINE"` The animation's interpolation is computed using a cubic spline with specified tangents. The number of output elements must equal three times the number of input elements. For each input element, the output stores three elements, an in-tangent, a spline vertex, and an out-tangent. There must be at least two keyframes when using this interpolation.
+
+#### animation.sampler.output :white_check_mark: 
+
+The index of an accessor containing keyframe output values. When targeting translation or scale paths, the `accessor.componentType` of the output values must be `FLOAT`. When targeting rotation or morph weights, the `accessor.componentType` of the output values must be `FLOAT` or normalized integer. For weights, each output element stores `SCALAR` values with a count equal to the number of morph targets.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### animation.sampler.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### animation.sampler.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
 <a name="reference-asset"></a>
 ### asset
 
@@ -2024,7 +2086,7 @@ A view into a buffer generally representing a subset of the buffer.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**buffer**|[`glTFid`](#reference-gltfid)|The index of the buffer.| :white_check_mark: Yes|
+|**buffer**|`integer`|The index of the buffer.| :white_check_mark: Yes|
 |**byteOffset**|`integer`|The offset into the buffer in bytes.|No, default: `0`|
 |**byteLength**|`integer`|The total byte length of the buffer view.| :white_check_mark: Yes|
 |**byteStride**|`integer`|The stride, in bytes.|No|
@@ -2041,7 +2103,7 @@ Additional properties are allowed.
 
 The index of the buffer.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
@@ -2187,7 +2249,7 @@ Targets an animation's sampler at a node's property.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**sampler**|[`glTFid`](#reference-gltfid)|The index of a sampler in this animation used to compute the value for the target.| :white_check_mark: Yes|
+|**sampler**|`integer`|The index of a sampler in this animation used to compute the value for the target.| :white_check_mark: Yes|
 |**target**|[`animation.channel.target`](#reference-animation-channel-target)|The index of the node and TRS property to target.| :white_check_mark: Yes|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
@@ -2200,7 +2262,7 @@ Additional properties are allowed.
 
 The index of a sampler in this animation used to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS).
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
@@ -2220,47 +2282,6 @@ Dictionary object with extension-specific objects.
 * **Type of each property**: extension
 
 #### animation.channel.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-gltfchildofrootproperty"></a>
-### Child of a glTF root property
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [glTFChildOfRootProperty.schema.json](schema/glTFChildOfRootProperty.schema.json)
-
-#### glTFChildOfRootProperty.name
-
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
-
-* **Type**: `string`
-* **Required**: No
-
-#### glTFChildOfRootProperty.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: extension
-
-#### glTFChildOfRootProperty.extras
 
 Application-specific data.
 
@@ -2292,7 +2313,7 @@ Application-specific data.
 
 
 ---------------------------------------
-<a name="reference-gltfproperty"></a>
+<a name="reference-gltf"></a>
 ### glTF
 
 The root object for a glTF asset.
@@ -2314,7 +2335,7 @@ The root object for a glTF asset.
 |**meshes**|[`mesh`](#reference-mesh) `[1-*]`|An array of meshes.|No|
 |**nodes**|[`node`](#reference-node) `[1-*]`|An array of nodes.|No|
 |**samplers**|[`sampler`](#reference-sampler) `[1-*]`|An array of samplers.|No|
-|**scene**|[`glTFid`](#reference-gltfid)|The index of the default scene.|No|
+|**scene**|`integer`|The index of the default scene.|No|
 |**scenes**|[`scene`](#reference-scene) `[1-*]`|An array of scenes.|No|
 |**skins**|[`skin`](#reference-skin) `[1-*]`|An array of skins.|No|
 |**textures**|[`texture`](#reference-texture) `[1-*]`|An array of textures.|No|
@@ -2325,7 +2346,7 @@ Additional properties are allowed.
 
 * **JSON schema**: [glTF.schema.json](schema/glTF.schema.json)
 
-#### glTFProperty.extensionsUsed
+#### gltf.extensionsUsed
 
 Names of glTF extensions used somewhere in this asset.
 
@@ -2333,7 +2354,7 @@ Names of glTF extensions used somewhere in this asset.
    * Each element in the array must be unique.
 * **Required**: No
 
-#### glTFProperty.extensionsRequired
+#### gltf.extensionsRequired
 
 Names of glTF extensions required to properly load this asset.
 
@@ -2341,113 +2362,113 @@ Names of glTF extensions required to properly load this asset.
    * Each element in the array must be unique.
 * **Required**: No
 
-#### glTFProperty.accessors
+#### gltf.accessors
 
 An array of accessors.  An accessor is a typed view into a bufferView.
 
 * **Type**: [`accessor`](#reference-accessor) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.animations
+#### gltf.animations
 
 An array of keyframe animations.
 
 * **Type**: [`animation`](#reference-animation) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.asset
+#### gltf.asset
 
 Metadata about the glTF asset.
 
 * **Type**: [`asset`](#reference-asset)
 * **Required**: No
 
-#### glTFProperty.buffers
+#### gltf.buffers
 
 An array of buffers.  A buffer points to binary geometry, animation, or skins.
 
 * **Type**: [`buffer`](#reference-buffer) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.bufferViews
+#### gltf.bufferViews
 
 An array of bufferViews.  A bufferView is a view into a buffer generally representing a subset of the buffer.
 
 * **Type**: [`bufferView`](#reference-bufferview) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.cameras
+#### gltf.cameras
 
 An array of cameras.  A camera defines a projection matrix.
 
 * **Type**: [`camera`](#reference-camera) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.images
+#### gltf.images
 
 An array of images.  An image defines data used to create a texture.
 
 * **Type**: [`image`](#reference-image) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.materials
+#### gltf.materials
 
 An array of materials.  A material defines the appearance of a primitive.
 
 * **Type**: [`material`](#reference-material) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.meshes
+#### gltf.meshes
 
 An array of meshes.  A mesh is a set of primitives to be rendered.
 
 * **Type**: [`mesh`](#reference-mesh) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.nodes
+#### gltf.nodes
 
 An array of nodes.
 
 * **Type**: [`node`](#reference-node) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.samplers
+#### gltf.samplers
 
 An array of samplers.  A sampler contains properties for texture filtering and wrapping modes.
 
 * **Type**: [`sampler`](#reference-sampler) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.scene
+#### gltf.scene
 
 The index of the default scene.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
-#### glTFProperty.scenes
+#### gltf.scenes
 
 An array of scenes.
 
 * **Type**: [`scene`](#reference-scene) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.skins
+#### gltf.skins
 
 An array of skins.  A skin is defined by joints and matrices.
 
 * **Type**: [`skin`](#reference-skin) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.textures
+#### gltf.textures
 
 An array of textures.
 
 * **Type**: [`texture`](#reference-texture) `[1-*]`
 * **Required**: No
 
-#### glTFProperty.extensions
+#### gltf.extensions
 
 Dictionary object with extension-specific objects.
 
@@ -2455,7 +2476,7 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: extension
 
-#### glTFProperty.extras
+#### gltf.extras
 
 Application-specific data.
 
@@ -2463,43 +2484,6 @@ Application-specific data.
 * **Required**: No
 
 
-
-
----------------------------------------
-<a name="reference-gltfid"></a>
-### glTF element index
-
-
-
----------------------------------------
-<a name="reference-gltfproperty"></a>
-### glTF property
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [glTFProperty.schema.json](schema/glTFProperty.schema.json)
-
-#### glTFProperty.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: extension
-
-#### glTFProperty.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
 
 
 
@@ -2516,7 +2500,7 @@ Image data used to create a texture. Image can be referenced by URI or [`bufferV
 |---|----|-----------|--------|
 |**uri**|`string`|The uri of the image.|No|
 |**mimeType**|`string`|The image's MIME type. Required if [`bufferView`](#reference-bufferview) is defined.|No|
-|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
+|**bufferView**|`integer`|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
@@ -2547,7 +2531,7 @@ The image's MIME type. Required if [`bufferView`](#reference-bufferview) is defi
 
 The index of the bufferView that contains the image. Use this instead of the image's uri property.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -2586,7 +2570,7 @@ Indices of those attributes that deviate from their initialization value.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
+|**bufferView**|`integer`|The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
 |**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
 |**componentType**|`integer`|The indices data type.| :white_check_mark: Yes|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
@@ -2600,7 +2584,7 @@ Additional properties are allowed.
 
 The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
@@ -2823,11 +2807,11 @@ A node in the node hierarchy.  When the node contains [`skin`](#reference-skin),
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**camera**|[`glTFid`](#reference-gltfid)|The index of the camera referenced by this node.|No|
+|**camera**|`integer`|The index of the camera referenced by this node.|No|
 |**children**|`integer` `[1-*]`|The indices of this node's children.|No|
-|**skin**|[`glTFid`](#reference-gltfid)|The index of the skin referenced by this node.|No|
+|**skin**|`integer`|The index of the skin referenced by this node.|No|
 |**matrix**|`number` `[16]`|A floating-point 4x4 transformation matrix stored in column-major order.|No, default: `[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]`|
-|**mesh**|[`glTFid`](#reference-gltfid)|The index of the mesh in this node.|No|
+|**mesh**|`integer`|The index of the mesh in this node.|No|
 |**rotation**|`number` `[4]`|The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.|No, default: `[0,0,0,1]`|
 |**scale**|`number` `[3]`|The node's non-uniform scale, given as the scaling factors along the x, y, and z axes.|No, default: `[1,1,1]`|
 |**translation**|`number` `[3]`|The node's translation along the x, y, and z axes.|No, default: `[0,0,0]`|
@@ -2844,7 +2828,7 @@ Additional properties are allowed.
 
 The index of the camera referenced by this node.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -2861,7 +2845,7 @@ The indices of this node's children.
 
 The index of the skin referenced by this node. When a skin is referenced by a node within a scene, all joints used by the skin must belong to the same scene.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -2877,7 +2861,7 @@ A floating-point 4x4 transformation matrix stored in column-major order.
 
 The index of the mesh in this node.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -2945,7 +2929,7 @@ Reference to a texture.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**index**|[`glTFid`](#reference-gltfid)|The index of the texture.| :white_check_mark: Yes|
+|**index**|`integer`|The index of the texture.| :white_check_mark: Yes|
 |**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
 |**scale**|`number`|The scalar multiplier applied to each normal vector of the normal texture.|No, default: `1`|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
@@ -2959,7 +2943,7 @@ Additional properties are allowed.
 
 The index of the texture.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
@@ -3006,7 +2990,7 @@ Reference to a texture.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**index**|[`glTFid`](#reference-gltfid)|The index of the texture.| :white_check_mark: Yes|
+|**index**|`integer`|The index of the texture.| :white_check_mark: Yes|
 |**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
 |**strength**|`number`|A scalar multiplier controlling the amount of occlusion applied.|No, default: `1`|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
@@ -3020,7 +3004,7 @@ Additional properties are allowed.
 
 The index of the texture.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
@@ -3292,8 +3276,8 @@ Geometry to be rendered with the given material.
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**attributes**|`object`|A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.| :white_check_mark: Yes|
-|**indices**|[`glTFid`](#reference-gltfid)|The index of the accessor that contains the indices.|No|
-|**material**|[`glTFid`](#reference-gltfid)|The index of the material to apply to this primitive when rendering.|No|
+|**indices**|`integer`|The index of the accessor that contains the indices.|No|
+|**material**|`integer`|The index of the material to apply to this primitive when rendering.|No|
 |**mode**|`integer`|The type of primitives to render.|No, default: `4`|
 |**targets**|`object` `[1-*]`|An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
@@ -3309,13 +3293,13 @@ A dictionary object, where each key corresponds to mesh attribute semantic and e
 
 * **Type**: `object`
 * **Required**: Yes
-* **Type of each property**: `glTFid`
+* **Type of each property**: `integer`
 
 #### mesh.primitive.indices
 
 The index of the accessor that contains mesh indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.  When defined, the accessor must contain indices: the [`bufferView`](#reference-bufferview) referenced by the accessor should have a [`target`](#reference-target) equal to 34963 (ELEMENT_ARRAY_BUFFER); `componentType` must be 5121 (UNSIGNED_BYTE), 5123 (UNSIGNED_SHORT) or 5125 (UNSIGNED_INT), the latter may require enabling additional hardware support; `type` must be `"SCALAR"`. For triangle primitives, the front face has a counter-clockwise (CCW) winding order. Values of the index accessor must not include the maximum value for the given component type, which triggers primitive restart in several graphics APIs and would require client implementations to rebuild the index buffer. Primitive restart values are disallowed and all index values must refer to actual vertices. As a result, the index accessor's values must not exceed the following maxima: BYTE `< 255`, UNSIGNED_SHORT `< 65535`, UNSIGNED_INT `< 4294967295`.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -3323,7 +3307,7 @@ The index of the accessor that contains mesh indices.  When this is not defined,
 
 The index of the material to apply to this primitive when rendering.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -3358,71 +3342,6 @@ Dictionary object with extension-specific objects.
 * **Type of each property**: extension
 
 #### mesh.primitive.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-animation-sampler"></a>
-### sampler
-
-Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**input**|[`glTFid`](#reference-gltfid)|The index of an accessor containing keyframe input values, e.g., time.| :white_check_mark: Yes|
-|**interpolation**|`string`|Interpolation algorithm.|No, default: `"LINEAR"`|
-|**output**|[`glTFid`](#reference-gltfid)|The index of an accessor, containing keyframe output values.| :white_check_mark: Yes|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
-
-#### animation.sampler.input :white_check_mark: 
-
-The index of an accessor containing keyframe input values, e.g., time. That accessor must have componentType `FLOAT`. The values represent time in seconds with `time[0] >= 0.0`, and strictly increasing values, i.e., `time[n + 1] > time[n]`.
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### animation.sampler.interpolation
-
-Interpolation algorithm.
-
-* **Type**: `string`
-* **Required**: No, default: `"LINEAR"`
-* **Allowed values**:
-   * `"LINEAR"` The animated values are linearly interpolated between keyframes. When targeting a rotation, spherical linear interpolation (slerp) should be used to interpolate quaternions. The number output of elements must equal the number of input elements.
-   * `"STEP"` The animated values remain constant to the output of the first keyframe, until the next keyframe. The number of output elements must equal the number of input elements.
-   * `"CUBICSPLINE"` The animation's interpolation is computed using a cubic spline with specified tangents. The number of output elements must equal three times the number of input elements. For each input element, the output stores three elements, an in-tangent, a spline vertex, and an out-tangent. There must be at least two keyframes when using this interpolation.
-
-#### animation.sampler.output :white_check_mark: 
-
-The index of an accessor containing keyframe output values. When targeting translation or scale paths, the `accessor.componentType` of the output values must be `FLOAT`. When targeting rotation or morph weights, the `accessor.componentType` of the output values must be `FLOAT` or normalized integer. For weights, each output element stores `SCALAR` values with a count equal to the number of morph targets.
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### animation.sampler.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: extension
-
-#### animation.sampler.extras
 
 Application-specific data.
 
@@ -3594,8 +3513,8 @@ Joints and matrices defining a skin.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**inverseBindMatrices**|[`glTFid`](#reference-gltfid)|The index of the accessor containing the floating-point 4x4 inverse-bind matrices.  The default is that each matrix is a 4x4 identity matrix, which implies that inverse-bind matrices were pre-applied.|No|
-|**skeleton**|[`glTFid`](#reference-gltfid)|The index of the node used as a skeleton root.|No|
+|**inverseBindMatrices**|`integer`|The index of the accessor containing the floating-point 4x4 inverse-bind matrices.  The default is that each matrix is a 4x4 identity matrix, which implies that inverse-bind matrices were pre-applied.|No|
+|**skeleton**|`integer`|The index of the node used as a skeleton root.|No|
 |**joints**|`integer` `[1-*]`|Indices of skeleton nodes, used as joints in this skin.| :white_check_mark: Yes|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
@@ -3609,7 +3528,7 @@ Additional properties are allowed.
 
 The index of the accessor containing the floating-point 4x4 inverse-bind matrices.  The default is that each matrix is a 4x4 identity matrix, which implies that inverse-bind matrices were pre-applied.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -3617,7 +3536,7 @@ The index of the accessor containing the floating-point 4x4 inverse-bind matrice
 
 The index of the node used as a skeleton root. The node must be the closest common root of the joints hierarchy or a direct or indirect parent node of the closest common root.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -3725,7 +3644,7 @@ The index of the node and TRS property that an animation channel targets.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**node**|[`glTFid`](#reference-gltfid)|The index of the node to target.|No|
+|**node**|`integer`|The index of the node to target.|No|
 |**path**|`string`|The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.| :white_check_mark: Yes|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
@@ -3738,7 +3657,7 @@ Additional properties are allowed.
 
 The index of the node to target.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -3784,8 +3703,8 @@ A texture and its sampler.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**sampler**|[`glTFid`](#reference-gltfid)|The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.|No|
-|**source**|[`glTFid`](#reference-gltfid)|The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined.|No|
+|**sampler**|`integer`|The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.|No|
+|**source**|`integer`|The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined.|No|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
@@ -3798,7 +3717,7 @@ Additional properties are allowed.
 
 The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -3806,7 +3725,7 @@ The index of the sampler used by this texture. When undefined, a sampler with re
 
 The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -3845,7 +3764,7 @@ Reference to a texture.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**index**|[`glTFid`](#reference-gltfid)|The index of the texture.| :white_check_mark: Yes|
+|**index**|`integer`|The index of the texture.| :white_check_mark: Yes|
 |**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
@@ -3858,7 +3777,7 @@ Additional properties are allowed.
 
 The index of the texture.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
@@ -3898,7 +3817,7 @@ Array of size `accessor.sparse.count` times number of components storing the dis
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
+|**bufferView**|`integer`|The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
 |**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
@@ -3911,7 +3830,7 @@ Additional properties are allowed.
 
 The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
 
-* **Type**: [`glTFid`](#reference-gltfid)
+* **Type**: `integer`
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 

--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -1712,6 +1712,8 @@ A typed view into a bufferView.  A bufferView contains raw binary data.  An acce
 
 Additional properties are allowed.
 
+* **JSON schema**: [accessor.schema.json](schema/accessor.schema.json)
+
 #### accessor.bufferView
 
 The index of the bufferView. When not defined, accessor must be initialized with zeros; `sparse` property or extensions could override zeros with actual values.
@@ -1843,6 +1845,8 @@ Sparse storage of attributes that deviate from their initialization value.
 
 Additional properties are allowed.
 
+* **JSON schema**: [accessor.sparse.schema.json](schema/accessor.sparse.schema.json)
+
 #### accessor.sparse.count :white_check_mark: 
 
 The number of attributes encoded in this sparse accessor.
@@ -1900,6 +1904,8 @@ Indices of those attributes that deviate from their initialization value.
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [accessor.sparse.indices.schema.json](schema/accessor.sparse.indices.schema.json)
 
 #### accessor.sparse.indices.bufferView :white_check_mark: 
 
@@ -1963,6 +1969,8 @@ Array of size `accessor.sparse.count` times number of components storing the dis
 
 Additional properties are allowed.
 
+* **JSON schema**: [accessor.sparse.values.schema.json](schema/accessor.sparse.values.schema.json)
+
 #### accessor.sparse.values.bufferView :white_check_mark: 
 
 The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
@@ -2014,6 +2022,8 @@ A keyframe animation.
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [animation.schema.json](schema/animation.schema.json)
 
 #### animation.channels :white_check_mark: 
 
@@ -2071,6 +2081,8 @@ Targets an animation's sampler at a node's property.
 
 Additional properties are allowed.
 
+* **JSON schema**: [animation.channel.schema.json](schema/animation.channel.schema.json)
+
 #### animation.channel.sampler :white_check_mark: 
 
 The index of a sampler in this animation used to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS).
@@ -2120,6 +2132,8 @@ The index of the node and TRS property that an animation channel targets.
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [animation.channel.target.schema.json](schema/animation.channel.target.schema.json)
 
 #### animation.channel.target.node
 
@@ -2176,6 +2190,8 @@ Combines input and output accessors with an interpolation algorithm to define a 
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
 
 #### animation.sampler.input :white_check_mark: 
 
@@ -2241,6 +2257,8 @@ Metadata about the glTF asset.
 
 Additional properties are allowed.
 
+* **JSON schema**: [asset.schema.json](schema/asset.schema.json)
+
 #### asset.copyright
 
 A copyright message suitable for display to credit the content creator.
@@ -2305,6 +2323,8 @@ A buffer points to binary geometry, animation, or skins.
 
 Additional properties are allowed.
 
+* **JSON schema**: [buffer.schema.json](schema/buffer.schema.json)
+
 #### buffer.uri
 
 The uri of the buffer.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.
@@ -2366,6 +2386,8 @@ A view into a buffer generally representing a subset of the buffer.
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [bufferView.schema.json](schema/bufferView.schema.json)
 
 #### bufferView.buffer :white_check_mark: 
 
@@ -2456,6 +2478,8 @@ A camera's projection.  A node can reference a camera to apply a transform to pl
 
 Additional properties are allowed.
 
+* **JSON schema**: [camera.schema.json](schema/camera.schema.json)
+
 #### camera.orthographic
 
 An orthographic camera containing properties to create an orthographic projection matrix.
@@ -2524,6 +2548,8 @@ An orthographic camera containing properties to create an orthographic projectio
 
 Additional properties are allowed.
 
+* **JSON schema**: [camera.orthographic.schema.json](schema/camera.orthographic.schema.json)
+
 #### camera.orthographic.xmag :white_check_mark: 
 
 The floating-point horizontal magnification of the view. Must not be zero.
@@ -2591,6 +2617,8 @@ A perspective camera containing properties to create a perspective projection ma
 
 Additional properties are allowed.
 
+* **JSON schema**: [camera.perspective.schema.json](schema/camera.perspective.schema.json)
+
 #### camera.perspective.aspectRatio
 
 The floating-point aspect ratio of the field of view. When this is undefined, the aspect ratio of the canvas is used.
@@ -2649,6 +2677,8 @@ Dictionary object with extension-specific objects.
 
 Additional properties are allowed.
 
+* **JSON schema**: [extension.schema.json](schema/extension.schema.json)
+
 
 
 
@@ -2691,6 +2721,8 @@ The root object for a glTF asset.
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [glTF.schema.json](schema/glTF.schema.json)
 
 #### glTFProperty.extensionsUsed
 
@@ -2846,6 +2878,8 @@ Application-specific data.
 
 Additional properties are allowed.
 
+* **JSON schema**: [glTFChildOfRootProperty.schema.json](schema/glTFChildOfRootProperty.schema.json)
+
 #### glTFChildOfRootProperty.name
 
 The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
@@ -2890,6 +2924,8 @@ Application-specific data.
 
 Additional properties are allowed.
 
+* **JSON schema**: [glTFProperty.schema.json](schema/glTFProperty.schema.json)
+
 #### glTFProperty.extensions
 
 Dictionary object with extension-specific objects.
@@ -2926,6 +2962,8 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [image.schema.json](schema/image.schema.json)
 
 #### image.uri
 
@@ -3001,6 +3039,8 @@ The material appearance of a primitive.
 |**doubleSided**|`boolean`|Specifies whether the material is double sided.|No, default: `false`|
 
 Additional properties are allowed.
+
+* **JSON schema**: [material.schema.json](schema/material.schema.json)
 
 #### material.name
 
@@ -3107,6 +3147,8 @@ Reference to a texture.
 
 Additional properties are allowed.
 
+* **JSON schema**: [material.normalTextureInfo.schema.json](schema/material.normalTextureInfo.schema.json)
+
 #### material.normalTextureInfo.index :white_check_mark: 
 
 The index of the texture.
@@ -3165,6 +3207,8 @@ Reference to a texture.
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [material.occlusionTextureInfo.schema.json](schema/material.occlusionTextureInfo.schema.json)
 
 #### material.occlusionTextureInfo.index :white_check_mark: 
 
@@ -3228,6 +3272,8 @@ A set of parameter values that are used to define the metallic-roughness materia
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [material.pbrMetallicRoughness.schema.json](schema/material.pbrMetallicRoughness.schema.json)
 
 #### material.pbrMetallicRoughness.baseColorFactor
 
@@ -3305,6 +3351,8 @@ A set of primitives to be rendered.  A node can contain one mesh.  A node's tran
 
 Additional properties are allowed.
 
+* **JSON schema**: [mesh.schema.json](schema/mesh.schema.json)
+
 #### mesh.primitives :white_check_mark: 
 
 An array of primitives, each defining geometry to be rendered with a material.
@@ -3365,6 +3413,8 @@ Geometry to be rendered with the given material.
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [mesh.primitive.schema.json](schema/mesh.primitive.schema.json)
 
 #### mesh.primitive.attributes :white_check_mark: 
 
@@ -3454,6 +3504,8 @@ A node in the node hierarchy.  When the node contains `skin`, all `mesh.primitiv
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [node.schema.json](schema/node.schema.json)
 
 #### node.camera
 
@@ -3572,6 +3624,8 @@ Texture sampler properties for filtering and wrapping modes.
 
 Additional properties are allowed.
 
+* **JSON schema**: [sampler.schema.json](schema/sampler.schema.json)
+
 #### sampler.magFilter
 
 Magnification filter.  Valid values correspond to WebGL enums: `9728` (NEAREST) and `9729` (LINEAR).
@@ -3664,6 +3718,8 @@ The root nodes of a scene.
 
 Additional properties are allowed.
 
+* **JSON schema**: [scene.schema.json](schema/scene.schema.json)
+
 #### scene.nodes
 
 The indices of each root node.
@@ -3716,6 +3772,8 @@ Joints and matrices defining a skin.
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [skin.schema.json](schema/skin.schema.json)
 
 #### skin.inverseBindMatrices
 
@@ -3787,6 +3845,8 @@ A texture and its sampler.
 
 Additional properties are allowed.
 
+* **JSON schema**: [texture.schema.json](schema/texture.schema.json)
+
 #### texture.sampler
 
 The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.
@@ -3844,6 +3904,8 @@ Reference to a texture.
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
+
+* **JSON schema**: [textureInfo.schema.json](schema/textureInfo.schema.json)
 
 #### textureInfo.index :white_check_mark: 
 

--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -2326,7 +2326,7 @@ The root object for a glTF asset.
 |**extensionsRequired**|`string` `[1-*]`|Names of glTF extensions required to properly load this asset.|No|
 |**accessors**|[`accessor`](#reference-accessor) `[1-*]`|An array of accessors.|No|
 |**animations**|[`animation`](#reference-animation) `[1-*]`|An array of keyframe animations.|No|
-|**asset**|[`asset`](#reference-asset)|Metadata about the glTF asset.|No|
+|**asset**|[`asset`](#reference-asset)|Metadata about the glTF asset.| :white_check_mark: Yes|
 |**buffers**|[`buffer`](#reference-buffer) `[1-*]`|An array of buffers.|No|
 |**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.|No|
 |**cameras**|[`camera`](#reference-camera) `[1-*]`|An array of cameras.|No|
@@ -2376,12 +2376,12 @@ An array of keyframe animations.
 * **Type**: [`animation`](#reference-animation) `[1-*]`
 * **Required**: No
 
-#### gltf.asset
+#### gltf.asset :white_check_mark: 
 
 Metadata about the glTF asset.
 
 * **Type**: [`asset`](#reference-asset)
-* **Required**: No
+* **Required**: Yes
 
 #### gltf.buffers
 

--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -2088,7 +2088,7 @@ A view into a buffer generally representing a subset of the buffer.
 |---|----|-----------|--------|
 |**buffer**|`integer`|The index of the buffer.| :white_check_mark: Yes|
 |**byteOffset**|`integer`|The offset into the buffer in bytes.|No, default: `0`|
-|**byteLength**|`integer`|The total byte length of the buffer view.| :white_check_mark: Yes|
+|**byteLength**|`integer`|The length of the bufferView in bytes.| :white_check_mark: Yes|
 |**byteStride**|`integer`|The stride, in bytes.|No|
 |**target**|`integer`|The target that the GPU buffer should be bound to.|No|
 |**name**|`string`|The user-defined name of this object.|No|
@@ -2117,7 +2117,7 @@ The offset into the buffer in bytes.
 
 #### bufferView.byteLength :white_check_mark: 
 
-The total byte length of the buffer view.
+The length of the bufferView in bytes.
 
 * **Type**: `integer`
 * **Required**: Yes

--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -1652,41 +1652,44 @@ This chunk must be padded with trailing zeros (`0x00`) to satisfy alignment requ
 # Properties Reference
 
 ## Objects
-* [`accessor`](#reference-accessor)
-   * [`sparse`](#reference-sparse)
-      * [`indices`](#reference-indices)
-      * [`values`](#reference-values)
-* [`animation`](#reference-animation)
-   * [`animation sampler`](#reference-animation-sampler)
-   * [`channel`](#reference-channel)
-      * [`target`](#reference-target)
-* [`asset`](#reference-asset)
-* [`buffer`](#reference-buffer)
-* [`bufferView`](#reference-bufferview)
-* [`camera`](#reference-camera)
-   * [`orthographic`](#reference-orthographic)
-   * [`perspective`](#reference-perspective)
-* [`extension`](#reference-extension)
-* [`extras`](#reference-extras)
-* [`glTF`](#reference-gltf) (root object)
-* [`image`](#reference-image)
-* [`material`](#reference-material)
-   * [`normalTextureInfo`](#reference-normaltextureinfo)
-   * [`occlusionTextureInfo`](#reference-occlusiontextureinfo)
-   * [`pbrMetallicRoughness`](#reference-pbrmetallicroughness)
-* [`mesh`](#reference-mesh)
-   * [`primitive`](#reference-primitive)
-* [`node`](#reference-node)
-* [`sampler`](#reference-sampler)
-* [`scene`](#reference-scene)
-* [`skin`](#reference-skin)
-* [`texture`](#reference-texture)
-* [`textureInfo`](#reference-textureinfo)
+* [`Accessor`](#reference-accessor)
+   * [`Sparse`](#reference-accessor-sparse)
+      * [`Indices`](#reference-accessor-sparse-indices)
+      * [`Values`](#reference-accessor-sparse-values)
+* [`Animation`](#reference-animation)
+   * [`Channel`](#reference-animation-channel)
+      * [`Target`](#reference-animation-channel-target)
+   * [`Sampler`](#reference-animation-sampler)
+* [`Asset`](#reference-asset)
+* [`Buffer`](#reference-buffer)
+* [`Buffer View`](#reference-bufferview)
+* [`Camera`](#reference-camera)
+   * [`Orthographic`](#reference-camera-orthographic)
+   * [`Perspective`](#reference-camera-perspective)
+* [`Extension`](#reference-extension)
+* [`Extras`](#reference-extras)
+* [`glTF`](#reference-gltfproperty) (root object)
+* [`glTF Child of Root Property`](#reference-gltfchildofrootproperty)
+* [`glTF Id`](#reference-gltfid)
+* [`glTF Property`](#reference-gltfproperty)
+* [`Image`](#reference-image)
+* [`Material`](#reference-material)
+   * [`Normal Texture Info`](#reference-material-normaltextureinfo)
+   * [`Occlusion Texture Info`](#reference-material-occlusiontextureinfo)
+   * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
+* [`Mesh`](#reference-mesh)
+   * [`Primitive`](#reference-mesh-primitive)
+* [`Node`](#reference-node)
+* [`Sampler`](#reference-sampler)
+* [`Scene`](#reference-scene)
+* [`Skin`](#reference-skin)
+* [`Texture`](#reference-texture)
+* [`Texture Info`](#reference-textureinfo)
 
 
 ---------------------------------------
 <a name="reference-accessor"></a>
-### accessor
+### Accessor
 
 A typed view into a bufferView.  A bufferView contains raw binary data.  An accessor provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.
 
@@ -1694,7 +1697,7 @@ A typed view into a bufferView.  A bufferView contains raw binary data.  An acce
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**bufferView**|`integer`|The index of the bufferView.|No|
+|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView.|No|
 |**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes.|No, default: `0`|
 |**componentType**|`integer`|The datatype of components in the attribute.| :white_check_mark: Yes|
 |**normalized**|`boolean`|Specifies whether integer data values should be normalized.|No, default: `false`|
@@ -1702,20 +1705,18 @@ A typed view into a bufferView.  A bufferView contains raw binary data.  An acce
 |**type**|`string`|Specifies if the attribute is a scalar, vector, or matrix.| :white_check_mark: Yes|
 |**max**|`number` `[1-16]`|Maximum value of each component in this attribute.|No|
 |**min**|`number` `[1-16]`|Minimum value of each component in this attribute.|No|
-|**sparse**|`object`|Sparse storage of attributes that deviate from their initialization value.|No|
+|**sparse**|[`accessor.sparse`](#reference-accessor-sparse)|Sparse storage of attributes that deviate from their initialization value.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
-* **JSON schema**: [accessor.schema.json](schema/accessor.schema.json)
-
 #### accessor.bufferView
 
-The index of the bufferView. When not defined, accessor must be initialized with zeros; [`sparse`](#reference-sparse) property or extensions could override zeros with actual values.
+The index of the bufferView. When not defined, accessor must be initialized with zeros; `sparse` property or extensions could override zeros with actual values.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -1796,7 +1797,7 @@ Minimum value of each component in this attribute.  Array elements must be treat
 
 Sparse storage of attributes that deviate from their initialization value.
 
-* **Type**: `object`
+* **Type**: [`accessor.sparse`](#reference-accessor-sparse)
 * **Required**: No
 
 #### accessor.name
@@ -1810,15 +1811,187 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### accessor.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-accessor-sparse"></a>
+### Accessor Sparse
+
+Sparse storage of attributes that deviate from their initialization value.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**count**|`integer`|Number of entries stored in the sparse array.| :white_check_mark: Yes|
+|**indices**|[`accessor.sparse.indices`](#reference-accessor-sparse-indices)|Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.| :white_check_mark: Yes|
+|**values**|[`accessor.sparse.values`](#reference-accessor-sparse-values)|Array of size `count` times number of components, storing the displaced accessor attributes pointed by `indices`. Substituted values must have the same `componentType` and number of components as the base accessor.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### accessor.sparse.count :white_check_mark: 
+
+The number of attributes encoded in this sparse accessor.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+#### accessor.sparse.indices :white_check_mark: 
+
+Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.
+
+* **Type**: [`accessor.sparse.indices`](#reference-accessor-sparse-indices)
+* **Required**: Yes
+
+#### accessor.sparse.values :white_check_mark: 
+
+Array of size `count` times number of components, storing the displaced accessor attributes pointed by `indices`. Substituted values must have the same `componentType` and number of components as the base accessor.
+
+* **Type**: [`accessor.sparse.values`](#reference-accessor-sparse-values)
+* **Required**: Yes
+
+#### accessor.sparse.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### accessor.sparse.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-accessor-sparse-indices"></a>
+### Accessor Sparse Indices
+
+Indices of those attributes that deviate from their initialization value.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
+|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
+|**componentType**|`integer`|The indices data type.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### accessor.sparse.indices.bufferView :white_check_mark: 
+
+The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.indices.byteOffset
+
+The offset relative to the start of the bufferView in bytes. Must be aligned.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.indices.componentType :white_check_mark: 
+
+The indices data type.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `5123` (UNSIGNED_SHORT), `5125` (UNSIGNED_INT).
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Allowed values**:
+   * `5121` UNSIGNED_BYTE
+   * `5123` UNSIGNED_SHORT
+   * `5125` UNSIGNED_INT
+
+#### accessor.sparse.indices.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### accessor.sparse.indices.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-accessor-sparse-values"></a>
+### Accessor Sparse Values
+
+Array of size `accessor.sparse.count` times number of components storing the displaced accessor attributes pointed by `accessor.sparse.indices`.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
+|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### accessor.sparse.values.bufferView :white_check_mark: 
+
+The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.values.byteOffset
+
+The offset relative to the start of the bufferView in bytes. Must be aligned.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.values.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### accessor.sparse.values.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -1826,7 +1999,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-animation"></a>
-### animation
+### Animation
 
 A keyframe animation.
 
@@ -1834,28 +2007,26 @@ A keyframe animation.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**channels**|channel `[1-*]`|An array of channels, each of which targets an animation's sampler at a node's property. Different channels of the same animation can't have equal targets.| :white_check_mark: Yes|
-|**samplers**|animation sampler `[1-*]`|An array of samplers that combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).| :white_check_mark: Yes|
+|**channels**|[`animation.channel`](#reference-animation-channel) `[1-*]`|An array of channels, each of which targets an animation's sampler at a node's property. Different channels of the same animation can't have equal targets.| :white_check_mark: Yes|
+|**samplers**|[`animation.sampler`](#reference-animation-sampler) `[1-*]`|An array of samplers that combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).| :white_check_mark: Yes|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [animation.schema.json](schema/animation.schema.json)
 
 #### animation.channels :white_check_mark: 
 
 An array of channels, each of which targets an animation's sampler at a node's property. Different channels of the same animation can't have equal targets.
 
-* **Type**: channel `[1-*]`
+* **Type**: [`animation.channel`](#reference-animation-channel) `[1-*]`
 * **Required**: Yes
 
 #### animation.samplers :white_check_mark: 
 
 An array of samplers that combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
 
-* **Type**: animation sampler `[1-*]`
+* **Type**: [`animation.sampler`](#reference-animation-sampler) `[1-*]`
 * **Required**: Yes
 
 #### animation.name
@@ -1869,15 +2040,120 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### animation.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-animation-channel"></a>
+### Animation Channel
+
+Targets an animation's sampler at a node's property.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**sampler**|[`glTFid`](#reference-gltfid)|The index of a sampler in this animation used to compute the value for the target.| :white_check_mark: Yes|
+|**target**|[`animation.channel.target`](#reference-animation-channel-target)|The index of the node and TRS property to target.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### animation.channel.sampler :white_check_mark: 
+
+The index of a sampler in this animation used to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS).
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### animation.channel.target :white_check_mark: 
+
+The index of the node and TRS property to target.
+
+* **Type**: [`animation.channel.target`](#reference-animation-channel-target)
+* **Required**: Yes
+
+#### animation.channel.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### animation.channel.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-animation-channel-target"></a>
+### Animation Channel Target
+
+The index of the node and TRS property that an animation channel targets.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**node**|[`glTFid`](#reference-gltfid)|The index of the node to target.|No|
+|**path**|`string`|The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### animation.channel.target.node
+
+The index of the node to target.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### animation.channel.target.path :white_check_mark: 
+
+The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+   * `"translation"`
+   * `"rotation"`
+   * `"scale"`
+   * `"weights"`
+
+#### animation.channel.target.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### animation.channel.target.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -1885,7 +2161,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-animation-sampler"></a>
-### animation sampler
+### Animation Sampler
 
 Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
 
@@ -1893,25 +2169,23 @@ Combines input and output accessors with an interpolation algorithm to define a 
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**input**|`integer`|The index of an accessor containing keyframe input values, e.g., time.| :white_check_mark: Yes|
+|**input**|[`glTFid`](#reference-gltfid)|The index of an accessor containing keyframe input values, e.g., time.| :white_check_mark: Yes|
 |**interpolation**|`string`|Interpolation algorithm.|No, default: `"LINEAR"`|
-|**output**|`integer`|The index of an accessor, containing keyframe output values.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**output**|[`glTFid`](#reference-gltfid)|The index of an accessor, containing keyframe output values.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
-* **JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
-
-#### animation sampler.input :white_check_mark: 
+#### animation.sampler.input :white_check_mark: 
 
 The index of an accessor containing keyframe input values, e.g., time. That accessor must have componentType `FLOAT`. The values represent time in seconds with `time[0] >= 0.0`, and strictly increasing values, i.e., `time[n + 1] > time[n]`.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
-#### animation sampler.interpolation
+#### animation.sampler.interpolation
 
 Interpolation algorithm.
 
@@ -1922,27 +2196,27 @@ Interpolation algorithm.
    * `"STEP"` The animated values remain constant to the output of the first keyframe, until the next keyframe. The number of output elements must equal the number of input elements.
    * `"CUBICSPLINE"` The animation's interpolation is computed using a cubic spline with specified tangents. The number of output elements must equal three times the number of input elements. For each input element, the output stores three elements, an in-tangent, a spline vertex, and an out-tangent. There must be at least two keyframes when using this interpolation.
 
-#### animation sampler.output :white_check_mark: 
+#### animation.sampler.output :white_check_mark: 
 
 The index of an accessor containing keyframe output values. When targeting translation or scale paths, the `accessor.componentType` of the output values must be `FLOAT`. When targeting rotation or morph weights, the `accessor.componentType` of the output values must be `FLOAT` or normalized integer. For weights, each output element stores `SCALAR` values with a count equal to the number of morph targets.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
-#### animation sampler.extensions
+#### animation.sampler.extensions
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
-#### animation sampler.extras
+#### animation.sampler.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -1950,7 +2224,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-asset"></a>
-### asset
+### Asset
 
 Metadata about the glTF asset.
 
@@ -1962,12 +2236,10 @@ Metadata about the glTF asset.
 |**generator**|`string`|Tool that generated this glTF model.  Useful for debugging.|No|
 |**version**|`string`|The glTF version that this asset targets.| :white_check_mark: Yes|
 |**minVersion**|`string`|The minimum glTF version that this asset targets.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [asset.schema.json](schema/asset.schema.json)
 
 #### asset.copyright
 
@@ -2001,15 +2273,15 @@ The minimum glTF version that this asset targets.
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### asset.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2017,7 +2289,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-buffer"></a>
-### buffer
+### Buffer
 
 A buffer points to binary geometry, animation, or skins.
 
@@ -2026,14 +2298,12 @@ A buffer points to binary geometry, animation, or skins.
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**uri**|`string`|The uri of the buffer.|No|
-|**byteLength**|`integer`|The total byte length of the buffer view.| :white_check_mark: Yes|
+|**byteLength**|`integer`|The length of the buffer in bytes.| :white_check_mark: Yes|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [buffer.schema.json](schema/buffer.schema.json)
 
 #### buffer.uri
 
@@ -2045,7 +2315,7 @@ The uri of the buffer.  Relative paths are relative to the .gltf file.  Instead 
 
 #### buffer.byteLength :white_check_mark: 
 
-The total byte length of the buffer view.
+The length of the buffer in bytes.
 
 * **Type**: `integer`
 * **Required**: Yes
@@ -2062,15 +2332,15 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### buffer.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2078,7 +2348,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-bufferview"></a>
-### bufferView
+### Buffer View
 
 A view into a buffer generally representing a subset of the buffer.
 
@@ -2086,24 +2356,22 @@ A view into a buffer generally representing a subset of the buffer.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**buffer**|`integer`|The index of the buffer.| :white_check_mark: Yes|
+|**buffer**|[`glTFid`](#reference-gltfid)|The index of the buffer.| :white_check_mark: Yes|
 |**byteOffset**|`integer`|The offset into the buffer in bytes.|No, default: `0`|
-|**byteLength**|`integer`|The length of the bufferView in bytes.| :white_check_mark: Yes|
+|**byteLength**|`integer`|The total byte length of the buffer view.| :white_check_mark: Yes|
 |**byteStride**|`integer`|The stride, in bytes.|No|
 |**target**|`integer`|The target that the GPU buffer should be bound to.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [bufferView.schema.json](schema/bufferView.schema.json)
 
 #### bufferView.buffer :white_check_mark: 
 
 The index of the buffer.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
@@ -2117,7 +2385,7 @@ The offset into the buffer in bytes.
 
 #### bufferView.byteLength :white_check_mark: 
 
-The length of the bufferView in bytes.
+The total byte length of the buffer view.
 
 * **Type**: `integer`
 * **Required**: Yes
@@ -2155,15 +2423,15 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### bufferView.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2171,7 +2439,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-camera"></a>
-### camera
+### Camera
 
 A camera's projection.  A node can reference a camera to apply a transform to place the camera in the scene.
 
@@ -2179,34 +2447,32 @@ A camera's projection.  A node can reference a camera to apply a transform to pl
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**orthographic**|`object`|An orthographic camera containing properties to create an orthographic projection matrix.|No|
-|**perspective**|`object`|A perspective camera containing properties to create a perspective projection matrix.|No|
+|**orthographic**|[`camera.orthographic`](#reference-camera-orthographic)|An orthographic camera containing properties to create an orthographic projection matrix.|No|
+|**perspective**|[`camera.perspective`](#reference-camera-perspective)|A perspective camera containing properties to create a perspective projection matrix.|No|
 |**type**|`string`|Specifies if the camera uses a perspective or orthographic projection.| :white_check_mark: Yes|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [camera.schema.json](schema/camera.schema.json)
 
 #### camera.orthographic
 
 An orthographic camera containing properties to create an orthographic projection matrix.
 
-* **Type**: `object`
+* **Type**: [`camera.orthographic`](#reference-camera-orthographic)
 * **Required**: No
 
 #### camera.perspective
 
 A perspective camera containing properties to create a perspective projection matrix.
 
-* **Type**: `object`
+* **Type**: [`camera.perspective`](#reference-camera-perspective)
 * **Required**: No
 
 #### camera.type :white_check_mark: 
 
-Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's [`perspective`](#reference-perspective) or [`orthographic`](#reference-orthographic) property will be defined.
+Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's `perspective` or `orthographic` property will be defined.
 
 * **Type**: `string`
 * **Required**: Yes
@@ -2225,67 +2491,151 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### camera.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
 
 
 ---------------------------------------
-<a name="reference-channel"></a>
-### channel
+<a name="reference-camera-orthographic"></a>
+### Camera Orthographic
 
-Targets an animation's sampler at a node's property.
+An orthographic camera containing properties to create an orthographic projection matrix.
 
 **Properties**
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**sampler**|`integer`|The index of a sampler in this animation used to compute the value for the target.| :white_check_mark: Yes|
-|**target**|`object`|The index of the node and TRS property to target.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**xmag**|`number`|The floating-point horizontal magnification of the view. Must not be zero.| :white_check_mark: Yes|
+|**ymag**|`number`|The floating-point vertical magnification of the view. Must not be zero.| :white_check_mark: Yes|
+|**zfar**|`number`|The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.| :white_check_mark: Yes|
+|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
-* **JSON schema**: [animation.channel.schema.json](schema/animation.channel.schema.json)
+#### camera.orthographic.xmag :white_check_mark: 
 
-#### channel.sampler :white_check_mark: 
+The floating-point horizontal magnification of the view. Must not be zero.
 
-The index of a sampler in this animation used to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS).
+* **Type**: `number`
+* **Required**: Yes
 
-* **Type**: `integer`
+#### camera.orthographic.ymag :white_check_mark: 
+
+The floating-point vertical magnification of the view. Must not be zero.
+
+* **Type**: `number`
+* **Required**: Yes
+
+#### camera.orthographic.zfar :white_check_mark: 
+
+The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+#### camera.orthographic.znear :white_check_mark: 
+
+The floating-point distance to the near clipping plane.
+
+* **Type**: `number`
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
-#### channel.target :white_check_mark: 
-
-The index of the node and TRS property to target.
-
-* **Type**: `object`
-* **Required**: Yes
-
-#### channel.extensions
+#### camera.orthographic.extensions
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
-#### channel.extras
+#### camera.orthographic.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-camera-perspective"></a>
+### Camera Perspective
+
+A perspective camera containing properties to create a perspective projection matrix.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**aspectRatio**|`number`|The floating-point aspect ratio of the field of view.|No|
+|**yfov**|`number`|The floating-point vertical field of view in radians.| :white_check_mark: Yes|
+|**zfar**|`number`|The floating-point distance to the far clipping plane.|No|
+|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### camera.perspective.aspectRatio
+
+The floating-point aspect ratio of the field of view. When this is undefined, the aspect ratio of the canvas is used.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+
+#### camera.perspective.yfov :white_check_mark: 
+
+The floating-point vertical field of view in radians.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+#### camera.perspective.zfar
+
+The floating-point distance to the far clipping plane. When defined, `zfar` must be greater than `znear`. If `zfar` is undefined, runtime must use infinite projection matrix.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+
+#### camera.perspective.znear :white_check_mark: 
+
+The floating-point distance to the near clipping plane.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+#### camera.perspective.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### camera.perspective.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2293,29 +2643,25 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-extension"></a>
-### extension
+### Extension
 
 Dictionary object with extension-specific objects.
 
 Additional properties are allowed.
-
-* **JSON schema**: [extension.schema.json](schema/extension.schema.json)
 
 
 
 
 ---------------------------------------
 <a name="reference-extras"></a>
-### extras
+### Extras
 
 Application-specific data.
 
-> **Implementation Note:** Although extras may have any type, it is common for applications to
-store and access custom data as key/value pairs. As best practice, extras should be an Object
-rather than a primitive value for best portability.
+
 
 ---------------------------------------
-<a name="reference-gltf"></a>
+<a name="reference-gltfproperty"></a>
 ### glTF
 
 The root object for a glTF asset.
@@ -2326,29 +2672,27 @@ The root object for a glTF asset.
 |---|----|-----------|--------|
 |**extensionsUsed**|`string` `[1-*]`|Names of glTF extensions used somewhere in this asset.|No|
 |**extensionsRequired**|`string` `[1-*]`|Names of glTF extensions required to properly load this asset.|No|
-|**accessors**|accessor `[1-*]`|An array of accessors.|No|
-|**animations**|animation `[1-*]`|An array of keyframe animations.|No|
-|**asset**|`object`|Metadata about the glTF asset.|Yes|
-|**buffers**|buffer `[1-*]`|An array of buffers.|No|
-|**bufferViews**|bufferView `[1-*]`|An array of bufferViews.|No|
-|**cameras**|camera `[1-*]`|An array of cameras.|No|
-|**images**|image `[1-*]`|An array of images.|No|
-|**materials**|material `[1-*]`|An array of materials.|No|
-|**meshes**|mesh `[1-*]`|An array of meshes.|No|
-|**nodes**|node `[1-*]`|An array of nodes.|No|
-|**samplers**|sampler `[1-*]`|An array of samplers.|No|
-|**scene**|`integer`|The index of the default scene.|No|
-|**scenes**|scene `[1-*]`|An array of scenes.|No|
-|**skins**|skin `[1-*]`|An array of skins.|No|
-|**textures**|texture `[1-*]`|An array of textures.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**accessors**|[`accessor`](#reference-accessor) `[1-*]`|An array of accessors.|No|
+|**animations**|[`animation`](#reference-animation) `[1-*]`|An array of keyframe animations.|No|
+|**asset**|[`asset`](#reference-asset)|Metadata about the glTF asset.|No|
+|**buffers**|[`buffer`](#reference-buffer) `[1-*]`|An array of buffers.|No|
+|**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.|No|
+|**cameras**|[`camera`](#reference-camera) `[1-*]`|An array of cameras.|No|
+|**images**|[`image`](#reference-image) `[1-*]`|An array of images.|No|
+|**materials**|[`material`](#reference-material) `[1-*]`|An array of materials.|No|
+|**meshes**|[`mesh`](#reference-mesh) `[1-*]`|An array of meshes.|No|
+|**nodes**|[`node`](#reference-node) `[1-*]`|An array of nodes.|No|
+|**samplers**|[`sampler`](#reference-sampler) `[1-*]`|An array of samplers.|No|
+|**scene**|[`glTFid`](#reference-gltfid)|The index of the default scene.|No|
+|**scenes**|[`scene`](#reference-scene) `[1-*]`|An array of scenes.|No|
+|**skins**|[`skin`](#reference-skin) `[1-*]`|An array of skins.|No|
+|**textures**|[`texture`](#reference-texture) `[1-*]`|An array of textures.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
-* **JSON schema**: [glTF.schema.json](schema/glTF.schema.json)
-
-#### glTF.extensionsUsed
+#### glTFProperty.extensionsUsed
 
 Names of glTF extensions used somewhere in this asset.
 
@@ -2356,7 +2700,7 @@ Names of glTF extensions used somewhere in this asset.
    * Each element in the array must be unique.
 * **Required**: No
 
-#### glTF.extensionsRequired
+#### glTFProperty.extensionsRequired
 
 Names of glTF extensions required to properly load this asset.
 
@@ -2364,152 +2708,224 @@ Names of glTF extensions required to properly load this asset.
    * Each element in the array must be unique.
 * **Required**: No
 
-#### glTF.accessors
+#### glTFProperty.accessors
 
 An array of accessors.  An accessor is a typed view into a bufferView.
 
-* **Type**: accessor `[1-*]`
+* **Type**: [`accessor`](#reference-accessor) `[1-*]`
 * **Required**: No
 
-#### glTF.animations
+#### glTFProperty.animations
 
 An array of keyframe animations.
 
-* **Type**: animation `[1-*]`
+* **Type**: [`animation`](#reference-animation) `[1-*]`
 * **Required**: No
 
-#### glTF.asset :white_check_mark: 
+#### glTFProperty.asset
 
 Metadata about the glTF asset.
 
-* **Type**: `object`
-* **Required**: Yes
+* **Type**: [`asset`](#reference-asset)
+* **Required**: No
 
-#### glTF.buffers
+#### glTFProperty.buffers
 
 An array of buffers.  A buffer points to binary geometry, animation, or skins.
 
-* **Type**: buffer `[1-*]`
+* **Type**: [`buffer`](#reference-buffer) `[1-*]`
 * **Required**: No
 
-#### glTF.bufferViews
+#### glTFProperty.bufferViews
 
 An array of bufferViews.  A bufferView is a view into a buffer generally representing a subset of the buffer.
 
-* **Type**: bufferView `[1-*]`
+* **Type**: [`bufferView`](#reference-bufferview) `[1-*]`
 * **Required**: No
 
-#### glTF.cameras
+#### glTFProperty.cameras
 
 An array of cameras.  A camera defines a projection matrix.
 
-* **Type**: camera `[1-*]`
+* **Type**: [`camera`](#reference-camera) `[1-*]`
 * **Required**: No
 
-#### glTF.images
+#### glTFProperty.images
 
 An array of images.  An image defines data used to create a texture.
 
-* **Type**: image `[1-*]`
+* **Type**: [`image`](#reference-image) `[1-*]`
 * **Required**: No
 
-#### glTF.materials
+#### glTFProperty.materials
 
 An array of materials.  A material defines the appearance of a primitive.
 
-* **Type**: material `[1-*]`
+* **Type**: [`material`](#reference-material) `[1-*]`
 * **Required**: No
 
-#### glTF.meshes
+#### glTFProperty.meshes
 
 An array of meshes.  A mesh is a set of primitives to be rendered.
 
-* **Type**: mesh `[1-*]`
+* **Type**: [`mesh`](#reference-mesh) `[1-*]`
 * **Required**: No
 
-#### glTF.nodes
+#### glTFProperty.nodes
 
 An array of nodes.
 
-* **Type**: node `[1-*]`
+* **Type**: [`node`](#reference-node) `[1-*]`
 * **Required**: No
 
-#### glTF.samplers
+#### glTFProperty.samplers
 
 An array of samplers.  A sampler contains properties for texture filtering and wrapping modes.
 
-* **Type**: sampler `[1-*]`
+* **Type**: [`sampler`](#reference-sampler) `[1-*]`
 * **Required**: No
 
-#### glTF.scene
+#### glTFProperty.scene
 
 The index of the default scene.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: No
 * **Minimum**: ` >= 0`
 
-#### glTF.scenes
+#### glTFProperty.scenes
 
 An array of scenes.
 
-* **Type**: scene `[1-*]`
+* **Type**: [`scene`](#reference-scene) `[1-*]`
 * **Required**: No
 
-#### glTF.skins
+#### glTFProperty.skins
 
 An array of skins.  A skin is defined by joints and matrices.
 
-* **Type**: skin `[1-*]`
+* **Type**: [`skin`](#reference-skin) `[1-*]`
 * **Required**: No
 
-#### glTF.textures
+#### glTFProperty.textures
 
 An array of textures.
 
-* **Type**: texture `[1-*]`
+* **Type**: [`texture`](#reference-texture) `[1-*]`
 * **Required**: No
 
-#### glTF.extensions
+#### glTFProperty.extensions
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
-#### glTF.extras
+#### glTFProperty.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
+
+
+---------------------------------------
+<a name="reference-gltfchildofrootproperty"></a>
+### glTF Child of Root Property
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### glTFChildOfRootProperty.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+#### glTFChildOfRootProperty.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### glTFChildOfRootProperty.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-gltfid"></a>
+### glTF Id
+
+
+
+---------------------------------------
+<a name="reference-gltfproperty"></a>
+### glTF Property
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### glTFProperty.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### glTFProperty.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
 
 
 
 
 ---------------------------------------
 <a name="reference-image"></a>
-### image
+### Image
 
-Image data used to create a texture. Image can be referenced by URI or [`bufferView`](#reference-bufferview) index. `mimeType` is required in the latter case.
+Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.
 
 **Properties**
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**uri**|`string`|The uri of the image.|No|
-|**mimeType**|`string`|The image's MIME type.|No|
-|**bufferView**|`integer`|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
+|**mimeType**|`string`|The image's MIME type. Required if `bufferView` is defined.|No|
+|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [image.schema.json](schema/image.schema.json)
 
 #### image.uri
 
@@ -2533,7 +2949,7 @@ The image's MIME type. Required if `bufferView` is defined.
 
 The index of the bufferView that contains the image. Use this instead of the image's uri property.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -2548,80 +2964,15 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### image.extras
 
 Application-specific data.
 
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-indices"></a>
-### indices
-
-Indices of those attributes that deviate from their initialization value.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**bufferView**|`integer`|The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
-|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
-|**componentType**|`integer`|The indices data type.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [accessor.sparse.indices.schema.json](schema/accessor.sparse.indices.schema.json)
-
-#### indices.bufferView :white_check_mark: 
-
-The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### indices.byteOffset
-
-The offset relative to the start of the bufferView in bytes. Must be aligned.
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### indices.componentType :white_check_mark: 
-
-The indices data type.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `5123` (UNSIGNED_SHORT), `5125` (UNSIGNED_INT).
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Allowed values**:
-   * `5121` UNSIGNED_BYTE
-   * `5123` UNSIGNED_SHORT
-   * `5125` UNSIGNED_INT
-
-#### indices.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### indices.extras
-
-Application-specific data.
-
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2629,7 +2980,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-material"></a>
-### material
+### Material
 
 The material appearance of a primitive.
 
@@ -2638,20 +2989,18 @@ The material appearance of a primitive.
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-|**pbrMetallicRoughness**|`object`|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of [`pbrMetallicRoughness`](#reference-pbrmetallicroughness) apply.|No|
-|**normalTexture**|`object`|The normal map texture.|No|
-|**occlusionTexture**|`object`|The occlusion map texture.|No|
-|**emissiveTexture**|`object`|The emissive map texture.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+|**pbrMetallicRoughness**|[`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.|No|
+|**normalTexture**|[`material.normalTextureInfo`](#reference-material-normaltextureinfo)|The normal map texture.|No|
+|**occlusionTexture**|[`material.occlusionTextureInfo`](#reference-material-occlusiontextureinfo)|The occlusion map texture.|No|
+|**emissiveTexture**|[`textureInfo`](#reference-textureinfo)|The emissive map texture.|No|
 |**emissiveFactor**|`number` `[3]`|The emissive color of the material.|No, default: `[0,0,0]`|
 |**alphaMode**|`string`|The alpha rendering mode of the material.|No, default: `"OPAQUE"`|
 |**alphaCutoff**|`number`|The alpha cutoff value of the material.|No, default: `0.5`|
 |**doubleSided**|`boolean`|Specifies whether the material is double sided.|No, default: `false`|
 
 Additional properties are allowed.
-
-* **JSON schema**: [material.schema.json](schema/material.schema.json)
 
 #### material.name
 
@@ -2664,43 +3013,43 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### material.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 #### material.pbrMetallicRoughness
 
-A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of [`pbrMetallicRoughness`](#reference-pbrmetallicroughness) apply.
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
 
-* **Type**: `object`
+* **Type**: [`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)
 * **Required**: No
 
 #### material.normalTexture
 
-A tangent space normal map. The texture contains RGB components in linear space. Each texel represents the XYZ components of a normal vector in tangent space. Red [0 to 255] maps to X [-1 to 1]. Green [0 to 255] maps to Y [-1 to 1]. Blue [128 to 255] maps to Z [1/255 to 1]. The normal vectors use OpenGL conventions where +X is right and +Y is up. +Z points toward the viewer. In GLSL, this vector would be unpacked like so: `vec3 normalVector = tex2D(normalMap, texCoord) * 2 - 1`. Client implementations should normalize the normal vectors before using them in lighting equations.
+A tangent space normal map. The texture contains RGB components in linear space. Each texel represents the XYZ components of a normal vector in tangent space. Red [0 to 255] maps to X [-1 to 1]. Green [0 to 255] maps to Y [-1 to 1]. Blue [128 to 255] maps to Z [1/255 to 1]. The normal vectors use OpenGL conventions where +X is right and +Y is up. +Z points toward the viewer. In GLSL, this vector would be unpacked like so: `float3 normalVector = tex2D(<sampled normal map texture value>, texCoord) * 2 - 1`. Client implementations should normalize the normal vectors before using them in lighting equations.
 
-* **Type**: `object`
+* **Type**: [`material.normalTextureInfo`](#reference-material-normaltextureinfo)
 * **Required**: No
 
 #### material.occlusionTexture
 
 The occlusion map texture. The occlusion values are sampled from the R channel. Higher values indicate areas that should receive full indirect lighting and lower values indicate no indirect lighting. These values are linear. If other channels are present (GBA), they are ignored for occlusion calculations.
 
-* **Type**: `object`
+* **Type**: [`material.occlusionTextureInfo`](#reference-material-occlusiontextureinfo)
 * **Required**: No
 
 #### material.emissiveTexture
 
 The emissive map controls the color and intensity of the light being emitted by the material. This texture contains RGB components encoded with the sRGB transfer function. If a fourth component (A) is present, it is ignored.
 
-* **Type**: `object`
+* **Type**: [`textureInfo`](#reference-textureinfo)
 * **Required**: No
 
 #### material.emissiveFactor
@@ -2741,8 +3090,206 @@ Specifies whether the material is double sided. When this value is false, back-f
 
 
 ---------------------------------------
+<a name="reference-material-normaltextureinfo"></a>
+### Material Normal Texture Info
+
+Reference to a texture.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**index**|[`glTFid`](#reference-gltfid)|The index of the texture.| :white_check_mark: Yes|
+|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
+|**scale**|`number`|The scalar multiplier applied to each normal vector of the normal texture.|No, default: `1`|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### material.normalTextureInfo.index :white_check_mark: 
+
+The index of the texture.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### material.normalTextureInfo.texCoord
+
+This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### material.normalTextureInfo.scale
+
+The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+
+#### material.normalTextureInfo.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### material.normalTextureInfo.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-material-occlusiontextureinfo"></a>
+### Material Occlusion Texture Info
+
+Reference to a texture.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**index**|[`glTFid`](#reference-gltfid)|The index of the texture.| :white_check_mark: Yes|
+|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
+|**strength**|`number`|A scalar multiplier controlling the amount of occlusion applied.|No, default: `1`|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### material.occlusionTextureInfo.index :white_check_mark: 
+
+The index of the texture.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### material.occlusionTextureInfo.texCoord
+
+This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### material.occlusionTextureInfo.strength
+
+A scalar multiplier controlling the amount of occlusion applied. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion. This value affects the resulting color using the formula: `occludedColor = lerp(color, color * <sampled occlusion texture value>, <occlusion strength>)`. This value is ignored if the corresponding texture is not specified. This value is linear.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.occlusionTextureInfo.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### material.occlusionTextureInfo.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-material-pbrmetallicroughness"></a>
+### Material PBR Metallic Roughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**baseColorFactor**|`number` `[4]`|The material's base color factor.|No, default: `[1,1,1,1]`|
+|**baseColorTexture**|[`textureInfo`](#reference-textureinfo)|The base color texture.|No|
+|**metallicFactor**|`number`|The metalness of the material.|No, default: `1`|
+|**roughnessFactor**|`number`|The roughness of the material.|No, default: `1`|
+|**metallicRoughnessTexture**|[`textureInfo`](#reference-textureinfo)|The metallic-roughness texture.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### material.pbrMetallicRoughness.baseColorFactor
+
+The RGBA components of the base color of the material. The fourth component (A) is the alpha coverage of the material. The `alphaMode` property specifies how alpha is interpreted. These values are linear. If a baseColorTexture is specified, this value is multiplied with the texel values.
+
+* **Type**: `number` `[4]`
+   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[1,1,1,1]`
+
+#### material.pbrMetallicRoughness.baseColorTexture
+
+The base color texture. The first three components (RGB) are encoded with the sRGB transfer function. They specify the base color of the material. If the fourth component (A) is present, it represents the linear alpha coverage of the material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property specifies how alpha is interpreted. The stored texels must not be premultiplied.
+
+* **Type**: [`textureInfo`](#reference-textureinfo)
+* **Required**: No
+
+#### material.pbrMetallicRoughness.metallicFactor
+
+The metalness of the material. A value of 1.0 means the material is a metal. A value of 0.0 means the material is a dielectric. Values in between are for blending between metals and dielectrics such as dirty metallic surfaces. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the metallic texel values.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.pbrMetallicRoughness.roughnessFactor
+
+The roughness of the material. A value of 1.0 means the material is completely rough. A value of 0.0 means the material is completely smooth. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the roughness texel values.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.pbrMetallicRoughness.metallicRoughnessTexture
+
+The metallic-roughness texture. The metalness values are sampled from the B channel. The roughness values are sampled from the G channel. These values are linear. If other channels are present (R or A), they are ignored for metallic-roughness calculations.
+
+* **Type**: [`textureInfo`](#reference-textureinfo)
+* **Required**: No
+
+#### material.pbrMetallicRoughness.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### material.pbrMetallicRoughness.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
 <a name="reference-mesh"></a>
-### mesh
+### Mesh
 
 A set of primitives to be rendered.  A node can contain one mesh.  A node's transform places the mesh in the scene.
 
@@ -2750,21 +3297,19 @@ A set of primitives to be rendered.  A node can contain one mesh.  A node's tran
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**primitives**|primitive `[1-*]`|An array of primitives, each defining geometry to be rendered with a material.| :white_check_mark: Yes|
+|**primitives**|[`mesh.primitive`](#reference-mesh-primitive) `[1-*]`|An array of primitives, each defining geometry to be rendered with a material.| :white_check_mark: Yes|
 |**weights**|`number` `[1-*]`|Array of weights to be applied to the Morph Targets.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [mesh.schema.json](schema/mesh.schema.json)
 
 #### mesh.primitives :white_check_mark: 
 
 An array of primitives, each defining geometry to be rendered with a material.
 
-* **Type**: primitive `[1-*]`
+* **Type**: [`mesh.primitive`](#reference-mesh-primitive) `[1-*]`
 * **Required**: Yes
 
 #### mesh.weights
@@ -2785,15 +3330,101 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### mesh.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-mesh-primitive"></a>
+### Mesh Primitive
+
+Geometry to be rendered with the given material.
+
+**Related WebGL functions**: `drawElements()` and `drawArrays()`
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**attributes**|`object`|A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.| :white_check_mark: Yes|
+|**indices**|[`glTFid`](#reference-gltfid)|The index of the accessor that contains the indices.|No|
+|**material**|[`glTFid`](#reference-gltfid)|The index of the material to apply to this primitive when rendering.|No|
+|**mode**|`integer`|The type of primitives to render.|No, default: `4`|
+|**targets**|`object` `[1-*]`|An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+#### mesh.primitive.attributes :white_check_mark: 
+
+A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.
+
+* **Type**: `object`
+* **Required**: Yes
+* **Type of each property**: `glTFid`
+
+#### mesh.primitive.indices
+
+The index of the accessor that contains mesh indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.  When defined, the accessor must contain indices: the `bufferView` referenced by the accessor should have a `target` equal to 34963 (ELEMENT_ARRAY_BUFFER); `componentType` must be 5121 (UNSIGNED_BYTE), 5123 (UNSIGNED_SHORT) or 5125 (UNSIGNED_INT), the latter may require enabling additional hardware support; `type` must be `"SCALAR"`. For triangle primitives, the front face has a counter-clockwise (CCW) winding order. Values of the index accessor must not include the maximum value for the given component type, which triggers primitive restart in several graphics APIs and would require client implementations to rebuild the index buffer. Primitive restart values are disallowed and all index values must refer to actual vertices. As a result, the index accessor's values must not exceed the following maxima: BYTE `< 255`, UNSIGNED_SHORT `< 65535`, UNSIGNED_INT `< 4294967295`.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### mesh.primitive.material
+
+The index of the material to apply to this primitive when rendering.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### mesh.primitive.mode
+
+The type of primitives to render. All valid values correspond to WebGL enums.
+
+* **Type**: `integer`
+* **Required**: No, default: `4`
+* **Allowed values**:
+   * `0` POINTS
+   * `1` LINES
+   * `2` LINE_LOOP
+   * `3` LINE_STRIP
+   * `4` TRIANGLES
+   * `5` TRIANGLE_STRIP
+   * `6` TRIANGLE_FAN
+
+#### mesh.primitive.targets
+
+An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.
+
+* **Type**: `object` `[1-*]`
+* **Required**: No
+
+#### mesh.primitive.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### mesh.primitive.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2801,36 +3432,34 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-node"></a>
-### node
+### Node
 
-A node in the node hierarchy.  When the node contains [`skin`](#reference-skin), all `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.
+A node in the node hierarchy.  When the node contains `skin`, all `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.
 
 **Properties**
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**camera**|`integer`|The index of the camera referenced by this node.|No|
+|**camera**|[`glTFid`](#reference-gltfid)|The index of the camera referenced by this node.|No|
 |**children**|`integer` `[1-*]`|The indices of this node's children.|No|
-|**skin**|`integer`|The index of the skin referenced by this node.|No|
+|**skin**|[`glTFid`](#reference-gltfid)|The index of the skin referenced by this node.|No|
 |**matrix**|`number` `[16]`|A floating-point 4x4 transformation matrix stored in column-major order.|No, default: `[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]`|
-|**mesh**|`integer`|The index of the mesh in this node.|No|
+|**mesh**|[`glTFid`](#reference-gltfid)|The index of the mesh in this node.|No|
 |**rotation**|`number` `[4]`|The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.|No, default: `[0,0,0,1]`|
 |**scale**|`number` `[3]`|The node's non-uniform scale, given as the scaling factors along the x, y, and z axes.|No, default: `[1,1,1]`|
 |**translation**|`number` `[3]`|The node's translation along the x, y, and z axes.|No, default: `[0,0,0]`|
 |**weights**|`number` `[1-*]`|The weights of the instantiated Morph Target. Number of elements must match number of Morph Targets of used mesh.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [node.schema.json](schema/node.schema.json)
 
 #### node.camera
 
 The index of the camera referenced by this node.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -2847,7 +3476,7 @@ The indices of this node's children.
 
 The index of the skin referenced by this node. When a skin is referenced by a node within a scene, all joints used by the skin must belong to the same scene.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -2863,7 +3492,7 @@ A floating-point 4x4 transformation matrix stored in column-major order.
 
 The index of the mesh in this node.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -2907,449 +3536,15 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### node.extras
 
 Application-specific data.
 
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-normaltextureinfo"></a>
-### normalTextureInfo
-
-Reference to a texture.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**index**|`integer`|The index of the texture.| :white_check_mark: Yes|
-|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
-|**scale**|`number`|The scalar multiplier applied to each normal vector of the normal texture.|No, default: `1`|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [material.normalTextureInfo.schema.json](schema/material.normalTextureInfo.schema.json)
-
-#### normalTextureInfo.index :white_check_mark: 
-
-The index of the texture.
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### normalTextureInfo.texCoord
-
-This integer value is used to construct a string in the format TEXCOORD_<set index> which is a reference to a key in mesh.primitives.attributes (e.g. A value of 0 corresponds to TEXCOORD_0).
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### normalTextureInfo.scale
-
-The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-
-#### normalTextureInfo.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### normalTextureInfo.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-occlusiontextureinfo"></a>
-### occlusionTextureInfo
-
-Reference to a texture.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**index**|`integer`|The index of the texture.| :white_check_mark: Yes|
-|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
-|**strength**|`number`|A scalar multiplier controlling the amount of occlusion applied.|No, default: `1`|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [material.occlusionTextureInfo.schema.json](schema/material.occlusionTextureInfo.schema.json)
-
-#### occlusionTextureInfo.index :white_check_mark: 
-
-The index of the texture.
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### occlusionTextureInfo.texCoord
-
-This integer value is used to construct a string in the format TEXCOORD_<set index> which is a reference to a key in mesh.primitives.attributes (e.g. A value of 0 corresponds to TEXCOORD_0).
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### occlusionTextureInfo.strength
-
-A scalar multiplier controlling the amount of occlusion applied. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion. This value affects the resulting color using the formula: `occludedColor = lerp(color, color * <sampled occlusion texture value>, <occlusion strength>)`. This value is ignored if the corresponding texture is not specified. This value is linear.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-* **Minimum**: ` >= 0`
-* **Maximum**: ` <= 1`
-
-#### occlusionTextureInfo.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### occlusionTextureInfo.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-orthographic"></a>
-### orthographic
-
-An orthographic camera containing properties to create an orthographic projection matrix.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**xmag**|`number`|The floating-point horizontal magnification of the view.| :white_check_mark: Yes|
-|**ymag**|`number`|The floating-point vertical magnification of the view.| :white_check_mark: Yes|
-|**zfar**|`number`|The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.| :white_check_mark: Yes|
-|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [camera.orthographic.schema.json](schema/camera.orthographic.schema.json)
-
-#### orthographic.xmag :white_check_mark: 
-
-The floating-point horizontal magnification of the view.
-
-* **Type**: `number`
-* **Required**: Yes
-
-#### orthographic.ymag :white_check_mark: 
-
-The floating-point vertical magnification of the view.
-
-* **Type**: `number`
-* **Required**: Yes
-
-#### orthographic.zfar :white_check_mark: 
-
-The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.
-
-* **Type**: `number`
-* **Required**: Yes
-* **Minimum**: ` > 0`
-
-#### orthographic.znear :white_check_mark: 
-
-The floating-point distance to the near clipping plane.
-
-* **Type**: `number`
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### orthographic.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### orthographic.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-pbrmetallicroughness"></a>
-### pbrMetallicRoughness
-
-A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**baseColorFactor**|`number` `[4]`|The material's base color factor.|No, default: `[1,1,1,1]`|
-|**baseColorTexture**|`object`|The base color texture.|No|
-|**metallicFactor**|`number`|The metalness of the material.|No, default: `1`|
-|**roughnessFactor**|`number`|The roughness of the material.|No, default: `1`|
-|**metallicRoughnessTexture**|`object`|The metallic-roughness texture.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [material.pbrMetallicRoughness.schema.json](schema/material.pbrMetallicRoughness.schema.json)
-
-#### pbrMetallicRoughness.baseColorFactor
-
-The RGBA components of the base color of the material. The fourth component (A) is the alpha coverage of the material. The `alphaMode` property specifies how alpha is interpreted. These values are linear. If a baseColorTexture is specified, this value is multiplied with the texel values.
-
-* **Type**: `number` `[4]`
-   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
-* **Required**: No, default: `[1,1,1,1]`
-
-#### pbrMetallicRoughness.baseColorTexture
-
-The base color texture. The first three components (RGB) are encoded with the sRGB transfer function. They specify the base color of the material. If the fourth component (A) is present, it represents the linear alpha coverage of the material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property specifies how alpha is interpreted. The stored texels must not be premultiplied.
-
-* **Type**: `object`
-* **Required**: No
-
-#### pbrMetallicRoughness.metallicFactor
-
-The metalness of the material. A value of 1.0 means the material is a metal. A value of 0.0 means the material is a dielectric. Values in between are for blending between metals and dielectrics such as dirty metallic surfaces. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the metallic texel values.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-* **Minimum**: ` >= 0`
-* **Maximum**: ` <= 1`
-
-#### pbrMetallicRoughness.roughnessFactor
-
-The roughness of the material. A value of 1.0 means the material is completely rough. A value of 0.0 means the material is completely smooth. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the roughness texel values.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-* **Minimum**: ` >= 0`
-* **Maximum**: ` <= 1`
-
-#### pbrMetallicRoughness.metallicRoughnessTexture
-
-The metallic-roughness texture. The metalness values are sampled from the B channel. The roughness values are sampled from the G channel. These values are linear. If other channels are present (R or A), they are ignored for metallic-roughness calculations.
-
-* **Type**: `object`
-* **Required**: No
-
-#### pbrMetallicRoughness.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### pbrMetallicRoughness.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-perspective"></a>
-### perspective
-
-A perspective camera containing properties to create a perspective projection matrix.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**aspectRatio**|`number`|The floating-point aspect ratio of the field of view.|No|
-|**yfov**|`number`|The floating-point vertical field of view in radians.| :white_check_mark: Yes|
-|**zfar**|`number`|The floating-point distance to the far clipping plane.|No|
-|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [camera.perspective.schema.json](schema/camera.perspective.schema.json)
-
-#### perspective.aspectRatio
-
-The floating-point aspect ratio of the field of view. When this is undefined, the aspect ratio of the canvas is used.
-
-* **Type**: `number`
-* **Required**: No
-* **Minimum**: ` > 0`
-
-#### perspective.yfov :white_check_mark: 
-
-The floating-point vertical field of view in radians.
-
-* **Type**: `number`
-* **Required**: Yes
-* **Minimum**: ` > 0`
-
-#### perspective.zfar
-
-The floating-point distance to the far clipping plane. When defined, `zfar` must be greater than `znear`. If `zfar` is undefined, runtime must use infinite projection matrix.
-
-* **Type**: `number`
-* **Required**: No
-* **Minimum**: ` > 0`
-
-#### perspective.znear :white_check_mark: 
-
-The floating-point distance to the near clipping plane.
-
-* **Type**: `number`
-* **Required**: Yes
-* **Minimum**: ` > 0`
-
-#### perspective.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### perspective.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-primitive"></a>
-### primitive
-
-Geometry to be rendered with the given material.
-
-**Related WebGL functions**: `drawElements()` and `drawArrays()`
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**attributes**|`object`|A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.| :white_check_mark: Yes|
-|**indices**|`integer`|The index of the accessor that contains the indices.|No|
-|**material**|`integer`|The index of the material to apply to this primitive when rendering.|No|
-|**mode**|`integer`|The type of primitives to render.|No, default: `4`|
-|**targets**|`object` `[1-*]`|An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [mesh.primitive.schema.json](schema/mesh.primitive.schema.json)
-
-#### primitive.attributes :white_check_mark: 
-
-A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.
-
-* **Type**: `object`
-* **Required**: Yes
-* **Type of each property**: `integer`
-
-#### primitive.indices
-
-The index of the accessor that contains mesh indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.  When defined, the accessor must contain indices: the [`bufferView`](#reference-bufferview) referenced by the accessor should have a [`target`](#reference-target) equal to 34963 (ELEMENT_ARRAY_BUFFER); `componentType` must be 5121 (UNSIGNED_BYTE), 5123 (UNSIGNED_SHORT) or 5125 (UNSIGNED_INT), the latter may require enabling additional hardware support; `type` must be `"SCALAR"`. For triangle primitives, the front face has a counter-clockwise (CCW) winding order.
-
-Values of the index accessor must not include the maximum value for the given component type, which triggers primitive restart in several graphics APIs and would require client implementations to rebuild the index buffer. Primitive restart values are disallowed and all index values must refer to actual vertices. As a result, the index accessor's values must not exceed the following maxima: BYTE `< 255`, UNSIGNED_SHORT `< 65535`, UNSIGNED_INT `< 4294967295`.
-
-* **Type**: `integer`
-* **Required**: No
-* **Minimum**: ` >= 0`
-
-#### primitive.material
-
-The index of the material to apply to this primitive when rendering.
-
-* **Type**: `integer`
-* **Required**: No
-* **Minimum**: ` >= 0`
-
-#### primitive.mode
-
-The type of primitives to render. All valid values correspond to WebGL enums.
-
-* **Type**: `integer`
-* **Required**: No, default: `4`
-* **Allowed values**:
-   * `0` POINTS
-   * `1` LINES
-   * `2` LINE_LOOP
-   * `3` LINE_STRIP
-   * `4` TRIANGLES
-   * `5` TRIANGLE_STRIP
-   * `6` TRIANGLE_FAN
-
-#### primitive.targets
-
-An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.
-
-* **Type**: `object` `[1-*]`
-* **Required**: No
-
-#### primitive.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### primitive.extras
-
-Application-specific data.
-
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -3357,7 +3552,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-sampler"></a>
-### sampler
+### Sampler
 
 Texture sampler properties for filtering and wrapping modes.
 
@@ -3372,12 +3567,10 @@ Texture sampler properties for filtering and wrapping modes.
 |**wrapS**|`integer`|s wrapping mode.|No, default: `10497`|
 |**wrapT**|`integer`|t wrapping mode.|No, default: `10497`|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [sampler.schema.json](schema/sampler.schema.json)
 
 #### sampler.magFilter
 
@@ -3440,15 +3633,15 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### sampler.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -3456,7 +3649,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-scene"></a>
-### scene
+### Scene
 
 The root nodes of a scene.
 
@@ -3466,12 +3659,10 @@ The root nodes of a scene.
 |---|----|-----------|--------|
 |**nodes**|`integer` `[1-*]`|The indices of each root node.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [scene.schema.json](schema/scene.schema.json)
 
 #### scene.nodes
 
@@ -3493,15 +3684,15 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### scene.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -3509,7 +3700,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-skin"></a>
-### skin
+### Skin
 
 Joints and matrices defining a skin.
 
@@ -3517,22 +3708,20 @@ Joints and matrices defining a skin.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**inverseBindMatrices**|`integer`|The index of the accessor containing the floating-point 4x4 inverse-bind matrices.  The default is that each matrix is a 4x4 identity matrix, which implies that inverse-bind matrices were pre-applied.|No|
-|**skeleton**|`integer`|The index of the node used as a skeleton root.|No|
+|**inverseBindMatrices**|[`glTFid`](#reference-gltfid)|The index of the accessor containing the floating-point 4x4 inverse-bind matrices.  The default is that each matrix is a 4x4 identity matrix, which implies that inverse-bind matrices were pre-applied.|No|
+|**skeleton**|[`glTFid`](#reference-gltfid)|The index of the node used as a skeleton root.|No|
 |**joints**|`integer` `[1-*]`|Indices of skeleton nodes, used as joints in this skin.| :white_check_mark: Yes|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [skin.schema.json](schema/skin.schema.json)
 
 #### skin.inverseBindMatrices
 
 The index of the accessor containing the floating-point 4x4 inverse-bind matrices.  The default is that each matrix is a 4x4 identity matrix, which implies that inverse-bind matrices were pre-applied.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -3540,7 +3729,7 @@ The index of the accessor containing the floating-point 4x4 inverse-bind matrice
 
 The index of the node used as a skeleton root. The node must be the closest common root of the joints hierarchy or a direct or indirect parent node of the closest common root.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -3564,132 +3753,15 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### skin.extras
 
 Application-specific data.
 
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-sparse"></a>
-### sparse
-
-Sparse storage of attributes that deviate from their initialization value.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**count**|`integer`|Number of entries stored in the sparse array.| :white_check_mark: Yes|
-|**indices**|`object`|Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.| :white_check_mark: Yes|
-|**values**|`object`|Array of size `count` times number of components, storing the displaced accessor attributes pointed by [`indices`](#reference-indices). Substituted values must have the same `componentType` and number of components as the base accessor.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [accessor.sparse.schema.json](schema/accessor.sparse.schema.json)
-
-#### sparse.count :white_check_mark: 
-
-The number of attributes encoded in this sparse accessor.
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Minimum**: ` >= 1`
-
-#### sparse.indices :white_check_mark: 
-
-Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.
-
-* **Type**: `object`
-* **Required**: Yes
-
-#### sparse.values :white_check_mark: 
-
-Array of size `count` times number of components, storing the displaced accessor attributes pointed by [`indices`](#reference-indices). Substituted values must have the same `componentType` and number of components as the base accessor.
-
-* **Type**: `object`
-* **Required**: Yes
-
-#### sparse.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### sparse.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-target"></a>
-### target
-
-The index of the node and TRS property that an animation channel targets.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**node**|`integer`|The index of the node to target.|No|
-|**path**|`string`|The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [animation.channel.target.schema.json](schema/animation.channel.target.schema.json)
-
-#### target.node
-
-The index of the node to target.
-
-* **Type**: `integer`
-* **Required**: No
-* **Minimum**: ` >= 0`
-
-#### target.path :white_check_mark: 
-
-The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.
-
-* **Type**: `string`
-* **Required**: Yes
-* **Allowed values**:
-   * `"translation"`
-   * `"rotation"`
-   * `"scale"`
-   * `"weights"`
-
-#### target.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### target.extras
-
-Application-specific data.
-
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -3697,7 +3769,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-texture"></a>
-### texture
+### Texture
 
 A texture and its sampler.
 
@@ -3707,21 +3779,19 @@ A texture and its sampler.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**sampler**|`integer`|The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.|No|
-|**source**|`integer`|The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined.|No|
+|**sampler**|[`glTFid`](#reference-gltfid)|The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.|No|
+|**source**|[`glTFid`](#reference-gltfid)|The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [texture.schema.json](schema/texture.schema.json)
 
 #### texture.sampler
 
 The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -3729,7 +3799,7 @@ The index of the sampler used by this texture. When undefined, a sampler with re
 
 The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: No
 * **Minimum**: ` >= 0`
 
@@ -3744,15 +3814,15 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### texture.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -3760,7 +3830,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-textureinfo"></a>
-### textureInfo
+### Texture Info
 
 Reference to a texture.
 
@@ -3768,20 +3838,18 @@ Reference to a texture.
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**index**|`integer`|The index of the texture.| :white_check_mark: Yes|
+|**index**|[`glTFid`](#reference-gltfid)|The index of the texture.| :white_check_mark: Yes|
 |**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
-
-* **JSON schema**: [textureInfo.schema.json](schema/textureInfo.schema.json)
 
 #### textureInfo.index :white_check_mark: 
 
 The index of the texture.
 
-* **Type**: `integer`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
@@ -3797,68 +3865,15 @@ This integer value is used to construct a string in the format `TEXCOORD_<set in
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: extension
+* **Type of each property**: Extension
 
 #### textureInfo.extras
 
 Application-specific data.
 
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-values"></a>
-### values
-
-Array of size `accessor.sparse.count` times number of components storing the displaced accessor attributes pointed by `accessor.sparse.indices`.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**bufferView**|`integer`|The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
-|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [accessor.sparse.values.schema.json](schema/accessor.sparse.values.schema.json)
-
-#### values.bufferView :white_check_mark: 
-
-The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### values.byteOffset
-
-The offset relative to the start of the bufferView in bytes. Must be aligned.
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### values.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### values.extras
-
-Application-specific data.
-
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 

--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -1652,44 +1652,43 @@ This chunk must be padded with trailing zeros (`0x00`) to satisfy alignment requ
 # Properties Reference
 
 ## Objects
-* [`Accessor`](#reference-accessor)
-   * [`Sparse`](#reference-accessor-sparse)
-      * [`Indices`](#reference-accessor-sparse-indices)
-      * [`Values`](#reference-accessor-sparse-values)
-* [`Animation`](#reference-animation)
-   * [`Channel`](#reference-animation-channel)
-      * [`Target`](#reference-animation-channel-target)
-   * [`Sampler`](#reference-animation-sampler)
-* [`Asset`](#reference-asset)
-* [`Buffer`](#reference-buffer)
-* [`Buffer View`](#reference-bufferview)
-* [`Camera`](#reference-camera)
-   * [`Orthographic`](#reference-camera-orthographic)
-   * [`Perspective`](#reference-camera-perspective)
-* [`Extension`](#reference-extension)
-* [`Extras`](#reference-extras)
+* [`accessor`](#reference-accessor)
+   * [`sparse`](#reference-accessor-sparse)
+      * [`indices`](#reference-accessor-sparse-indices)
+      * [`values`](#reference-accessor-sparse-values)
+* [`animation`](#reference-animation)
+   * [`channel`](#reference-animation-channel)
+      * [`target`](#reference-animation-channel-target)
+* [`asset`](#reference-asset)
+* [`buffer`](#reference-buffer)
+* [`bufferView`](#reference-bufferview)
+* [`camera`](#reference-camera)
+   * [`orthographic`](#reference-camera-orthographic)
+   * [`perspective`](#reference-camera-perspective)
+* [`Child of a glTF root property`](#reference-gltfchildofrootproperty)
+* [`extension`](#reference-extension)
+* [`extras`](#reference-extras)
 * [`glTF`](#reference-gltfproperty) (root object)
-* [`glTF Child of Root Property`](#reference-gltfchildofrootproperty)
-* [`glTF Id`](#reference-gltfid)
-* [`glTF Property`](#reference-gltfproperty)
-* [`Image`](#reference-image)
-* [`Material`](#reference-material)
-   * [`Normal Texture Info`](#reference-material-normaltextureinfo)
-   * [`Occlusion Texture Info`](#reference-material-occlusiontextureinfo)
-   * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
-* [`Mesh`](#reference-mesh)
-   * [`Primitive`](#reference-mesh-primitive)
-* [`Node`](#reference-node)
-* [`Sampler`](#reference-sampler)
-* [`Scene`](#reference-scene)
-* [`Skin`](#reference-skin)
-* [`Texture`](#reference-texture)
-* [`Texture Info`](#reference-textureinfo)
+* [`glTF element index`](#reference-gltfid)
+* [`glTF property`](#reference-gltfproperty)
+* [`image`](#reference-image)
+* [`material`](#reference-material)
+   * [`normalTextureInfo`](#reference-material-normaltextureinfo)
+   * [`occlusionTextureInfo`](#reference-material-occlusiontextureinfo)
+   * [`pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)
+* [`mesh`](#reference-mesh)
+   * [`primitive`](#reference-mesh-primitive)
+* [`node`](#reference-node)
+* [`sampler`](#reference-sampler)
+* [`scene`](#reference-scene)
+* [`skin`](#reference-skin)
+* [`texture`](#reference-texture)
+* [`textureInfo`](#reference-textureinfo)
 
 
 ---------------------------------------
 <a name="reference-accessor"></a>
-### Accessor
+### accessor
 
 A typed view into a bufferView.  A bufferView contains raw binary data.  An accessor provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.
 
@@ -1716,7 +1715,7 @@ Additional properties are allowed.
 
 #### accessor.bufferView
 
-The index of the bufferView. When not defined, accessor must be initialized with zeros; `sparse` property or extensions could override zeros with actual values.
+The index of the bufferView. When not defined, accessor must be initialized with zeros; [`sparse`](#reference-sparse) property or extensions could override zeros with actual values.
 
 * **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: No
@@ -1815,7 +1814,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### accessor.extras
 
@@ -1828,186 +1827,8 @@ Application-specific data.
 
 
 ---------------------------------------
-<a name="reference-accessor-sparse"></a>
-### Accessor Sparse
-
-Sparse storage of attributes that deviate from their initialization value.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**count**|`integer`|Number of entries stored in the sparse array.| :white_check_mark: Yes|
-|**indices**|[`accessor.sparse.indices`](#reference-accessor-sparse-indices)|Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.| :white_check_mark: Yes|
-|**values**|[`accessor.sparse.values`](#reference-accessor-sparse-values)|Array of size `count` times number of components, storing the displaced accessor attributes pointed by `indices`. Substituted values must have the same `componentType` and number of components as the base accessor.| :white_check_mark: Yes|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [accessor.sparse.schema.json](schema/accessor.sparse.schema.json)
-
-#### accessor.sparse.count :white_check_mark: 
-
-The number of attributes encoded in this sparse accessor.
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Minimum**: ` >= 1`
-
-#### accessor.sparse.indices :white_check_mark: 
-
-Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.
-
-* **Type**: [`accessor.sparse.indices`](#reference-accessor-sparse-indices)
-* **Required**: Yes
-
-#### accessor.sparse.values :white_check_mark: 
-
-Array of size `count` times number of components, storing the displaced accessor attributes pointed by `indices`. Substituted values must have the same `componentType` and number of components as the base accessor.
-
-* **Type**: [`accessor.sparse.values`](#reference-accessor-sparse-values)
-* **Required**: Yes
-
-#### accessor.sparse.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: Extension
-
-#### accessor.sparse.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-accessor-sparse-indices"></a>
-### Accessor Sparse Indices
-
-Indices of those attributes that deviate from their initialization value.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
-|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
-|**componentType**|`integer`|The indices data type.| :white_check_mark: Yes|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [accessor.sparse.indices.schema.json](schema/accessor.sparse.indices.schema.json)
-
-#### accessor.sparse.indices.bufferView :white_check_mark: 
-
-The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### accessor.sparse.indices.byteOffset
-
-The offset relative to the start of the bufferView in bytes. Must be aligned.
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### accessor.sparse.indices.componentType :white_check_mark: 
-
-The indices data type.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `5123` (UNSIGNED_SHORT), `5125` (UNSIGNED_INT).
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Allowed values**:
-   * `5121` UNSIGNED_BYTE
-   * `5123` UNSIGNED_SHORT
-   * `5125` UNSIGNED_INT
-
-#### accessor.sparse.indices.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: Extension
-
-#### accessor.sparse.indices.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-accessor-sparse-values"></a>
-### Accessor Sparse Values
-
-Array of size `accessor.sparse.count` times number of components storing the displaced accessor attributes pointed by `accessor.sparse.indices`.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
-|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [accessor.sparse.values.schema.json](schema/accessor.sparse.values.schema.json)
-
-#### accessor.sparse.values.bufferView :white_check_mark: 
-
-The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### accessor.sparse.values.byteOffset
-
-The offset relative to the start of the bufferView in bytes. Must be aligned.
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### accessor.sparse.values.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: Extension
-
-#### accessor.sparse.values.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
 <a name="reference-animation"></a>
-### Animation
+### animation
 
 A keyframe animation.
 
@@ -2052,7 +1873,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### animation.extras
 
@@ -2065,182 +1886,8 @@ Application-specific data.
 
 
 ---------------------------------------
-<a name="reference-animation-channel"></a>
-### Animation Channel
-
-Targets an animation's sampler at a node's property.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**sampler**|[`glTFid`](#reference-gltfid)|The index of a sampler in this animation used to compute the value for the target.| :white_check_mark: Yes|
-|**target**|[`animation.channel.target`](#reference-animation-channel-target)|The index of the node and TRS property to target.| :white_check_mark: Yes|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [animation.channel.schema.json](schema/animation.channel.schema.json)
-
-#### animation.channel.sampler :white_check_mark: 
-
-The index of a sampler in this animation used to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS).
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### animation.channel.target :white_check_mark: 
-
-The index of the node and TRS property to target.
-
-* **Type**: [`animation.channel.target`](#reference-animation-channel-target)
-* **Required**: Yes
-
-#### animation.channel.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: Extension
-
-#### animation.channel.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-animation-channel-target"></a>
-### Animation Channel Target
-
-The index of the node and TRS property that an animation channel targets.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**node**|[`glTFid`](#reference-gltfid)|The index of the node to target.|No|
-|**path**|`string`|The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.| :white_check_mark: Yes|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [animation.channel.target.schema.json](schema/animation.channel.target.schema.json)
-
-#### animation.channel.target.node
-
-The index of the node to target.
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: No
-* **Minimum**: ` >= 0`
-
-#### animation.channel.target.path :white_check_mark: 
-
-The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.
-
-* **Type**: `string`
-* **Required**: Yes
-* **Allowed values**:
-   * `"translation"`
-   * `"rotation"`
-   * `"scale"`
-   * `"weights"`
-
-#### animation.channel.target.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: Extension
-
-#### animation.channel.target.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-animation-sampler"></a>
-### Animation Sampler
-
-Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**input**|[`glTFid`](#reference-gltfid)|The index of an accessor containing keyframe input values, e.g., time.| :white_check_mark: Yes|
-|**interpolation**|`string`|Interpolation algorithm.|No, default: `"LINEAR"`|
-|**output**|[`glTFid`](#reference-gltfid)|The index of an accessor, containing keyframe output values.| :white_check_mark: Yes|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
-
-#### animation.sampler.input :white_check_mark: 
-
-The index of an accessor containing keyframe input values, e.g., time. That accessor must have componentType `FLOAT`. The values represent time in seconds with `time[0] >= 0.0`, and strictly increasing values, i.e., `time[n + 1] > time[n]`.
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### animation.sampler.interpolation
-
-Interpolation algorithm.
-
-* **Type**: `string`
-* **Required**: No, default: `"LINEAR"`
-* **Allowed values**:
-   * `"LINEAR"` The animated values are linearly interpolated between keyframes. When targeting a rotation, spherical linear interpolation (slerp) should be used to interpolate quaternions. The number output of elements must equal the number of input elements.
-   * `"STEP"` The animated values remain constant to the output of the first keyframe, until the next keyframe. The number of output elements must equal the number of input elements.
-   * `"CUBICSPLINE"` The animation's interpolation is computed using a cubic spline with specified tangents. The number of output elements must equal three times the number of input elements. For each input element, the output stores three elements, an in-tangent, a spline vertex, and an out-tangent. There must be at least two keyframes when using this interpolation.
-
-#### animation.sampler.output :white_check_mark: 
-
-The index of an accessor containing keyframe output values. When targeting translation or scale paths, the `accessor.componentType` of the output values must be `FLOAT`. When targeting rotation or morph weights, the `accessor.componentType` of the output values must be `FLOAT` or normalized integer. For weights, each output element stores `SCALAR` values with a count equal to the number of morph targets.
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### animation.sampler.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: Extension
-
-#### animation.sampler.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
 <a name="reference-asset"></a>
-### Asset
+### asset
 
 Metadata about the glTF asset.
 
@@ -2293,7 +1940,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### asset.extras
 
@@ -2307,7 +1954,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-buffer"></a>
-### Buffer
+### buffer
 
 A buffer points to binary geometry, animation, or skins.
 
@@ -2354,7 +2001,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### buffer.extras
 
@@ -2368,7 +2015,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-bufferview"></a>
-### Buffer View
+### bufferView
 
 A view into a buffer generally representing a subset of the buffer.
 
@@ -2447,7 +2094,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### bufferView.extras
 
@@ -2461,7 +2108,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-camera"></a>
-### Camera
+### camera
 
 A camera's projection.  A node can reference a camera to apply a transform to place the camera in the scene.
 
@@ -2496,7 +2143,7 @@ A perspective camera containing properties to create a perspective projection ma
 
 #### camera.type :white_check_mark: 
 
-Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's `perspective` or `orthographic` property will be defined.
+Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's [`perspective`](#reference-perspective) or [`orthographic`](#reference-orthographic) property will be defined.
 
 * **Type**: `string`
 * **Required**: Yes
@@ -2517,7 +2164,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### camera.extras
 
@@ -2530,65 +2177,48 @@ Application-specific data.
 
 
 ---------------------------------------
-<a name="reference-camera-orthographic"></a>
-### Camera Orthographic
+<a name="reference-animation-channel"></a>
+### channel
 
-An orthographic camera containing properties to create an orthographic projection matrix.
+Targets an animation's sampler at a node's property.
 
 **Properties**
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**xmag**|`number`|The floating-point horizontal magnification of the view. Must not be zero.| :white_check_mark: Yes|
-|**ymag**|`number`|The floating-point vertical magnification of the view. Must not be zero.| :white_check_mark: Yes|
-|**zfar**|`number`|The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.| :white_check_mark: Yes|
-|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
+|**sampler**|[`glTFid`](#reference-gltfid)|The index of a sampler in this animation used to compute the value for the target.| :white_check_mark: Yes|
+|**target**|[`animation.channel.target`](#reference-animation-channel-target)|The index of the node and TRS property to target.| :white_check_mark: Yes|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
-* **JSON schema**: [camera.orthographic.schema.json](schema/camera.orthographic.schema.json)
+* **JSON schema**: [animation.channel.schema.json](schema/animation.channel.schema.json)
 
-#### camera.orthographic.xmag :white_check_mark: 
+#### animation.channel.sampler :white_check_mark: 
 
-The floating-point horizontal magnification of the view. Must not be zero.
+The index of a sampler in this animation used to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS).
 
-* **Type**: `number`
-* **Required**: Yes
-
-#### camera.orthographic.ymag :white_check_mark: 
-
-The floating-point vertical magnification of the view. Must not be zero.
-
-* **Type**: `number`
-* **Required**: Yes
-
-#### camera.orthographic.zfar :white_check_mark: 
-
-The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.
-
-* **Type**: `number`
-* **Required**: Yes
-* **Minimum**: ` > 0`
-
-#### camera.orthographic.znear :white_check_mark: 
-
-The floating-point distance to the near clipping plane.
-
-* **Type**: `number`
+* **Type**: [`glTFid`](#reference-gltfid)
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
-#### camera.orthographic.extensions
+#### animation.channel.target :white_check_mark: 
+
+The index of the node and TRS property to target.
+
+* **Type**: [`animation.channel.target`](#reference-animation-channel-target)
+* **Required**: Yes
+
+#### animation.channel.extensions
 
 Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
-#### camera.orthographic.extras
+#### animation.channel.extras
 
 Application-specific data.
 
@@ -2599,67 +2229,37 @@ Application-specific data.
 
 
 ---------------------------------------
-<a name="reference-camera-perspective"></a>
-### Camera Perspective
-
-A perspective camera containing properties to create a perspective projection matrix.
+<a name="reference-gltfchildofrootproperty"></a>
+### Child of a glTF root property
 
 **Properties**
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
-|**aspectRatio**|`number`|The floating-point aspect ratio of the field of view.|No|
-|**yfov**|`number`|The floating-point vertical field of view in radians.| :white_check_mark: Yes|
-|**zfar**|`number`|The floating-point distance to the far clipping plane.|No|
-|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
+|**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
-* **JSON schema**: [camera.perspective.schema.json](schema/camera.perspective.schema.json)
+* **JSON schema**: [glTFChildOfRootProperty.schema.json](schema/glTFChildOfRootProperty.schema.json)
 
-#### camera.perspective.aspectRatio
+#### glTFChildOfRootProperty.name
 
-The floating-point aspect ratio of the field of view. When this is undefined, the aspect ratio of the canvas is used.
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
 
-* **Type**: `number`
+* **Type**: `string`
 * **Required**: No
-* **Minimum**: ` > 0`
 
-#### camera.perspective.yfov :white_check_mark: 
-
-The floating-point vertical field of view in radians.
-
-* **Type**: `number`
-* **Required**: Yes
-* **Minimum**: ` > 0`
-
-#### camera.perspective.zfar
-
-The floating-point distance to the far clipping plane. When defined, `zfar` must be greater than `znear`. If `zfar` is undefined, runtime must use infinite projection matrix.
-
-* **Type**: `number`
-* **Required**: No
-* **Minimum**: ` > 0`
-
-#### camera.perspective.znear :white_check_mark: 
-
-The floating-point distance to the near clipping plane.
-
-* **Type**: `number`
-* **Required**: Yes
-* **Minimum**: ` > 0`
-
-#### camera.perspective.extensions
+#### glTFChildOfRootProperty.extensions
 
 Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
-#### camera.perspective.extras
+#### glTFChildOfRootProperty.extras
 
 Application-specific data.
 
@@ -2671,7 +2271,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-extension"></a>
-### Extension
+### extension
 
 Dictionary object with extension-specific objects.
 
@@ -2684,7 +2284,7 @@ Additional properties are allowed.
 
 ---------------------------------------
 <a name="reference-extras"></a>
-### Extras
+### extras
 
 Application-specific data.
 
@@ -2852,7 +2452,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### glTFProperty.extras
 
@@ -2865,55 +2465,14 @@ Application-specific data.
 
 
 ---------------------------------------
-<a name="reference-gltfchildofrootproperty"></a>
-### glTF Child of Root Property
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [glTFChildOfRootProperty.schema.json](schema/glTFChildOfRootProperty.schema.json)
-
-#### glTFChildOfRootProperty.name
-
-The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
-
-* **Type**: `string`
-* **Required**: No
-
-#### glTFChildOfRootProperty.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: Extension
-
-#### glTFChildOfRootProperty.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
 <a name="reference-gltfid"></a>
-### glTF Id
+### glTF element index
 
 
 
 ---------------------------------------
 <a name="reference-gltfproperty"></a>
-### glTF Property
+### glTF property
 
 **Properties**
 
@@ -2932,7 +2491,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### glTFProperty.extras
 
@@ -2946,16 +2505,16 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-image"></a>
-### Image
+### image
 
-Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.
+Image data used to create a texture. Image can be referenced by URI or [`bufferView`](#reference-bufferview) index. `mimeType` is required in the latter case.
 
 **Properties**
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**uri**|`string`|The uri of the image.|No|
-|**mimeType**|`string`|The image's MIME type. Required if `bufferView` is defined.|No|
+|**mimeType**|`string`|The image's MIME type. Required if [`bufferView`](#reference-bufferview) is defined.|No|
 |**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
@@ -2975,7 +2534,7 @@ The uri of the image.  Relative paths are relative to the .gltf file.  Instead o
 
 #### image.mimeType
 
-The image's MIME type. Required if `bufferView` is defined.
+The image's MIME type. Required if [`bufferView`](#reference-bufferview) is defined.
 
 * **Type**: `string`
 * **Required**: No
@@ -3004,7 +2563,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### image.extras
 
@@ -3017,8 +2576,73 @@ Application-specific data.
 
 
 ---------------------------------------
+<a name="reference-accessor-sparse-indices"></a>
+### indices
+
+Indices of those attributes that deviate from their initialization value.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
+|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
+|**componentType**|`integer`|The indices data type.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [accessor.sparse.indices.schema.json](schema/accessor.sparse.indices.schema.json)
+
+#### accessor.sparse.indices.bufferView :white_check_mark: 
+
+The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.indices.byteOffset
+
+The offset relative to the start of the bufferView in bytes. Must be aligned.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.indices.componentType :white_check_mark: 
+
+The indices data type.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `5123` (UNSIGNED_SHORT), `5125` (UNSIGNED_INT).
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Allowed values**:
+   * `5121` UNSIGNED_BYTE
+   * `5123` UNSIGNED_SHORT
+   * `5125` UNSIGNED_INT
+
+#### accessor.sparse.indices.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### accessor.sparse.indices.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
 <a name="reference-material"></a>
-### Material
+### material
 
 The material appearance of a primitive.
 
@@ -3029,7 +2653,7 @@ The material appearance of a primitive.
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-|**pbrMetallicRoughness**|[`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.|No|
+|**pbrMetallicRoughness**|[`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of [`pbrMetallicRoughness`](#reference-pbrmetallicroughness) apply.|No|
 |**normalTexture**|[`material.normalTextureInfo`](#reference-material-normaltextureinfo)|The normal map texture.|No|
 |**occlusionTexture**|[`material.occlusionTextureInfo`](#reference-material-occlusiontextureinfo)|The occlusion map texture.|No|
 |**emissiveTexture**|[`textureInfo`](#reference-textureinfo)|The emissive map texture.|No|
@@ -3055,7 +2679,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### material.extras
 
@@ -3066,7 +2690,7 @@ Application-specific data.
 
 #### material.pbrMetallicRoughness
 
-A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of [`pbrMetallicRoughness`](#reference-pbrmetallicroughness) apply.
 
 * **Type**: [`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)
 * **Required**: No
@@ -3130,212 +2754,8 @@ Specifies whether the material is double sided. When this value is false, back-f
 
 
 ---------------------------------------
-<a name="reference-material-normaltextureinfo"></a>
-### Material Normal Texture Info
-
-Reference to a texture.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**index**|[`glTFid`](#reference-gltfid)|The index of the texture.| :white_check_mark: Yes|
-|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
-|**scale**|`number`|The scalar multiplier applied to each normal vector of the normal texture.|No, default: `1`|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [material.normalTextureInfo.schema.json](schema/material.normalTextureInfo.schema.json)
-
-#### material.normalTextureInfo.index :white_check_mark: 
-
-The index of the texture.
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### material.normalTextureInfo.texCoord
-
-This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### material.normalTextureInfo.scale
-
-The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-
-#### material.normalTextureInfo.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: Extension
-
-#### material.normalTextureInfo.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-material-occlusiontextureinfo"></a>
-### Material Occlusion Texture Info
-
-Reference to a texture.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**index**|[`glTFid`](#reference-gltfid)|The index of the texture.| :white_check_mark: Yes|
-|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
-|**strength**|`number`|A scalar multiplier controlling the amount of occlusion applied.|No, default: `1`|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [material.occlusionTextureInfo.schema.json](schema/material.occlusionTextureInfo.schema.json)
-
-#### material.occlusionTextureInfo.index :white_check_mark: 
-
-The index of the texture.
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### material.occlusionTextureInfo.texCoord
-
-This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### material.occlusionTextureInfo.strength
-
-A scalar multiplier controlling the amount of occlusion applied. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion. This value affects the resulting color using the formula: `occludedColor = lerp(color, color * <sampled occlusion texture value>, <occlusion strength>)`. This value is ignored if the corresponding texture is not specified. This value is linear.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-* **Minimum**: ` >= 0`
-* **Maximum**: ` <= 1`
-
-#### material.occlusionTextureInfo.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: Extension
-
-#### material.occlusionTextureInfo.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-material-pbrmetallicroughness"></a>
-### Material PBR Metallic Roughness
-
-A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**baseColorFactor**|`number` `[4]`|The material's base color factor.|No, default: `[1,1,1,1]`|
-|**baseColorTexture**|[`textureInfo`](#reference-textureinfo)|The base color texture.|No|
-|**metallicFactor**|`number`|The metalness of the material.|No, default: `1`|
-|**roughnessFactor**|`number`|The roughness of the material.|No, default: `1`|
-|**metallicRoughnessTexture**|[`textureInfo`](#reference-textureinfo)|The metallic-roughness texture.|No|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [material.pbrMetallicRoughness.schema.json](schema/material.pbrMetallicRoughness.schema.json)
-
-#### material.pbrMetallicRoughness.baseColorFactor
-
-The RGBA components of the base color of the material. The fourth component (A) is the alpha coverage of the material. The `alphaMode` property specifies how alpha is interpreted. These values are linear. If a baseColorTexture is specified, this value is multiplied with the texel values.
-
-* **Type**: `number` `[4]`
-   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
-* **Required**: No, default: `[1,1,1,1]`
-
-#### material.pbrMetallicRoughness.baseColorTexture
-
-The base color texture. The first three components (RGB) are encoded with the sRGB transfer function. They specify the base color of the material. If the fourth component (A) is present, it represents the linear alpha coverage of the material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property specifies how alpha is interpreted. The stored texels must not be premultiplied.
-
-* **Type**: [`textureInfo`](#reference-textureinfo)
-* **Required**: No
-
-#### material.pbrMetallicRoughness.metallicFactor
-
-The metalness of the material. A value of 1.0 means the material is a metal. A value of 0.0 means the material is a dielectric. Values in between are for blending between metals and dielectrics such as dirty metallic surfaces. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the metallic texel values.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-* **Minimum**: ` >= 0`
-* **Maximum**: ` <= 1`
-
-#### material.pbrMetallicRoughness.roughnessFactor
-
-The roughness of the material. A value of 1.0 means the material is completely rough. A value of 0.0 means the material is completely smooth. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the roughness texel values.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-* **Minimum**: ` >= 0`
-* **Maximum**: ` <= 1`
-
-#### material.pbrMetallicRoughness.metallicRoughnessTexture
-
-The metallic-roughness texture. The metalness values are sampled from the B channel. The roughness values are sampled from the G channel. These values are linear. If other channels are present (R or A), they are ignored for metallic-roughness calculations.
-
-* **Type**: [`textureInfo`](#reference-textureinfo)
-* **Required**: No
-
-#### material.pbrMetallicRoughness.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: Extension
-
-#### material.pbrMetallicRoughness.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
 <a name="reference-mesh"></a>
-### Mesh
+### mesh
 
 A set of primitives to be rendered.  A node can contain one mesh.  A node's transform places the mesh in the scene.
 
@@ -3380,7 +2800,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### mesh.extras
 
@@ -3393,98 +2813,10 @@ Application-specific data.
 
 
 ---------------------------------------
-<a name="reference-mesh-primitive"></a>
-### Mesh Primitive
-
-Geometry to be rendered with the given material.
-
-**Related WebGL functions**: `drawElements()` and `drawArrays()`
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**attributes**|`object`|A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.| :white_check_mark: Yes|
-|**indices**|[`glTFid`](#reference-gltfid)|The index of the accessor that contains the indices.|No|
-|**material**|[`glTFid`](#reference-gltfid)|The index of the material to apply to this primitive when rendering.|No|
-|**mode**|`integer`|The type of primitives to render.|No, default: `4`|
-|**targets**|`object` `[1-*]`|An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.|No|
-|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
-|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [mesh.primitive.schema.json](schema/mesh.primitive.schema.json)
-
-#### mesh.primitive.attributes :white_check_mark: 
-
-A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.
-
-* **Type**: `object`
-* **Required**: Yes
-* **Type of each property**: `glTFid`
-
-#### mesh.primitive.indices
-
-The index of the accessor that contains mesh indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.  When defined, the accessor must contain indices: the `bufferView` referenced by the accessor should have a `target` equal to 34963 (ELEMENT_ARRAY_BUFFER); `componentType` must be 5121 (UNSIGNED_BYTE), 5123 (UNSIGNED_SHORT) or 5125 (UNSIGNED_INT), the latter may require enabling additional hardware support; `type` must be `"SCALAR"`. For triangle primitives, the front face has a counter-clockwise (CCW) winding order. Values of the index accessor must not include the maximum value for the given component type, which triggers primitive restart in several graphics APIs and would require client implementations to rebuild the index buffer. Primitive restart values are disallowed and all index values must refer to actual vertices. As a result, the index accessor's values must not exceed the following maxima: BYTE `< 255`, UNSIGNED_SHORT `< 65535`, UNSIGNED_INT `< 4294967295`.
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: No
-* **Minimum**: ` >= 0`
-
-#### mesh.primitive.material
-
-The index of the material to apply to this primitive when rendering.
-
-* **Type**: [`glTFid`](#reference-gltfid)
-* **Required**: No
-* **Minimum**: ` >= 0`
-
-#### mesh.primitive.mode
-
-The type of primitives to render. All valid values correspond to WebGL enums.
-
-* **Type**: `integer`
-* **Required**: No, default: `4`
-* **Allowed values**:
-   * `0` POINTS
-   * `1` LINES
-   * `2` LINE_LOOP
-   * `3` LINE_STRIP
-   * `4` TRIANGLES
-   * `5` TRIANGLE_STRIP
-   * `6` TRIANGLE_FAN
-
-#### mesh.primitive.targets
-
-An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.
-
-* **Type**: `object` `[1-*]`
-* **Required**: No
-
-#### mesh.primitive.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: [`extension`](#reference-extension)
-* **Required**: No
-* **Type of each property**: Extension
-
-#### mesh.primitive.extras
-
-Application-specific data.
-
-* **Type**: [`extras`](#reference-extras)
-* **Required**: No
-
-
-
-
----------------------------------------
 <a name="reference-node"></a>
-### Node
+### node
 
-A node in the node hierarchy.  When the node contains `skin`, all `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.
+A node in the node hierarchy.  When the node contains [`skin`](#reference-skin), all `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.
 
 **Properties**
 
@@ -3590,7 +2922,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### node.extras
 
@@ -3603,8 +2935,440 @@ Application-specific data.
 
 
 ---------------------------------------
+<a name="reference-material-normaltextureinfo"></a>
+### normalTextureInfo
+
+Reference to a texture.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**index**|[`glTFid`](#reference-gltfid)|The index of the texture.| :white_check_mark: Yes|
+|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
+|**scale**|`number`|The scalar multiplier applied to each normal vector of the normal texture.|No, default: `1`|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [material.normalTextureInfo.schema.json](schema/material.normalTextureInfo.schema.json)
+
+#### material.normalTextureInfo.index :white_check_mark: 
+
+The index of the texture.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### material.normalTextureInfo.texCoord
+
+This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### material.normalTextureInfo.scale
+
+The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+
+#### material.normalTextureInfo.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### material.normalTextureInfo.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-material-occlusiontextureinfo"></a>
+### occlusionTextureInfo
+
+Reference to a texture.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**index**|[`glTFid`](#reference-gltfid)|The index of the texture.| :white_check_mark: Yes|
+|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
+|**strength**|`number`|A scalar multiplier controlling the amount of occlusion applied.|No, default: `1`|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [material.occlusionTextureInfo.schema.json](schema/material.occlusionTextureInfo.schema.json)
+
+#### material.occlusionTextureInfo.index :white_check_mark: 
+
+The index of the texture.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### material.occlusionTextureInfo.texCoord
+
+This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### material.occlusionTextureInfo.strength
+
+A scalar multiplier controlling the amount of occlusion applied. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion. This value affects the resulting color using the formula: `occludedColor = lerp(color, color * <sampled occlusion texture value>, <occlusion strength>)`. This value is ignored if the corresponding texture is not specified. This value is linear.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.occlusionTextureInfo.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### material.occlusionTextureInfo.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-camera-orthographic"></a>
+### orthographic
+
+An orthographic camera containing properties to create an orthographic projection matrix.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**xmag**|`number`|The floating-point horizontal magnification of the view. Must not be zero.| :white_check_mark: Yes|
+|**ymag**|`number`|The floating-point vertical magnification of the view. Must not be zero.| :white_check_mark: Yes|
+|**zfar**|`number`|The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.| :white_check_mark: Yes|
+|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [camera.orthographic.schema.json](schema/camera.orthographic.schema.json)
+
+#### camera.orthographic.xmag :white_check_mark: 
+
+The floating-point horizontal magnification of the view. Must not be zero.
+
+* **Type**: `number`
+* **Required**: Yes
+
+#### camera.orthographic.ymag :white_check_mark: 
+
+The floating-point vertical magnification of the view. Must not be zero.
+
+* **Type**: `number`
+* **Required**: Yes
+
+#### camera.orthographic.zfar :white_check_mark: 
+
+The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+#### camera.orthographic.znear :white_check_mark: 
+
+The floating-point distance to the near clipping plane.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### camera.orthographic.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### camera.orthographic.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-material-pbrmetallicroughness"></a>
+### pbrMetallicRoughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**baseColorFactor**|`number` `[4]`|The material's base color factor.|No, default: `[1,1,1,1]`|
+|**baseColorTexture**|[`textureInfo`](#reference-textureinfo)|The base color texture.|No|
+|**metallicFactor**|`number`|The metalness of the material.|No, default: `1`|
+|**roughnessFactor**|`number`|The roughness of the material.|No, default: `1`|
+|**metallicRoughnessTexture**|[`textureInfo`](#reference-textureinfo)|The metallic-roughness texture.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [material.pbrMetallicRoughness.schema.json](schema/material.pbrMetallicRoughness.schema.json)
+
+#### material.pbrMetallicRoughness.baseColorFactor
+
+The RGBA components of the base color of the material. The fourth component (A) is the alpha coverage of the material. The `alphaMode` property specifies how alpha is interpreted. These values are linear. If a baseColorTexture is specified, this value is multiplied with the texel values.
+
+* **Type**: `number` `[4]`
+   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[1,1,1,1]`
+
+#### material.pbrMetallicRoughness.baseColorTexture
+
+The base color texture. The first three components (RGB) are encoded with the sRGB transfer function. They specify the base color of the material. If the fourth component (A) is present, it represents the linear alpha coverage of the material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property specifies how alpha is interpreted. The stored texels must not be premultiplied.
+
+* **Type**: [`textureInfo`](#reference-textureinfo)
+* **Required**: No
+
+#### material.pbrMetallicRoughness.metallicFactor
+
+The metalness of the material. A value of 1.0 means the material is a metal. A value of 0.0 means the material is a dielectric. Values in between are for blending between metals and dielectrics such as dirty metallic surfaces. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the metallic texel values.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.pbrMetallicRoughness.roughnessFactor
+
+The roughness of the material. A value of 1.0 means the material is completely rough. A value of 0.0 means the material is completely smooth. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the roughness texel values.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.pbrMetallicRoughness.metallicRoughnessTexture
+
+The metallic-roughness texture. The metalness values are sampled from the B channel. The roughness values are sampled from the G channel. These values are linear. If other channels are present (R or A), they are ignored for metallic-roughness calculations.
+
+* **Type**: [`textureInfo`](#reference-textureinfo)
+* **Required**: No
+
+#### material.pbrMetallicRoughness.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### material.pbrMetallicRoughness.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-camera-perspective"></a>
+### perspective
+
+A perspective camera containing properties to create a perspective projection matrix.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**aspectRatio**|`number`|The floating-point aspect ratio of the field of view.|No|
+|**yfov**|`number`|The floating-point vertical field of view in radians.| :white_check_mark: Yes|
+|**zfar**|`number`|The floating-point distance to the far clipping plane.|No|
+|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [camera.perspective.schema.json](schema/camera.perspective.schema.json)
+
+#### camera.perspective.aspectRatio
+
+The floating-point aspect ratio of the field of view. When this is undefined, the aspect ratio of the canvas is used.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+
+#### camera.perspective.yfov :white_check_mark: 
+
+The floating-point vertical field of view in radians.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+#### camera.perspective.zfar
+
+The floating-point distance to the far clipping plane. When defined, `zfar` must be greater than `znear`. If `zfar` is undefined, runtime must use infinite projection matrix.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+
+#### camera.perspective.znear :white_check_mark: 
+
+The floating-point distance to the near clipping plane.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+#### camera.perspective.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### camera.perspective.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-mesh-primitive"></a>
+### primitive
+
+Geometry to be rendered with the given material.
+
+**Related WebGL functions**: `drawElements()` and `drawArrays()`
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**attributes**|`object`|A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.| :white_check_mark: Yes|
+|**indices**|[`glTFid`](#reference-gltfid)|The index of the accessor that contains the indices.|No|
+|**material**|[`glTFid`](#reference-gltfid)|The index of the material to apply to this primitive when rendering.|No|
+|**mode**|`integer`|The type of primitives to render.|No, default: `4`|
+|**targets**|`object` `[1-*]`|An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [mesh.primitive.schema.json](schema/mesh.primitive.schema.json)
+
+#### mesh.primitive.attributes :white_check_mark: 
+
+A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.
+
+* **Type**: `object`
+* **Required**: Yes
+* **Type of each property**: `glTFid`
+
+#### mesh.primitive.indices
+
+The index of the accessor that contains mesh indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.  When defined, the accessor must contain indices: the [`bufferView`](#reference-bufferview) referenced by the accessor should have a [`target`](#reference-target) equal to 34963 (ELEMENT_ARRAY_BUFFER); `componentType` must be 5121 (UNSIGNED_BYTE), 5123 (UNSIGNED_SHORT) or 5125 (UNSIGNED_INT), the latter may require enabling additional hardware support; `type` must be `"SCALAR"`. For triangle primitives, the front face has a counter-clockwise (CCW) winding order. Values of the index accessor must not include the maximum value for the given component type, which triggers primitive restart in several graphics APIs and would require client implementations to rebuild the index buffer. Primitive restart values are disallowed and all index values must refer to actual vertices. As a result, the index accessor's values must not exceed the following maxima: BYTE `< 255`, UNSIGNED_SHORT `< 65535`, UNSIGNED_INT `< 4294967295`.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### mesh.primitive.material
+
+The index of the material to apply to this primitive when rendering.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### mesh.primitive.mode
+
+The type of primitives to render. All valid values correspond to WebGL enums.
+
+* **Type**: `integer`
+* **Required**: No, default: `4`
+* **Allowed values**:
+   * `0` POINTS
+   * `1` LINES
+   * `2` LINE_LOOP
+   * `3` LINE_STRIP
+   * `4` TRIANGLES
+   * `5` TRIANGLE_STRIP
+   * `6` TRIANGLE_FAN
+
+#### mesh.primitive.targets
+
+An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.
+
+* **Type**: `object` `[1-*]`
+* **Required**: No
+
+#### mesh.primitive.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### mesh.primitive.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
 <a name="reference-sampler"></a>
-### Sampler
+### sampler
 
 Texture sampler properties for filtering and wrapping modes.
 
@@ -3689,7 +3453,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### sampler.extras
 
@@ -3703,7 +3467,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-scene"></a>
-### Scene
+### scene
 
 The root nodes of a scene.
 
@@ -3742,7 +3506,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### scene.extras
 
@@ -3756,7 +3520,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-skin"></a>
-### Skin
+### skin
 
 Joints and matrices defining a skin.
 
@@ -3813,7 +3577,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### skin.extras
 
@@ -3826,8 +3590,125 @@ Application-specific data.
 
 
 ---------------------------------------
+<a name="reference-accessor-sparse"></a>
+### sparse
+
+Sparse storage of attributes that deviate from their initialization value.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**count**|`integer`|Number of entries stored in the sparse array.| :white_check_mark: Yes|
+|**indices**|[`accessor.sparse.indices`](#reference-accessor-sparse-indices)|Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.| :white_check_mark: Yes|
+|**values**|[`accessor.sparse.values`](#reference-accessor-sparse-values)|Array of size `count` times number of components, storing the displaced accessor attributes pointed by [`indices`](#reference-indices). Substituted values must have the same `componentType` and number of components as the base accessor.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [accessor.sparse.schema.json](schema/accessor.sparse.schema.json)
+
+#### accessor.sparse.count :white_check_mark: 
+
+The number of attributes encoded in this sparse accessor.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+#### accessor.sparse.indices :white_check_mark: 
+
+Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.
+
+* **Type**: [`accessor.sparse.indices`](#reference-accessor-sparse-indices)
+* **Required**: Yes
+
+#### accessor.sparse.values :white_check_mark: 
+
+Array of size `count` times number of components, storing the displaced accessor attributes pointed by [`indices`](#reference-indices). Substituted values must have the same `componentType` and number of components as the base accessor.
+
+* **Type**: [`accessor.sparse.values`](#reference-accessor-sparse-values)
+* **Required**: Yes
+
+#### accessor.sparse.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### accessor.sparse.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-animation-channel-target"></a>
+### target
+
+The index of the node and TRS property that an animation channel targets.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**node**|[`glTFid`](#reference-gltfid)|The index of the node to target.|No|
+|**path**|`string`|The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [animation.channel.target.schema.json](schema/animation.channel.target.schema.json)
+
+#### animation.channel.target.node
+
+The index of the node to target.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### animation.channel.target.path :white_check_mark: 
+
+The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+   * `"translation"`
+   * `"rotation"`
+   * `"scale"`
+   * `"weights"`
+
+#### animation.channel.target.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### animation.channel.target.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
 <a name="reference-texture"></a>
-### Texture
+### texture
 
 A texture and its sampler.
 
@@ -3876,7 +3757,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### texture.extras
 
@@ -3890,7 +3771,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-textureinfo"></a>
-### Texture Info
+### textureInfo
 
 Reference to a texture.
 
@@ -3929,9 +3810,62 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: extension
 
 #### textureInfo.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-accessor-sparse-values"></a>
+### values
+
+Array of size `accessor.sparse.count` times number of components storing the displaced accessor attributes pointed by `accessor.sparse.indices`.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**bufferView**|[`glTFid`](#reference-gltfid)|The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
+|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [accessor.sparse.values.schema.json](schema/accessor.sparse.values.schema.json)
+
+#### accessor.sparse.values.bufferView :white_check_mark: 
+
+The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.values.byteOffset
+
+The offset relative to the start of the bufferView in bytes. Must be aligned.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.values.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### accessor.sparse.values.extras
 
 Application-specific data.
 

--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -1659,6 +1659,7 @@ This chunk must be padded with trailing zeros (`0x00`) to satisfy alignment requ
 * [`animation`](#reference-animation)
    * [`channel`](#reference-animation-channel)
       * [`target`](#reference-animation-channel-target)
+   * [`sampler`](#reference-animation-sampler)
 * [`asset`](#reference-asset)
 * [`buffer`](#reference-buffer)
 * [`bufferView`](#reference-bufferview)
@@ -3357,6 +3358,71 @@ Dictionary object with extension-specific objects.
 * **Type of each property**: extension
 
 #### mesh.primitive.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-animation-sampler"></a>
+### sampler
+
+Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**input**|[`glTFid`](#reference-gltfid)|The index of an accessor containing keyframe input values, e.g., time.| :white_check_mark: Yes|
+|**interpolation**|`string`|Interpolation algorithm.|No, default: `"LINEAR"`|
+|**output**|[`glTFid`](#reference-gltfid)|The index of an accessor, containing keyframe output values.| :white_check_mark: Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
+
+#### animation.sampler.input :white_check_mark: 
+
+The index of an accessor containing keyframe input values, e.g., time. That accessor must have componentType `FLOAT`. The values represent time in seconds with `time[0] >= 0.0`, and strictly increasing values, i.e., `time[n + 1] > time[n]`.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### animation.sampler.interpolation
+
+Interpolation algorithm.
+
+* **Type**: `string`
+* **Required**: No, default: `"LINEAR"`
+* **Allowed values**:
+   * `"LINEAR"` The animated values are linearly interpolated between keyframes. When targeting a rotation, spherical linear interpolation (slerp) should be used to interpolate quaternions. The number output of elements must equal the number of input elements.
+   * `"STEP"` The animated values remain constant to the output of the first keyframe, until the next keyframe. The number of output elements must equal the number of input elements.
+   * `"CUBICSPLINE"` The animation's interpolation is computed using a cubic spline with specified tangents. The number of output elements must equal three times the number of input elements. For each input element, the output stores three elements, an in-tangent, a spline vertex, and an out-tangent. There must be at least two keyframes when using this interpolation.
+
+#### animation.sampler.output :white_check_mark: 
+
+The index of an accessor containing keyframe output values. When targeting translation or scale paths, the `accessor.componentType` of the output values must be `FLOAT`. When targeting rotation or morph weights, the `accessor.componentType` of the output values must be `FLOAT` or normalized integer. For weights, each output element stores `SCALAR` values with a count equal to the number of morph targets.
+
+* **Type**: [`glTFid`](#reference-gltfid)
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### animation.sampler.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### animation.sampler.extras
 
 Application-specific data.
 

--- a/specification/2.0/schema/accessor.schema.json
+++ b/specification/2.0/schema/accessor.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Accessor",
+    "title": "accessor",
     "type": "object",
     "description": "A typed view into a bufferView.  A bufferView contains raw binary data.  An accessor provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/accessor.sparse.indices.schema.json
+++ b/specification/2.0/schema/accessor.sparse.indices.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Accessor Sparse Indices",
+    "title": "indices",
     "type": "object",
     "description": "Indices of those attributes that deviate from their initialization value.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/accessor.sparse.schema.json
+++ b/specification/2.0/schema/accessor.sparse.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Accessor Sparse",
+    "title": "sparse",
     "type": "object",
     "description": "Sparse storage of attributes that deviate from their initialization value.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/accessor.sparse.values.schema.json
+++ b/specification/2.0/schema/accessor.sparse.values.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Accessor Sparse Values",
+    "title": "values",
     "type": "object",
     "description": "Array of size `accessor.sparse.count` times number of components storing the displaced accessor attributes pointed by `accessor.sparse.indices`.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.channel.schema.json
+++ b/specification/2.0/schema/animation.channel.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Animation Channel",
+    "title": "channel",
     "type": "object",
     "description": "Targets an animation's sampler at a node's property.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.channel.target.schema.json
+++ b/specification/2.0/schema/animation.channel.target.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Animation Channel Target",
+    "title": "target",
     "type": "object",
     "description": "The index of the node and TRS property that an animation channel targets.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.sampler.schema.json
+++ b/specification/2.0/schema/animation.sampler.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "sampler",
+    "title": "animation_sampler",
     "type": "object",
     "description": "Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.sampler.schema.json
+++ b/specification/2.0/schema/animation.sampler.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Animation Sampler",
+    "title": "sampler",
     "type": "object",
     "description": "Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.schema.json
+++ b/specification/2.0/schema/animation.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Animation",
+    "title": "animation",
     "type": "object",
     "description": "A keyframe animation.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/asset.schema.json
+++ b/specification/2.0/schema/asset.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Asset",
+    "title": "asset",
     "type": "object",
     "description": "Metadata about the glTF asset.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/buffer.schema.json
+++ b/specification/2.0/schema/buffer.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Buffer",
+    "title": "buffer",
     "type": "object",
     "description": "A buffer points to binary geometry, animation, or skins.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/bufferView.schema.json
+++ b/specification/2.0/schema/bufferView.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Buffer View",
+    "title": "bufferView",
     "type": "object",
     "description": "A view into a buffer generally representing a subset of the buffer.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/camera.orthographic.schema.json
+++ b/specification/2.0/schema/camera.orthographic.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Camera Orthographic",
+    "title": "orthographic",
     "type": "object",
     "description": "An orthographic camera containing properties to create an orthographic projection matrix.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/camera.perspective.schema.json
+++ b/specification/2.0/schema/camera.perspective.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Camera Perspective",
+    "title": "perspective",
     "type": "object",
     "description": "A perspective camera containing properties to create a perspective projection matrix.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/camera.schema.json
+++ b/specification/2.0/schema/camera.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Camera",
+    "title": "camera",
     "type": "object",
     "description": "A camera's projection.  A node can reference a camera to apply a transform to place the camera in the scene.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/extension.schema.json
+++ b/specification/2.0/schema/extension.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Extension",
+    "title": "extension",
     "type": "object",
     "description": "Dictionary object with extension-specific objects.",
     "properties": {

--- a/specification/2.0/schema/extras.schema.json
+++ b/specification/2.0/schema/extras.schema.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Extras",
+    "title": "extras",
     "description": "Application-specific data."
 }

--- a/specification/2.0/schema/extras.schema.json
+++ b/specification/2.0/schema/extras.schema.json
@@ -2,5 +2,5 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "extras",
     "description": "Application-specific data.",
-    "gltf_detailedDescription": "Application-specific data. **Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability."
+    "gltf_sectionDescription": "**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability."
 }

--- a/specification/2.0/schema/glTFChildOfRootProperty.schema.json
+++ b/specification/2.0/schema/glTFChildOfRootProperty.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "glTF Child of Root Property",
+    "title": "Child of a glTF root property",
     "type": "object",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {

--- a/specification/2.0/schema/glTFProperty.schema.json
+++ b/specification/2.0/schema/glTFProperty.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "glTF Property",
+    "title": "glTF property",
     "type": "object",
     "properties": {
         "extensions": {

--- a/specification/2.0/schema/glTFid.schema.json
+++ b/specification/2.0/schema/glTFid.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "glTF Id",
+    "title": "glTF element index",
     "type": "integer",
     "minimum": 0
 }

--- a/specification/2.0/schema/image.schema.json
+++ b/specification/2.0/schema/image.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Image",
+    "title": "image",
     "type": "object",
     "description": "Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/material.normalTextureInfo.schema.json
+++ b/specification/2.0/schema/material.normalTextureInfo.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Material Normal Texture Info",
+    "title": "normalTextureInfo",
     "type": "object",
     "allOf": [ { "$ref": "textureInfo.schema.json" } ],
     "properties": {

--- a/specification/2.0/schema/material.occlusionTextureInfo.schema.json
+++ b/specification/2.0/schema/material.occlusionTextureInfo.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Material Occlusion Texture Info",
+    "title": "occlusionTextureInfo",
     "type": "object",
     "allOf": [ { "$ref": "textureInfo.schema.json" } ],
     "properties": {

--- a/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
+++ b/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Material PBR Metallic Roughness",
+    "title": "pbrMetallicRoughness",
     "type": "object",
     "description": "A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Material",
+    "title": "material",
     "type": "object",
     "description": "The material appearance of a primitive.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/mesh.primitive.schema.json
+++ b/specification/2.0/schema/mesh.primitive.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Mesh Primitive",
+    "title": "primitive",
     "type": "object",
     "description": "Geometry to be rendered with the given material.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/mesh.schema.json
+++ b/specification/2.0/schema/mesh.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Mesh",
+    "title": "mesh",
     "type": "object",
     "description": "A set of primitives to be rendered.  A node can contain one mesh.  A node's transform places the mesh in the scene.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/node.schema.json
+++ b/specification/2.0/schema/node.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Node",
+    "title": "node",
     "type": "object",
     "description": "A node in the node hierarchy.  When the node contains `skin`, all `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/sampler.schema.json
+++ b/specification/2.0/schema/sampler.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Sampler",
+    "title": "sampler",
     "type": "object",
     "description": "Texture sampler properties for filtering and wrapping modes.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/scene.schema.json
+++ b/specification/2.0/schema/scene.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Scene",
+    "title": "scene",
     "type": "object",
     "description": "The root nodes of a scene.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/skin.schema.json
+++ b/specification/2.0/schema/skin.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Skin",
+    "title": "skin",
     "type": "object",
     "description": "Joints and matrices defining a skin.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/texture.schema.json
+++ b/specification/2.0/schema/texture.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Texture",
+    "title": "texture",
     "type": "object",
     "description": "A texture and its sampler.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/textureInfo.schema.json
+++ b/specification/2.0/schema/textureInfo.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Texture Info",
+    "title": "textureInfo",
     "type": "object",
     "description": "Reference to a texture.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],


### PR DESCRIPTION
## DO NOT MERGE

This is simply to show the diff of what would happen if we took automated [wetzel](https://github.com/CesiumGS/wetzel) output and blindly used it as a replacement for the reference section.

**NOTE:** If there are functional differences between this and what's in the reference section, it may indicate a disparity between the main reference section and the JSON schemas.

The command-line used to generate this was:

```
$ bin/wetzel.js -l2 -a=cqo ../glTF/specification/2.0/schema/glTF.schema.json > ../wetzel_output/ref_2020-10-28.md
```
