### PR TITLE
Test new automated reference section

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -1653,29 +1653,29 @@ This chunk must be padded with trailing zeros (`0x00`) to satisfy alignment requ
 
 ## Objects
 * [`accessor`](#reference-accessor)
-   * [`sparse`](#reference-sparse)
-      * [`indices`](#reference-indices)
-      * [`values`](#reference-values)
+   * [`accessor.sparse`](#reference-accessor-sparse)
+      * [`accessor.sparse.indices`](#reference-accessor-sparse-indices)
+      * [`accessor.sparse.values`](#reference-accessor-sparse-values)
 * [`animation`](#reference-animation)
-   * [`animation sampler`](#reference-animation-sampler)
-   * [`channel`](#reference-channel)
-      * [`target`](#reference-target)
+   * [`animation.channel`](#reference-animation-channel)
+      * [`animation.channel.target`](#reference-animation-channel-target)
+   * [`animation.sampler`](#reference-animation-sampler)
 * [`asset`](#reference-asset)
 * [`buffer`](#reference-buffer)
 * [`bufferView`](#reference-bufferview)
 * [`camera`](#reference-camera)
-   * [`orthographic`](#reference-orthographic)
-   * [`perspective`](#reference-perspective)
+   * [`camera.orthographic`](#reference-camera-orthographic)
+   * [`camera.perspective`](#reference-camera-perspective)
 * [`extension`](#reference-extension)
 * [`extras`](#reference-extras)
 * [`glTF`](#reference-gltf) (root object)
 * [`image`](#reference-image)
 * [`material`](#reference-material)
-   * [`normalTextureInfo`](#reference-normaltextureinfo)
-   * [`occlusionTextureInfo`](#reference-occlusiontextureinfo)
-   * [`pbrMetallicRoughness`](#reference-pbrmetallicroughness)
+   * [`material.normalTextureInfo`](#reference-material-normaltextureinfo)
+   * [`material.occlusionTextureInfo`](#reference-material-occlusiontextureinfo)
+   * [`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)
 * [`mesh`](#reference-mesh)
-   * [`primitive`](#reference-primitive)
+   * [`mesh.primitive`](#reference-mesh-primitive)
 * [`node`](#reference-node)
 * [`sampler`](#reference-sampler)
 * [`scene`](#reference-scene)
@@ -1690,22 +1690,22 @@ This chunk must be padded with trailing zeros (`0x00`) to satisfy alignment requ
 
 A typed view into a bufferView.  A bufferView contains raw binary data.  An accessor provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.
 
-**Properties**
+**`accessor` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**bufferView**|`integer`|The index of the bufferView.|No|
 |**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes.|No, default: `0`|
-|**componentType**|`integer`|The datatype of components in the attribute.| :white_check_mark: Yes|
+|**componentType**|`integer`|The datatype of components in the attribute.| &#x2705; Yes|
 |**normalized**|`boolean`|Specifies whether integer data values should be normalized.|No, default: `false`|
-|**count**|`integer`|The number of attributes referenced by this accessor.| :white_check_mark: Yes|
-|**type**|`string`|Specifies if the attribute is a scalar, vector, or matrix.| :white_check_mark: Yes|
+|**count**|`integer`|The number of attributes referenced by this accessor.| &#x2705; Yes|
+|**type**|`string`|Specifies if the attribute is a scalar, vector, or matrix.| &#x2705; Yes|
 |**max**|`number` `[1-16]`|Maximum value of each component in this attribute.|No|
 |**min**|`number` `[1-16]`|Minimum value of each component in this attribute.|No|
-|**sparse**|`object`|Sparse storage of attributes that deviate from their initialization value.|No|
+|**sparse**|[`accessor.sparse`](#reference-accessor-sparse)|Sparse storage of attributes that deviate from their initialization value.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
@@ -1713,7 +1713,7 @@ Additional properties are allowed.
 
 #### accessor.bufferView
 
-The index of the bufferView. When not defined, accessor must be initialized with zeros; [`sparse`](#reference-sparse) property or extensions could override zeros with actual values.
+The index of the bufferView. When not defined, accessor must be initialized with zeros; `sparse` property or extensions could override zeros with actual values.
 
 * **Type**: `integer`
 * **Required**: No
@@ -1728,7 +1728,7 @@ The offset relative to the start of the bufferView in bytes.  This must be a mul
 * **Minimum**: ` >= 0`
 * **Related WebGL functions**: `vertexAttribPointer()` offset parameter
 
-#### accessor.componentType :white_check_mark: 
+#### accessor.componentType &#x2705; 
 
 The datatype of components in the attribute.  All valid values correspond to WebGL enums.  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, `Uint32Array`, and `Float32Array`, respectively.  5125 (UNSIGNED_INT) is only allowed when the accessor contains indices, i.e., the accessor is only referenced by `primitive.indices`.
 
@@ -1751,7 +1751,7 @@ Specifies whether integer data values should be normalized (`true`) to [0, 1] (f
 * **Required**: No, default: `false`
 * **Related WebGL functions**: `vertexAttribPointer()` normalized parameter
 
-#### accessor.count :white_check_mark: 
+#### accessor.count &#x2705; 
 
 The number of attributes referenced by this accessor, not to be confused with the number of bytes or number of components.
 
@@ -1759,7 +1759,7 @@ The number of attributes referenced by this accessor, not to be confused with th
 * **Required**: Yes
 * **Minimum**: ` >= 1`
 
-#### accessor.type :white_check_mark: 
+#### accessor.type &#x2705; 
 
 Specifies if the attribute is a scalar, vector, or matrix.
 
@@ -1796,7 +1796,7 @@ Minimum value of each component in this attribute.  Array elements must be treat
 
 Sparse storage of attributes that deviate from their initialization value.
 
-* **Type**: `object`
+* **Type**: [`accessor.sparse`](#reference-accessor-sparse)
 * **Required**: No
 
 #### accessor.name
@@ -1810,7 +1810,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -1818,7 +1818,185 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-accessor-sparse"></a>
+### accessor.sparse
+
+Sparse storage of attributes that deviate from their initialization value.
+
+**`accessor.sparse` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**count**|`integer`|Number of entries stored in the sparse array.| &#x2705; Yes|
+|**indices**|[`accessor.sparse.indices`](#reference-accessor-sparse-indices)|Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.| &#x2705; Yes|
+|**values**|[`accessor.sparse.values`](#reference-accessor-sparse-values)|Array of size `count` times number of components, storing the displaced accessor attributes pointed by `indices`. Substituted values must have the same `componentType` and number of components as the base accessor.| &#x2705; Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [accessor.sparse.schema.json](schema/accessor.sparse.schema.json)
+
+#### accessor.sparse.count &#x2705; 
+
+The number of attributes encoded in this sparse accessor.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+#### accessor.sparse.indices &#x2705; 
+
+Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.
+
+* **Type**: [`accessor.sparse.indices`](#reference-accessor-sparse-indices)
+* **Required**: Yes
+
+#### accessor.sparse.values &#x2705; 
+
+Array of size `count` times number of components, storing the displaced accessor attributes pointed by `indices`. Substituted values must have the same `componentType` and number of components as the base accessor.
+
+* **Type**: [`accessor.sparse.values`](#reference-accessor-sparse-values)
+* **Required**: Yes
+
+#### accessor.sparse.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### accessor.sparse.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-accessor-sparse-indices"></a>
+### accessor.sparse.indices
+
+Indices of those attributes that deviate from their initialization value.
+
+**`accessor.sparse.indices` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**bufferView**|`integer`|The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| &#x2705; Yes|
+|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
+|**componentType**|`integer`|The indices data type.| &#x2705; Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [accessor.sparse.indices.schema.json](schema/accessor.sparse.indices.schema.json)
+
+#### accessor.sparse.indices.bufferView &#x2705; 
+
+The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.indices.byteOffset
+
+The offset relative to the start of the bufferView in bytes. Must be aligned.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.indices.componentType &#x2705; 
+
+The indices data type.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `5123` (UNSIGNED_SHORT), `5125` (UNSIGNED_INT).
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Allowed values**:
+   * `5121` UNSIGNED_BYTE
+   * `5123` UNSIGNED_SHORT
+   * `5125` UNSIGNED_INT
+
+#### accessor.sparse.indices.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### accessor.sparse.indices.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-accessor-sparse-values"></a>
+### accessor.sparse.values
+
+Array of size `accessor.sparse.count` times number of components storing the displaced accessor attributes pointed by [`accessor.sparse.indices`](#reference-accessor-sparse-indices).
+
+**`accessor.sparse.values` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**bufferView**|`integer`|The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| &#x2705; Yes|
+|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [accessor.sparse.values.schema.json](schema/accessor.sparse.values.schema.json)
+
+#### accessor.sparse.values.bufferView &#x2705; 
+
+The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.values.byteOffset
+
+The offset relative to the start of the bufferView in bytes. Must be aligned.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### accessor.sparse.values.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### accessor.sparse.values.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -1830,32 +2008,32 @@ Application-specific data.
 
 A keyframe animation.
 
-**Properties**
+**`animation` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
-|**channels**|channel `[1-*]`|An array of channels, each of which targets an animation's sampler at a node's property. Different channels of the same animation can't have equal targets.| :white_check_mark: Yes|
-|**samplers**|animation sampler `[1-*]`|An array of samplers that combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).| :white_check_mark: Yes|
+|---|---|---|---|
+|**channels**|[`animation.channel`](#reference-animation-channel) `[1-*]`|An array of channels, each of which targets an animation's sampler at a node's property. Different channels of the same animation can't have equal targets.| &#x2705; Yes|
+|**samplers**|[`animation.sampler`](#reference-animation-sampler) `[1-*]`|An array of samplers that combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).| &#x2705; Yes|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
 * **JSON schema**: [animation.schema.json](schema/animation.schema.json)
 
-#### animation.channels :white_check_mark: 
+#### animation.channels &#x2705; 
 
 An array of channels, each of which targets an animation's sampler at a node's property. Different channels of the same animation can't have equal targets.
 
-* **Type**: channel `[1-*]`
+* **Type**: [`animation.channel`](#reference-animation-channel) `[1-*]`
 * **Required**: Yes
 
-#### animation.samplers :white_check_mark: 
+#### animation.samplers &#x2705; 
 
 An array of samplers that combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
 
-* **Type**: animation sampler `[1-*]`
+* **Type**: [`animation.sampler`](#reference-animation-sampler) `[1-*]`
 * **Required**: Yes
 
 #### animation.name
@@ -1869,7 +2047,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -1877,7 +2055,116 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-animation-channel"></a>
+### animation.channel
+
+Targets an animation's sampler at a node's property.
+
+**`animation.channel` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**sampler**|`integer`|The index of a sampler in this animation used to compute the value for the target.| &#x2705; Yes|
+|**target**|[`animation.channel.target`](#reference-animation-channel-target)|The index of the node and TRS property to target.| &#x2705; Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [animation.channel.schema.json](schema/animation.channel.schema.json)
+
+#### animation.channel.sampler &#x2705; 
+
+The index of a sampler in this animation used to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS).
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### animation.channel.target &#x2705; 
+
+The index of the node and TRS property to target.
+
+* **Type**: [`animation.channel.target`](#reference-animation-channel-target)
+* **Required**: Yes
+
+#### animation.channel.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### animation.channel.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-animation-channel-target"></a>
+### animation.channel.target
+
+The index of the node and TRS property that an animation channel targets.
+
+**`animation.channel.target` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**node**|`integer`|The index of the node to target.|No|
+|**path**|`string`|The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.| &#x2705; Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [animation.channel.target.schema.json](schema/animation.channel.target.schema.json)
+
+#### animation.channel.target.node
+
+The index of the node to target.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### animation.channel.target.path &#x2705; 
+
+The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+   * `"translation"`
+   * `"rotation"`
+   * `"scale"`
+   * `"weights"`
+
+#### animation.channel.target.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### animation.channel.target.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -1885,25 +2172,25 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-animation-sampler"></a>
-### animation sampler
+### animation.sampler
 
 Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
 
-**Properties**
+**`animation.sampler` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
-|**input**|`integer`|The index of an accessor containing keyframe input values, e.g., time.| :white_check_mark: Yes|
+|---|---|---|---|
+|**input**|`integer`|The index of an accessor containing keyframe input values, e.g., time.| &#x2705; Yes|
 |**interpolation**|`string`|Interpolation algorithm.|No, default: `"LINEAR"`|
-|**output**|`integer`|The index of an accessor, containing keyframe output values.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**output**|`integer`|The index of an accessor, containing keyframe output values.| &#x2705; Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
 * **JSON schema**: [animation.sampler.schema.json](schema/animation.sampler.schema.json)
 
-#### animation sampler.input :white_check_mark: 
+#### animation.sampler.input &#x2705; 
 
 The index of an accessor containing keyframe input values, e.g., time. That accessor must have componentType `FLOAT`. The values represent time in seconds with `time[0] >= 0.0`, and strictly increasing values, i.e., `time[n + 1] > time[n]`.
 
@@ -1911,7 +2198,7 @@ The index of an accessor containing keyframe input values, e.g., time. That acce
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
-#### animation sampler.interpolation
+#### animation.sampler.interpolation
 
 Interpolation algorithm.
 
@@ -1922,7 +2209,7 @@ Interpolation algorithm.
    * `"STEP"` The animated values remain constant to the output of the first keyframe, until the next keyframe. The number of output elements must equal the number of input elements.
    * `"CUBICSPLINE"` The animation's interpolation is computed using a cubic spline with specified tangents. The number of output elements must equal three times the number of input elements. For each input element, the output stores three elements, an in-tangent, a spline vertex, and an out-tangent. There must be at least two keyframes when using this interpolation.
 
-#### animation sampler.output :white_check_mark: 
+#### animation.sampler.output &#x2705; 
 
 The index of an accessor containing keyframe output values. When targeting translation or scale paths, the `accessor.componentType` of the output values must be `FLOAT`. When targeting rotation or morph weights, the `accessor.componentType` of the output values must be `FLOAT` or normalized integer. For weights, each output element stores `SCALAR` values with a count equal to the number of morph targets.
 
@@ -1930,19 +2217,19 @@ The index of an accessor containing keyframe output values. When targeting trans
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
-#### animation sampler.extensions
+#### animation.sampler.extensions
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
-#### animation sampler.extras
+#### animation.sampler.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -1954,16 +2241,16 @@ Application-specific data.
 
 Metadata about the glTF asset.
 
-**Properties**
+**`asset` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**copyright**|`string`|A copyright message suitable for display to credit the content creator.|No|
 |**generator**|`string`|Tool that generated this glTF model.  Useful for debugging.|No|
-|**version**|`string`|The glTF version that this asset targets.| :white_check_mark: Yes|
+|**version**|`string`|The glTF version that this asset targets.| &#x2705; Yes|
 |**minVersion**|`string`|The minimum glTF version that this asset targets.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
@@ -1983,7 +2270,7 @@ Tool that generated this glTF model.  Useful for debugging.
 * **Type**: `string`
 * **Required**: No
 
-#### asset.version :white_check_mark: 
+#### asset.version &#x2705; 
 
 The glTF version that this asset targets.
 
@@ -2001,7 +2288,7 @@ The minimum glTF version that this asset targets.
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -2009,7 +2296,7 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2021,15 +2308,15 @@ Application-specific data.
 
 A buffer points to binary geometry, animation, or skins.
 
-**Properties**
+**`buffer` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**uri**|`string`|The uri of the buffer.|No|
-|**byteLength**|`integer`|The length of the buffer in bytes.| :white_check_mark: Yes|
+|**byteLength**|`integer`|The length of the buffer in bytes.| &#x2705; Yes|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
@@ -2043,7 +2330,7 @@ The uri of the buffer.  Relative paths are relative to the .gltf file.  Instead 
 * **Required**: No
 * **Format**: uriref
 
-#### buffer.byteLength :white_check_mark: 
+#### buffer.byteLength &#x2705; 
 
 The length of the buffer in bytes.
 
@@ -2062,7 +2349,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -2070,7 +2357,7 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2082,24 +2369,24 @@ Application-specific data.
 
 A view into a buffer generally representing a subset of the buffer.
 
-**Properties**
+**`bufferView` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
-|**buffer**|`integer`|The index of the buffer.| :white_check_mark: Yes|
+|---|---|---|---|
+|**buffer**|`integer`|The index of the buffer.| &#x2705; Yes|
 |**byteOffset**|`integer`|The offset into the buffer in bytes.|No, default: `0`|
-|**byteLength**|`integer`|The length of the bufferView in bytes.| :white_check_mark: Yes|
+|**byteLength**|`integer`|The length of the bufferView in bytes.| &#x2705; Yes|
 |**byteStride**|`integer`|The stride, in bytes.|No|
 |**target**|`integer`|The target that the GPU buffer should be bound to.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
 * **JSON schema**: [bufferView.schema.json](schema/bufferView.schema.json)
 
-#### bufferView.buffer :white_check_mark: 
+#### bufferView.buffer &#x2705; 
 
 The index of the buffer.
 
@@ -2115,7 +2402,7 @@ The offset into the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: ` >= 0`
 
-#### bufferView.byteLength :white_check_mark: 
+#### bufferView.byteLength &#x2705; 
 
 The length of the bufferView in bytes.
 
@@ -2155,7 +2442,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -2163,7 +2450,7 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2175,16 +2462,16 @@ Application-specific data.
 
 A camera's projection.  A node can reference a camera to apply a transform to place the camera in the scene.
 
-**Properties**
+**`camera` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
-|**orthographic**|`object`|An orthographic camera containing properties to create an orthographic projection matrix.|No|
-|**perspective**|`object`|A perspective camera containing properties to create a perspective projection matrix.|No|
-|**type**|`string`|Specifies if the camera uses a perspective or orthographic projection.| :white_check_mark: Yes|
+|---|---|---|---|
+|**orthographic**|[`camera.orthographic`](#reference-camera-orthographic)|An orthographic camera containing properties to create an orthographic projection matrix.|No|
+|**perspective**|[`camera.perspective`](#reference-camera-perspective)|A perspective camera containing properties to create a perspective projection matrix.|No|
+|**type**|`string`|Specifies if the camera uses a perspective or orthographic projection.| &#x2705; Yes|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
@@ -2194,19 +2481,19 @@ Additional properties are allowed.
 
 An orthographic camera containing properties to create an orthographic projection matrix.
 
-* **Type**: `object`
+* **Type**: [`camera.orthographic`](#reference-camera-orthographic)
 * **Required**: No
 
 #### camera.perspective
 
 A perspective camera containing properties to create a perspective projection matrix.
 
-* **Type**: `object`
+* **Type**: [`camera.perspective`](#reference-camera-perspective)
 * **Required**: No
 
-#### camera.type :white_check_mark: 
+#### camera.type &#x2705; 
 
-Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's [`perspective`](#reference-perspective) or [`orthographic`](#reference-orthographic) property will be defined.
+Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's `perspective` or `orthographic` property will be defined.
 
 * **Type**: `string`
 * **Required**: Yes
@@ -2225,7 +2512,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -2233,59 +2520,147 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
 
 
 ---------------------------------------
-<a name="reference-channel"></a>
-### channel
+<a name="reference-camera-orthographic"></a>
+### camera.orthographic
 
-Targets an animation's sampler at a node's property.
+An orthographic camera containing properties to create an orthographic projection matrix.
 
-**Properties**
+**`camera.orthographic` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
-|**sampler**|`integer`|The index of a sampler in this animation used to compute the value for the target.| :white_check_mark: Yes|
-|**target**|`object`|The index of the node and TRS property to target.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|---|---|---|---|
+|**xmag**|`number`|The floating-point horizontal magnification of the view. Must not be zero.| &#x2705; Yes|
+|**ymag**|`number`|The floating-point vertical magnification of the view. Must not be zero.| &#x2705; Yes|
+|**zfar**|`number`|The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.| &#x2705; Yes|
+|**znear**|`number`|The floating-point distance to the near clipping plane.| &#x2705; Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
-* **JSON schema**: [animation.channel.schema.json](schema/animation.channel.schema.json)
+* **JSON schema**: [camera.orthographic.schema.json](schema/camera.orthographic.schema.json)
 
-#### channel.sampler :white_check_mark: 
+#### camera.orthographic.xmag &#x2705; 
 
-The index of a sampler in this animation used to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS).
+The floating-point horizontal magnification of the view. Must not be zero.
 
-* **Type**: `integer`
+* **Type**: `number`
+* **Required**: Yes
+
+#### camera.orthographic.ymag &#x2705; 
+
+The floating-point vertical magnification of the view. Must not be zero.
+
+* **Type**: `number`
+* **Required**: Yes
+
+#### camera.orthographic.zfar &#x2705; 
+
+The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+#### camera.orthographic.znear &#x2705; 
+
+The floating-point distance to the near clipping plane.
+
+* **Type**: `number`
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
-#### channel.target :white_check_mark: 
-
-The index of the node and TRS property to target.
-
-* **Type**: `object`
-* **Required**: Yes
-
-#### channel.extensions
+#### camera.orthographic.extensions
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
-#### channel.extras
+#### camera.orthographic.extras
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-camera-perspective"></a>
+### camera.perspective
+
+A perspective camera containing properties to create a perspective projection matrix.
+
+**`camera.perspective` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**aspectRatio**|`number`|The floating-point aspect ratio of the field of view.|No|
+|**yfov**|`number`|The floating-point vertical field of view in radians.| &#x2705; Yes|
+|**zfar**|`number`|The floating-point distance to the far clipping plane.|No|
+|**znear**|`number`|The floating-point distance to the near clipping plane.| &#x2705; Yes|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [camera.perspective.schema.json](schema/camera.perspective.schema.json)
+
+#### camera.perspective.aspectRatio
+
+The floating-point aspect ratio of the field of view. When this is undefined, the aspect ratio of the canvas is used.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+
+#### camera.perspective.yfov &#x2705; 
+
+The floating-point vertical field of view in radians.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+#### camera.perspective.zfar
+
+The floating-point distance to the far clipping plane. When defined, `zfar` must be greater than `znear`. If `zfar` is undefined, runtime must use infinite projection matrix.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+
+#### camera.perspective.znear &#x2705; 
+
+The floating-point distance to the near clipping plane.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+#### camera.perspective.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### camera.perspective.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2310,9 +2685,9 @@ Additional properties are allowed.
 
 Application-specific data.
 
-> **Implementation Note:** Although extras may have any type, it is common for applications to
-store and access custom data as key/value pairs. As best practice, extras should be an Object
-rather than a primitive value for best portability.
+**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
 
 ---------------------------------------
 <a name="reference-gltf"></a>
@@ -2320,29 +2695,29 @@ rather than a primitive value for best portability.
 
 The root object for a glTF asset.
 
-**Properties**
+**`glTF` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**extensionsUsed**|`string` `[1-*]`|Names of glTF extensions used somewhere in this asset.|No|
 |**extensionsRequired**|`string` `[1-*]`|Names of glTF extensions required to properly load this asset.|No|
-|**accessors**|accessor `[1-*]`|An array of accessors.|No|
-|**animations**|animation `[1-*]`|An array of keyframe animations.|No|
-|**asset**|`object`|Metadata about the glTF asset.|Yes|
-|**buffers**|buffer `[1-*]`|An array of buffers.|No|
-|**bufferViews**|bufferView `[1-*]`|An array of bufferViews.|No|
-|**cameras**|camera `[1-*]`|An array of cameras.|No|
-|**images**|image `[1-*]`|An array of images.|No|
-|**materials**|material `[1-*]`|An array of materials.|No|
-|**meshes**|mesh `[1-*]`|An array of meshes.|No|
-|**nodes**|node `[1-*]`|An array of nodes.|No|
-|**samplers**|sampler `[1-*]`|An array of samplers.|No|
+|**accessors**|[`accessor`](#reference-accessor) `[1-*]`|An array of accessors.|No|
+|**animations**|[`animation`](#reference-animation) `[1-*]`|An array of keyframe animations.|No|
+|**asset**|[`asset`](#reference-asset)|Metadata about the glTF asset.| &#x2705; Yes|
+|**buffers**|[`buffer`](#reference-buffer) `[1-*]`|An array of buffers.|No|
+|**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.|No|
+|**cameras**|[`camera`](#reference-camera) `[1-*]`|An array of cameras.|No|
+|**images**|[`image`](#reference-image) `[1-*]`|An array of images.|No|
+|**materials**|[`material`](#reference-material) `[1-*]`|An array of materials.|No|
+|**meshes**|[`mesh`](#reference-mesh) `[1-*]`|An array of meshes.|No|
+|**nodes**|[`node`](#reference-node) `[1-*]`|An array of nodes.|No|
+|**samplers**|[`sampler`](#reference-sampler) `[1-*]`|An array of samplers.|No|
 |**scene**|`integer`|The index of the default scene.|No|
-|**scenes**|scene `[1-*]`|An array of scenes.|No|
-|**skins**|skin `[1-*]`|An array of skins.|No|
-|**textures**|texture `[1-*]`|An array of textures.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**scenes**|[`scene`](#reference-scene) `[1-*]`|An array of scenes.|No|
+|**skins**|[`skin`](#reference-skin) `[1-*]`|An array of skins.|No|
+|**textures**|[`texture`](#reference-texture) `[1-*]`|An array of textures.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
@@ -2368,77 +2743,77 @@ Names of glTF extensions required to properly load this asset.
 
 An array of accessors.  An accessor is a typed view into a bufferView.
 
-* **Type**: accessor `[1-*]`
+* **Type**: [`accessor`](#reference-accessor) `[1-*]`
 * **Required**: No
 
 #### glTF.animations
 
 An array of keyframe animations.
 
-* **Type**: animation `[1-*]`
+* **Type**: [`animation`](#reference-animation) `[1-*]`
 * **Required**: No
 
-#### glTF.asset :white_check_mark: 
+#### glTF.asset &#x2705; 
 
 Metadata about the glTF asset.
 
-* **Type**: `object`
+* **Type**: [`asset`](#reference-asset)
 * **Required**: Yes
 
 #### glTF.buffers
 
 An array of buffers.  A buffer points to binary geometry, animation, or skins.
 
-* **Type**: buffer `[1-*]`
+* **Type**: [`buffer`](#reference-buffer) `[1-*]`
 * **Required**: No
 
 #### glTF.bufferViews
 
 An array of bufferViews.  A bufferView is a view into a buffer generally representing a subset of the buffer.
 
-* **Type**: bufferView `[1-*]`
+* **Type**: [`bufferView`](#reference-bufferview) `[1-*]`
 * **Required**: No
 
 #### glTF.cameras
 
 An array of cameras.  A camera defines a projection matrix.
 
-* **Type**: camera `[1-*]`
+* **Type**: [`camera`](#reference-camera) `[1-*]`
 * **Required**: No
 
 #### glTF.images
 
 An array of images.  An image defines data used to create a texture.
 
-* **Type**: image `[1-*]`
+* **Type**: [`image`](#reference-image) `[1-*]`
 * **Required**: No
 
 #### glTF.materials
 
 An array of materials.  A material defines the appearance of a primitive.
 
-* **Type**: material `[1-*]`
+* **Type**: [`material`](#reference-material) `[1-*]`
 * **Required**: No
 
 #### glTF.meshes
 
 An array of meshes.  A mesh is a set of primitives to be rendered.
 
-* **Type**: mesh `[1-*]`
+* **Type**: [`mesh`](#reference-mesh) `[1-*]`
 * **Required**: No
 
 #### glTF.nodes
 
 An array of nodes.
 
-* **Type**: node `[1-*]`
+* **Type**: [`node`](#reference-node) `[1-*]`
 * **Required**: No
 
 #### glTF.samplers
 
 An array of samplers.  A sampler contains properties for texture filtering and wrapping modes.
 
-* **Type**: sampler `[1-*]`
+* **Type**: [`sampler`](#reference-sampler) `[1-*]`
 * **Required**: No
 
 #### glTF.scene
@@ -2453,28 +2828,28 @@ The index of the default scene.
 
 An array of scenes.
 
-* **Type**: scene `[1-*]`
+* **Type**: [`scene`](#reference-scene) `[1-*]`
 * **Required**: No
 
 #### glTF.skins
 
 An array of skins.  A skin is defined by joints and matrices.
 
-* **Type**: skin `[1-*]`
+* **Type**: [`skin`](#reference-skin) `[1-*]`
 * **Required**: No
 
 #### glTF.textures
 
 An array of textures.
 
-* **Type**: texture `[1-*]`
+* **Type**: [`texture`](#reference-texture) `[1-*]`
 * **Required**: No
 
 #### glTF.extensions
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -2482,7 +2857,7 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2496,16 +2871,16 @@ Application-specific data.
 
 Image data used to create a texture. Image can be referenced by URI or [`bufferView`](#reference-bufferview) index. `mimeType` is required in the latter case.
 
-**Properties**
+**`image` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**uri**|`string`|The uri of the image.|No|
-|**mimeType**|`string`|The image's MIME type.  Required if `bufferView` is defined.|No|
+|**mimeType**|`string`|The image's MIME type. Required if [`bufferView`](#reference-bufferview) is defined.|No|
 |**bufferView**|`integer`|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
@@ -2521,7 +2896,7 @@ The uri of the image.  Relative paths are relative to the .gltf file.  Instead o
 
 #### image.mimeType
 
-The image's MIME type. Required if `bufferView` is defined.
+The image's MIME type. Required if [`bufferView`](#reference-bufferview) is defined.
 
 * **Type**: `string`
 * **Required**: No
@@ -2548,7 +2923,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -2556,72 +2931,7 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-indices"></a>
-### indices
-
-Indices of those attributes that deviate from their initialization value.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**bufferView**|`integer`|The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
-|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
-|**componentType**|`integer`|The indices data type.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [accessor.sparse.indices.schema.json](schema/accessor.sparse.indices.schema.json)
-
-#### indices.bufferView :white_check_mark: 
-
-The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### indices.byteOffset
-
-The offset relative to the start of the bufferView in bytes. Must be aligned.
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### indices.componentType :white_check_mark: 
-
-The indices data type.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `5123` (UNSIGNED_SHORT), `5125` (UNSIGNED_INT).
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Allowed values**:
-   * `5121` UNSIGNED_BYTE
-   * `5123` UNSIGNED_SHORT
-   * `5125` UNSIGNED_INT
-
-#### indices.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### indices.extras
-
-Application-specific data.
-
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2633,17 +2943,17 @@ Application-specific data.
 
 The material appearance of a primitive.
 
-**Properties**
+**`material` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-|**pbrMetallicRoughness**|`object`|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of [`pbrMetallicRoughness`](#reference-pbrmetallicroughness) apply.|No|
-|**normalTexture**|`object`|The normal map texture.|No|
-|**occlusionTexture**|`object`|The occlusion map texture.|No|
-|**emissiveTexture**|`object`|The emissive map texture.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+|**pbrMetallicRoughness**|[`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.|No|
+|**normalTexture**|[`material.normalTextureInfo`](#reference-material-normaltextureinfo)|The normal map texture.|No|
+|**occlusionTexture**|[`material.occlusionTextureInfo`](#reference-material-occlusiontextureinfo)|The occlusion map texture.|No|
+|**emissiveTexture**|[`textureInfo`](#reference-textureinfo)|The emissive map texture.|No|
 |**emissiveFactor**|`number` `[3]`|The emissive color of the material.|No, default: `[0,0,0]`|
 |**alphaMode**|`string`|The alpha rendering mode of the material.|No, default: `"OPAQUE"`|
 |**alphaCutoff**|`number`|The alpha cutoff value of the material.|No, default: `0.5`|
@@ -2664,7 +2974,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -2672,35 +2982,35 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 #### material.pbrMetallicRoughness
 
-A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of [`pbrMetallicRoughness`](#reference-pbrmetallicroughness) apply.
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
 
-* **Type**: `object`
+* **Type**: [`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)
 * **Required**: No
 
 #### material.normalTexture
 
 A tangent space normal map. The texture contains RGB components in linear space. Each texel represents the XYZ components of a normal vector in tangent space. Red [0 to 255] maps to X [-1 to 1]. Green [0 to 255] maps to Y [-1 to 1]. Blue [128 to 255] maps to Z [1/255 to 1]. The normal vectors use OpenGL conventions where +X is right and +Y is up. +Z points toward the viewer. In GLSL, this vector would be unpacked like so: `vec3 normalVector = tex2D(<sampled normal map texture value>, texCoord) * 2 - 1`. Client implementations should normalize the normal vectors before using them in lighting equations.
 
-* **Type**: `object`
+* **Type**: [`material.normalTextureInfo`](#reference-material-normaltextureinfo)
 * **Required**: No
 
 #### material.occlusionTexture
 
 The occlusion map texture. The occlusion values are sampled from the R channel. Higher values indicate areas that should receive full indirect lighting and lower values indicate no indirect lighting. These values are linear. If other channels are present (GBA), they are ignored for occlusion calculations.
 
-* **Type**: `object`
+* **Type**: [`material.occlusionTextureInfo`](#reference-material-occlusiontextureinfo)
 * **Required**: No
 
 #### material.emissiveTexture
 
 The emissive map controls the color and intensity of the light being emitted by the material. This texture contains RGB components encoded with the sRGB transfer function. If a fourth component (A) is present, it is ignored.
 
-* **Type**: `object`
+* **Type**: [`textureInfo`](#reference-textureinfo)
 * **Required**: No
 
 #### material.emissiveFactor
@@ -2741,30 +3051,234 @@ Specifies whether the material is double sided. When this value is false, back-f
 
 
 ---------------------------------------
+<a name="reference-material-normaltextureinfo"></a>
+### material.normalTextureInfo
+
+Reference to a texture.
+
+**`material.normalTextureInfo` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**index**|`integer`|The index of the texture.| &#x2705; Yes|
+|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
+|**scale**|`number`|The scalar multiplier applied to each normal vector of the normal texture.|No, default: `1`|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [material.normalTextureInfo.schema.json](schema/material.normalTextureInfo.schema.json)
+
+#### material.normalTextureInfo.index &#x2705; 
+
+The index of the texture.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### material.normalTextureInfo.texCoord
+
+This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### material.normalTextureInfo.scale
+
+The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+
+#### material.normalTextureInfo.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### material.normalTextureInfo.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-material-occlusiontextureinfo"></a>
+### material.occlusionTextureInfo
+
+Reference to a texture.
+
+**`material.occlusionTextureInfo` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**index**|`integer`|The index of the texture.| &#x2705; Yes|
+|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
+|**strength**|`number`|A scalar multiplier controlling the amount of occlusion applied.|No, default: `1`|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [material.occlusionTextureInfo.schema.json](schema/material.occlusionTextureInfo.schema.json)
+
+#### material.occlusionTextureInfo.index &#x2705; 
+
+The index of the texture.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+#### material.occlusionTextureInfo.texCoord
+
+This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### material.occlusionTextureInfo.strength
+
+A scalar multiplier controlling the amount of occlusion applied. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion. This value affects the resulting color using the formula: `occludedColor = lerp(color, color * <sampled occlusion texture value>, <occlusion strength>)`. This value is ignored if the corresponding texture is not specified. This value is linear.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.occlusionTextureInfo.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### material.occlusionTextureInfo.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-material-pbrmetallicroughness"></a>
+### material.pbrMetallicRoughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
+
+**`material.pbrMetallicRoughness` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**baseColorFactor**|`number` `[4]`|The material's base color factor.|No, default: `[1,1,1,1]`|
+|**baseColorTexture**|[`textureInfo`](#reference-textureinfo)|The base color texture.|No|
+|**metallicFactor**|`number`|The metalness of the material.|No, default: `1`|
+|**roughnessFactor**|`number`|The roughness of the material.|No, default: `1`|
+|**metallicRoughnessTexture**|[`textureInfo`](#reference-textureinfo)|The metallic-roughness texture.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [material.pbrMetallicRoughness.schema.json](schema/material.pbrMetallicRoughness.schema.json)
+
+#### material.pbrMetallicRoughness.baseColorFactor
+
+The RGBA components of the base color of the material. The fourth component (A) is the alpha coverage of the material. The `alphaMode` property specifies how alpha is interpreted. These values are linear. If a baseColorTexture is specified, this value is multiplied with the texel values.
+
+* **Type**: `number` `[4]`
+   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[1,1,1,1]`
+
+#### material.pbrMetallicRoughness.baseColorTexture
+
+The base color texture. The first three components (RGB) are encoded with the sRGB transfer function. They specify the base color of the material. If the fourth component (A) is present, it represents the linear alpha coverage of the material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property specifies how alpha is interpreted. The stored texels must not be premultiplied.
+
+* **Type**: [`textureInfo`](#reference-textureinfo)
+* **Required**: No
+
+#### material.pbrMetallicRoughness.metallicFactor
+
+The metalness of the material. A value of 1.0 means the material is a metal. A value of 0.0 means the material is a dielectric. Values in between are for blending between metals and dielectrics such as dirty metallic surfaces. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the metallic texel values.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.pbrMetallicRoughness.roughnessFactor
+
+The roughness of the material. A value of 1.0 means the material is completely rough. A value of 0.0 means the material is completely smooth. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the roughness texel values.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.pbrMetallicRoughness.metallicRoughnessTexture
+
+The metallic-roughness texture. The metalness values are sampled from the B channel. The roughness values are sampled from the G channel. These values are linear. If other channels are present (R or A), they are ignored for metallic-roughness calculations.
+
+* **Type**: [`textureInfo`](#reference-textureinfo)
+* **Required**: No
+
+#### material.pbrMetallicRoughness.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### material.pbrMetallicRoughness.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
 <a name="reference-mesh"></a>
 ### mesh
 
 A set of primitives to be rendered.  A node can contain one mesh.  A node's transform places the mesh in the scene.
 
-**Properties**
+**`mesh` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
-|**primitives**|primitive `[1-*]`|An array of primitives, each defining geometry to be rendered with a material.| :white_check_mark: Yes|
+|---|---|---|---|
+|**primitives**|[`mesh.primitive`](#reference-mesh-primitive) `[1-*]`|An array of primitives, each defining geometry to be rendered with a material.| &#x2705; Yes|
 |**weights**|`number` `[1-*]`|Array of weights to be applied to the Morph Targets.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
 * **JSON schema**: [mesh.schema.json](schema/mesh.schema.json)
 
-#### mesh.primitives :white_check_mark: 
+#### mesh.primitives &#x2705; 
 
 An array of primitives, each defining geometry to be rendered with a material.
 
-* **Type**: primitive `[1-*]`
+* **Type**: [`mesh.primitive`](#reference-mesh-primitive) `[1-*]`
 * **Required**: Yes
 
 #### mesh.weights
@@ -2785,7 +3299,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -2793,7 +3307,95 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-mesh-primitive"></a>
+### mesh.primitive
+
+Geometry to be rendered with the given material.
+
+**Related WebGL functions**: `drawElements()` and `drawArrays()`
+
+**`mesh.primitive` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**attributes**|`object`|A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.| &#x2705; Yes|
+|**indices**|`integer`|The index of the accessor that contains the indices.|No|
+|**material**|`integer`|The index of the material to apply to this primitive when rendering.|No|
+|**mode**|`integer`|The type of primitives to render.|No, default: `4`|
+|**targets**|`object` `[1-*]`|An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [mesh.primitive.schema.json](schema/mesh.primitive.schema.json)
+
+#### mesh.primitive.attributes &#x2705; 
+
+A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.
+
+* **Type**: `object`
+* **Required**: Yes
+* **Type of each property**: `integer`
+
+#### mesh.primitive.indices
+
+The index of the accessor that contains mesh indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.  When defined, the accessor must contain indices: the [`bufferView`](#reference-bufferview) referenced by the accessor should have a `target` equal to 34963 (ELEMENT_ARRAY_BUFFER); `componentType` must be 5121 (UNSIGNED_BYTE), 5123 (UNSIGNED_SHORT) or 5125 (UNSIGNED_INT), the latter may require enabling additional hardware support; `type` must be `"SCALAR"`. For triangle primitives, the front face has a counter-clockwise (CCW) winding order. Values of the index accessor must not include the maximum value for the given component type, which triggers primitive restart in several graphics APIs and would require client implementations to rebuild the index buffer. Primitive restart values are disallowed and all index values must refer to actual vertices. As a result, the index accessor's values must not exceed the following maxima: BYTE `< 255`, UNSIGNED_SHORT `< 65535`, UNSIGNED_INT `< 4294967295`.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### mesh.primitive.material
+
+The index of the material to apply to this primitive when rendering.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### mesh.primitive.mode
+
+The type of primitives to render. All valid values correspond to WebGL enums.
+
+* **Type**: `integer`
+* **Required**: No, default: `4`
+* **Allowed values**:
+   * `0` POINTS
+   * `1` LINES
+   * `2` LINE_LOOP
+   * `3` LINE_STRIP
+   * `4` TRIANGLES
+   * `5` TRIANGLE_STRIP
+   * `6` TRIANGLE_FAN
+
+#### mesh.primitive.targets
+
+An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.
+
+* **Type**: `object` `[1-*]`
+* **Required**: No
+
+#### mesh.primitive.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: extension
+
+#### mesh.primitive.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -2805,10 +3407,10 @@ Application-specific data.
 
 A node in the node hierarchy.  When the node contains [`skin`](#reference-skin), all `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.
 
-**Properties**
+**`node` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**camera**|`integer`|The index of the camera referenced by this node.|No|
 |**children**|`integer` `[1-*]`|The indices of this node's children.|No|
 |**skin**|`integer`|The index of the skin referenced by this node.|No|
@@ -2819,8 +3421,8 @@ A node in the node hierarchy.  When the node contains [`skin`](#reference-skin),
 |**translation**|`number` `[3]`|The node's translation along the x, y, and z axes.|No, default: `[0,0,0]`|
 |**weights**|`number` `[1-*]`|The weights of the instantiated Morph Target. Number of elements must match number of Morph Targets of used mesh.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
@@ -2907,7 +3509,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -2915,441 +3517,7 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-normaltextureinfo"></a>
-### normalTextureInfo
-
-Reference to a texture.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**index**|`integer`|The index of the texture.| :white_check_mark: Yes|
-|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
-|**scale**|`number`|The scalar multiplier applied to each normal vector of the normal texture.|No, default: `1`|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [material.normalTextureInfo.schema.json](schema/material.normalTextureInfo.schema.json)
-
-#### normalTextureInfo.index :white_check_mark: 
-
-The index of the texture.
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### normalTextureInfo.texCoord
-
-This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### normalTextureInfo.scale
-
-The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-
-#### normalTextureInfo.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### normalTextureInfo.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-occlusiontextureinfo"></a>
-### occlusionTextureInfo
-
-Reference to a texture.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**index**|`integer`|The index of the texture.| :white_check_mark: Yes|
-|**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
-|**strength**|`number`|A scalar multiplier controlling the amount of occlusion applied.|No, default: `1`|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [material.occlusionTextureInfo.schema.json](schema/material.occlusionTextureInfo.schema.json)
-
-#### occlusionTextureInfo.index :white_check_mark: 
-
-The index of the texture.
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### occlusionTextureInfo.texCoord
-
-This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### occlusionTextureInfo.strength
-
-A scalar multiplier controlling the amount of occlusion applied. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion. This value affects the resulting color using the formula: `occludedColor = lerp(color, color * <sampled occlusion texture value>, <occlusion strength>)`. This value is ignored if the corresponding texture is not specified. This value is linear.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-* **Minimum**: ` >= 0`
-* **Maximum**: ` <= 1`
-
-#### occlusionTextureInfo.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### occlusionTextureInfo.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-orthographic"></a>
-### orthographic
-
-An orthographic camera containing properties to create an orthographic projection matrix.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**xmag**|`number`|The floating-point horizontal magnification of the view. Must not be zero.| :white_check_mark: Yes|
-|**ymag**|`number`|The floating-point vertical magnification of the view. Must not be zero.| :white_check_mark: Yes|
-|**zfar**|`number`|The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.| :white_check_mark: Yes|
-|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [camera.orthographic.schema.json](schema/camera.orthographic.schema.json)
-
-#### orthographic.xmag :white_check_mark: 
-
-The floating-point horizontal magnification of the view. Must not be zero.
-
-* **Type**: `number`
-* **Required**: Yes
-
-#### orthographic.ymag :white_check_mark: 
-
-The floating-point vertical magnification of the view. Must not be zero.
-
-* **Type**: `number`
-* **Required**: Yes
-
-#### orthographic.zfar :white_check_mark: 
-
-The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.
-
-* **Type**: `number`
-* **Required**: Yes
-* **Minimum**: ` > 0`
-
-#### orthographic.znear :white_check_mark: 
-
-The floating-point distance to the near clipping plane.
-
-* **Type**: `number`
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### orthographic.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### orthographic.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-pbrmetallicroughness"></a>
-### pbrMetallicRoughness
-
-A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**baseColorFactor**|`number` `[4]`|The material's base color factor.|No, default: `[1,1,1,1]`|
-|**baseColorTexture**|`object`|The base color texture.|No|
-|**metallicFactor**|`number`|The metalness of the material.|No, default: `1`|
-|**roughnessFactor**|`number`|The roughness of the material.|No, default: `1`|
-|**metallicRoughnessTexture**|`object`|The metallic-roughness texture.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [material.pbrMetallicRoughness.schema.json](schema/material.pbrMetallicRoughness.schema.json)
-
-#### pbrMetallicRoughness.baseColorFactor
-
-The RGBA components of the base color of the material. The fourth component (A) is the alpha coverage of the material. The `alphaMode` property specifies how alpha is interpreted. These values are linear. If a baseColorTexture is specified, this value is multiplied with the texel values.
-
-* **Type**: `number` `[4]`
-   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
-* **Required**: No, default: `[1,1,1,1]`
-
-#### pbrMetallicRoughness.baseColorTexture
-
-The base color texture. The first three components (RGB) are encoded with the sRGB transfer function. They specify the base color of the material. If the fourth component (A) is present, it represents the linear alpha coverage of the material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property specifies how alpha is interpreted. The stored texels must not be premultiplied.
-
-* **Type**: `object`
-* **Required**: No
-
-#### pbrMetallicRoughness.metallicFactor
-
-The metalness of the material. A value of 1.0 means the material is a metal. A value of 0.0 means the material is a dielectric. Values in between are for blending between metals and dielectrics such as dirty metallic surfaces. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the metallic texel values.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-* **Minimum**: ` >= 0`
-* **Maximum**: ` <= 1`
-
-#### pbrMetallicRoughness.roughnessFactor
-
-The roughness of the material. A value of 1.0 means the material is completely rough. A value of 0.0 means the material is completely smooth. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the roughness texel values.
-
-* **Type**: `number`
-* **Required**: No, default: `1`
-* **Minimum**: ` >= 0`
-* **Maximum**: ` <= 1`
-
-#### pbrMetallicRoughness.metallicRoughnessTexture
-
-The metallic-roughness texture. The metalness values are sampled from the B channel. The roughness values are sampled from the G channel. These values are linear. If other channels are present (R or A), they are ignored for metallic-roughness calculations.
-
-* **Type**: `object`
-* **Required**: No
-
-#### pbrMetallicRoughness.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### pbrMetallicRoughness.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-perspective"></a>
-### perspective
-
-A perspective camera containing properties to create a perspective projection matrix.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**aspectRatio**|`number`|The floating-point aspect ratio of the field of view.|No|
-|**yfov**|`number`|The floating-point vertical field of view in radians.| :white_check_mark: Yes|
-|**zfar**|`number`|The floating-point distance to the far clipping plane.|No|
-|**znear**|`number`|The floating-point distance to the near clipping plane.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [camera.perspective.schema.json](schema/camera.perspective.schema.json)
-
-#### perspective.aspectRatio
-
-The floating-point aspect ratio of the field of view. When this is undefined, the aspect ratio of the canvas is used.
-
-* **Type**: `number`
-* **Required**: No
-* **Minimum**: ` > 0`
-
-#### perspective.yfov :white_check_mark: 
-
-The floating-point vertical field of view in radians.
-
-* **Type**: `number`
-* **Required**: Yes
-* **Minimum**: ` > 0`
-
-#### perspective.zfar
-
-The floating-point distance to the far clipping plane. When defined, `zfar` must be greater than `znear`. If `zfar` is undefined, runtime must use infinite projection matrix.
-
-* **Type**: `number`
-* **Required**: No
-* **Minimum**: ` > 0`
-
-#### perspective.znear :white_check_mark: 
-
-The floating-point distance to the near clipping plane.
-
-* **Type**: `number`
-* **Required**: Yes
-* **Minimum**: ` > 0`
-
-#### perspective.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### perspective.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-primitive"></a>
-### primitive
-
-Geometry to be rendered with the given material.
-
-**Related WebGL functions**: `drawElements()` and `drawArrays()`
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**attributes**|`object`|A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.| :white_check_mark: Yes|
-|**indices**|`integer`|The index of the accessor that contains the indices.|No|
-|**material**|`integer`|The index of the material to apply to this primitive when rendering.|No|
-|**mode**|`integer`|The type of primitives to render.|No, default: `4`|
-|**targets**|`object` `[1-*]`|An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [mesh.primitive.schema.json](schema/mesh.primitive.schema.json)
-
-#### primitive.attributes :white_check_mark: 
-
-A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.
-
-* **Type**: `object`
-* **Required**: Yes
-* **Type of each property**: `integer`
-
-#### primitive.indices
-
-The index of the accessor that contains mesh indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.  When defined, the accessor must contain indices: the [`bufferView`](#reference-bufferview) referenced by the accessor should have a [`target`](#reference-target) equal to 34963 (ELEMENT_ARRAY_BUFFER); `componentType` must be 5121 (UNSIGNED_BYTE), 5123 (UNSIGNED_SHORT) or 5125 (UNSIGNED_INT), the latter may require enabling additional hardware support; `type` must be `"SCALAR"`. For triangle primitives, the front face has a counter-clockwise (CCW) winding order.
-
-Values of the index accessor must not include the maximum value for the given component type, which triggers primitive restart in several graphics APIs and would require client implementations to rebuild the index buffer. Primitive restart values are disallowed and all index values must refer to actual vertices. As a result, the index accessor's values must not exceed the following maxima: BYTE `< 255`, UNSIGNED_SHORT `< 65535`, UNSIGNED_INT `< 4294967295`.
-
-* **Type**: `integer`
-* **Required**: No
-* **Minimum**: ` >= 0`
-
-#### primitive.material
-
-The index of the material to apply to this primitive when rendering.
-
-* **Type**: `integer`
-* **Required**: No
-* **Minimum**: ` >= 0`
-
-#### primitive.mode
-
-The type of primitives to render. All valid values correspond to WebGL enums.
-
-* **Type**: `integer`
-* **Required**: No, default: `4`
-* **Allowed values**:
-   * `0` POINTS
-   * `1` LINES
-   * `2` LINE_LOOP
-   * `3` LINE_STRIP
-   * `4` TRIANGLES
-   * `5` TRIANGLE_STRIP
-   * `6` TRIANGLE_FAN
-
-#### primitive.targets
-
-An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.
-
-* **Type**: `object` `[1-*]`
-* **Required**: No
-
-#### primitive.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### primitive.extras
-
-Application-specific data.
-
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -3363,17 +3531,17 @@ Texture sampler properties for filtering and wrapping modes.
 
 **Related WebGL functions**: `texParameterf()`
 
-**Properties**
+**`sampler` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**magFilter**|`integer`|Magnification filter.|No|
 |**minFilter**|`integer`|Minification filter.|No|
 |**wrapS**|`integer`|s wrapping mode.|No, default: `10497`|
 |**wrapT**|`integer`|t wrapping mode.|No, default: `10497`|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
@@ -3440,7 +3608,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -3448,7 +3616,7 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -3460,14 +3628,14 @@ Application-specific data.
 
 The root nodes of a scene.
 
-**Properties**
+**`scene` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**nodes**|`integer` `[1-*]`|The indices of each root node.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
@@ -3493,7 +3661,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -3501,7 +3669,7 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -3513,16 +3681,16 @@ Application-specific data.
 
 Joints and matrices defining a skin.
 
-**Properties**
+**`skin` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**inverseBindMatrices**|`integer`|The index of the accessor containing the floating-point 4x4 inverse-bind matrices.  The default is that each matrix is a 4x4 identity matrix, which implies that inverse-bind matrices were pre-applied.|No|
 |**skeleton**|`integer`|The index of the node used as a skeleton root.|No|
-|**joints**|`integer` `[1-*]`|Indices of skeleton nodes, used as joints in this skin.| :white_check_mark: Yes|
+|**joints**|`integer` `[1-*]`|Indices of skeleton nodes, used as joints in this skin.| &#x2705; Yes|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
@@ -3544,7 +3712,7 @@ The index of the node used as a skeleton root. The node must be the closest comm
 * **Required**: No
 * **Minimum**: ` >= 0`
 
-#### skin.joints :white_check_mark: 
+#### skin.joints &#x2705; 
 
 Indices of skeleton nodes, used as joints in this skin.  The array length must be the same as the `count` property of the `inverseBindMatrices` accessor (when defined).
 
@@ -3564,7 +3732,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -3572,124 +3740,7 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-sparse"></a>
-### sparse
-
-Sparse storage of attributes that deviate from their initialization value.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**count**|`integer`|Number of entries stored in the sparse array.| :white_check_mark: Yes|
-|**indices**|`object`|Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.| :white_check_mark: Yes|
-|**values**|`object`|Array of size `count` times number of components, storing the displaced accessor attributes pointed by [`indices`](#reference-indices). Substituted values must have the same `componentType` and number of components as the base accessor.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [accessor.sparse.schema.json](schema/accessor.sparse.schema.json)
-
-#### sparse.count :white_check_mark: 
-
-The number of attributes encoded in this sparse accessor.
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Minimum**: ` >= 1`
-
-#### sparse.indices :white_check_mark: 
-
-Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.
-
-* **Type**: `object`
-* **Required**: Yes
-
-#### sparse.values :white_check_mark: 
-
-Array of size `count` times number of components, storing the displaced accessor attributes pointed by [`indices`](#reference-indices). Substituted values must have the same `componentType` and number of components as the base accessor.
-
-* **Type**: `object`
-* **Required**: Yes
-
-#### sparse.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### sparse.extras
-
-Application-specific data.
-
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-target"></a>
-### target
-
-The index of the node and TRS property that an animation channel targets.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**node**|`integer`|The index of the node to target.|No|
-|**path**|`string`|The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.| :white_check_mark: Yes|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [animation.channel.target.schema.json](schema/animation.channel.target.schema.json)
-
-#### target.node
-
-The index of the node to target.
-
-* **Type**: `integer`
-* **Required**: No
-* **Minimum**: ` >= 0`
-
-#### target.path :white_check_mark: 
-
-The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.
-
-* **Type**: `string`
-* **Required**: Yes
-* **Allowed values**:
-   * `"translation"`
-   * `"rotation"`
-   * `"scale"`
-   * `"weights"`
-
-#### target.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### target.extras
-
-Application-specific data.
-
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -3703,15 +3754,15 @@ A texture and its sampler.
 
 **Related WebGL functions**: `createTexture()`, `deleteTexture()`, `bindTexture()`, `texImage2D()`, and `texParameterf()`
 
-**Properties**
+**`texture` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**sampler**|`integer`|The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.|No|
 |**source**|`integer`|The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined.|No|
 |**name**|`string`|The user-defined name of this object.|No|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
@@ -3744,7 +3795,7 @@ The user-defined name of this object.  This is not necessarily unique, e.g., an 
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -3752,7 +3803,7 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 
@@ -3764,20 +3815,20 @@ Application-specific data.
 
 Reference to a texture.
 
-**Properties**
+**`textureInfo` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
-|**index**|`integer`|The index of the texture.| :white_check_mark: Yes|
+|---|---|---|---|
+|**index**|`integer`|The index of the texture.| &#x2705; Yes|
 |**texCoord**|`integer`|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.|No, default: `0`|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
 Additional properties are allowed.
 
 * **JSON schema**: [textureInfo.schema.json](schema/textureInfo.schema.json)
 
-#### textureInfo.index :white_check_mark: 
+#### textureInfo.index &#x2705; 
 
 The index of the texture.
 
@@ -3797,7 +3848,7 @@ This integer value is used to construct a string in the format `TEXCOORD_<set in
 
 Dictionary object with extension-specific objects.
 
-* **Type**: `object`
+* **Type**: [`extension`](#reference-extension)
 * **Required**: No
 * **Type of each property**: extension
 
@@ -3805,60 +3856,7 @@ Dictionary object with extension-specific objects.
 
 Application-specific data.
 
-* **Type**: `any`
-* **Required**: No
-
-
-
-
----------------------------------------
-<a name="reference-values"></a>
-### values
-
-Array of size `accessor.sparse.count` times number of components storing the displaced accessor attributes pointed by `accessor.sparse.indices`.
-
-**Properties**
-
-|   |Type|Description|Required|
-|---|----|-----------|--------|
-|**bufferView**|`integer`|The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.| :white_check_mark: Yes|
-|**byteOffset**|`integer`|The offset relative to the start of the bufferView in bytes. Must be aligned.|No, default: `0`|
-|**extensions**|`object`|Dictionary object with extension-specific objects.|No|
-|**extras**|`any`|Application-specific data.|No|
-
-Additional properties are allowed.
-
-* **JSON schema**: [accessor.sparse.values.schema.json](schema/accessor.sparse.values.schema.json)
-
-#### values.bufferView :white_check_mark: 
-
-The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
-
-* **Type**: `integer`
-* **Required**: Yes
-* **Minimum**: ` >= 0`
-
-#### values.byteOffset
-
-The offset relative to the start of the bufferView in bytes. Must be aligned.
-
-* **Type**: `integer`
-* **Required**: No, default: `0`
-* **Minimum**: ` >= 0`
-
-#### values.extensions
-
-Dictionary object with extension-specific objects.
-
-* **Type**: `object`
-* **Required**: No
-* **Type of each property**: extension
-
-#### values.extras
-
-Application-specific data.
-
-* **Type**: `any`
+* **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
 

--- a/specification/2.0/REFERENCE.adoc
+++ b/specification/2.0/REFERENCE.adoc
@@ -1,0 +1,2973 @@
+== Objects
+* link:#reference-accessor[`accessor`]
+** link:#reference-accessor-sparse[`accessor.sparse`]
+*** link:#reference-accessor-sparse-indices[`accessor.sparse.indices`]
+*** link:#reference-accessor-sparse-values[`accessor.sparse.values`]
+* link:#reference-animation[`animation`]
+** link:#reference-animation-channel[`animation.channel`]
+*** link:#reference-animation-channel-target[`animation.channel.target`]
+** link:#reference-animation-sampler[`animation.sampler`]
+* link:#reference-asset[`asset`]
+* link:#reference-buffer[`buffer`]
+* link:#reference-bufferview[`bufferView`]
+* link:#reference-camera[`camera`]
+** link:#reference-camera-orthographic[`camera.orthographic`]
+** link:#reference-camera-perspective[`camera.perspective`]
+* link:#reference-extension[`extension`]
+* link:#reference-extras[`extras`]
+* link:#reference-gltf[`glTF`] (root object)
+* link:#reference-image[`image`]
+* link:#reference-material[`material`]
+** link:#reference-material-normaltextureinfo[`material.normalTextureInfo`]
+** link:#reference-material-occlusiontextureinfo[`material.occlusionTextureInfo`]
+** link:#reference-material-pbrmetallicroughness[`material.pbrMetallicRoughness`]
+* link:#reference-mesh[`mesh`]
+** link:#reference-mesh-primitive[`mesh.primitive`]
+* link:#reference-node[`node`]
+* link:#reference-sampler[`sampler`]
+* link:#reference-scene[`scene`]
+* link:#reference-skin[`skin`]
+* link:#reference-texture[`texture`]
+* link:#reference-textureinfo[`textureInfo`]
+
+
+'''
+[#reference-accessor]
+=== accessor
+
+A typed view into a bufferView.  A bufferView contains raw binary data.  An accessor provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.
+
+.`accessor` Properties
+|===
+|   |Type|Description|Required
+
+|**bufferView**
+|`integer`
+|The index of the bufferView.
+|No
+
+|**byteOffset**
+|`integer`
+|The offset relative to the start of the bufferView in bytes.
+|No, default: `0`
+
+|**componentType**
+|`integer`
+|The datatype of components in the attribute.
+| &#x2705; Yes
+
+|**normalized**
+|`boolean`
+|Specifies whether integer data values should be normalized.
+|No, default: `false`
+
+|**count**
+|`integer`
+|The number of attributes referenced by this accessor.
+| &#x2705; Yes
+
+|**type**
+|`string`
+|Specifies if the attribute is a scalar, vector, or matrix.
+| &#x2705; Yes
+
+|**max**
+|`number` `[1-16]`
+|Maximum value of each component in this attribute.
+|No
+
+|**min**
+|`number` `[1-16]`
+|Minimum value of each component in this attribute.
+|No
+
+|**sparse**
+|link:#reference-accessor-sparse[`accessor.sparse`]
+|Sparse storage of attributes that deviate from their initialization value.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/accessor.schema.json[accessor.schema.json]
+
+==== accessor.bufferView
+
+The index of the bufferView. When not defined, accessor must be initialized with zeros; `sparse` property or extensions could override zeros with actual values.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== accessor.byteOffset
+
+The offset relative to the start of the bufferView in bytes.  This must be a multiple of the size of the component datatype.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+* **Related WebGL functions**: `vertexAttribPointer()` offset parameter
+
+==== accessor.componentType &#x2705; 
+
+The datatype of components in the attribute.  All valid values correspond to WebGL enums.  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, `Uint32Array`, and `Float32Array`, respectively.  5125 (UNSIGNED_INT) is only allowed when the accessor contains indices, i.e., the accessor is only referenced by `primitive.indices`.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Allowed values**:
+** `5120` BYTE
+** `5121` UNSIGNED_BYTE
+** `5122` SHORT
+** `5123` UNSIGNED_SHORT
+** `5125` UNSIGNED_INT
+** `5126` FLOAT
+* **Related WebGL functions**: `vertexAttribPointer()` type parameter
+
+==== accessor.normalized
+
+Specifies whether integer data values should be normalized (`true`) to [0, 1] (for unsigned types) or [-1, 1] (for signed types), or converted directly (`false`) when they are accessed. This property is defined only for accessors that contain vertex attributes or animation output data.
+
+* **Type**: `boolean`
+* **Required**: No, default: `false`
+* **Related WebGL functions**: `vertexAttribPointer()` normalized parameter
+
+==== accessor.count &#x2705; 
+
+The number of attributes referenced by this accessor, not to be confused with the number of bytes or number of components.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+==== accessor.type &#x2705; 
+
+Specifies if the attribute is a scalar, vector, or matrix.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+** `"SCALAR"`
+** `"VEC2"`
+** `"VEC3"`
+** `"VEC4"`
+** `"MAT2"`
+** `"MAT3"`
+** `"MAT4"`
+
+==== accessor.max
+
+Maximum value of each component in this attribute.  Array elements must be treated as having the same data type as accessor's `componentType`. Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be 1, 2, 3, 4, 9, or 16.
+
+`normalized` property has no effect on array values: they always correspond to the actual values stored in the buffer. When accessor is sparse, this property must contain max values of accessor data with sparse substitution applied.
+
+* **Type**: `number` `[1-16]`
+* **Required**: No
+
+==== accessor.min
+
+Minimum value of each component in this attribute.  Array elements must be treated as having the same data type as accessor's `componentType`. Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be 1, 2, 3, 4, 9, or 16.
+
+`normalized` property has no effect on array values: they always correspond to the actual values stored in the buffer. When accessor is sparse, this property must contain min values of accessor data with sparse substitution applied.
+
+* **Type**: `number` `[1-16]`
+* **Required**: No
+
+==== accessor.sparse
+
+Sparse storage of attributes that deviate from their initialization value.
+
+* **Type**: link:#reference-accessor-sparse[`accessor.sparse`]
+* **Required**: No
+
+==== accessor.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== accessor.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== accessor.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-accessor-sparse]
+=== accessor.sparse
+
+Sparse storage of attributes that deviate from their initialization value.
+
+.`accessor.sparse` Properties
+|===
+|   |Type|Description|Required
+
+|**count**
+|`integer`
+|Number of entries stored in the sparse array.
+| &#x2705; Yes
+
+|**indices**
+|link:#reference-accessor-sparse-indices[`accessor.sparse.indices`]
+|Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.
+| &#x2705; Yes
+
+|**values**
+|link:#reference-accessor-sparse-values[`accessor.sparse.values`]
+|Array of size `count` times number of components, storing the displaced accessor attributes pointed by `indices`. Substituted values must have the same `componentType` and number of components as the base accessor.
+| &#x2705; Yes
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/accessor.sparse.schema.json[accessor.sparse.schema.json]
+
+==== accessor.sparse.count &#x2705; 
+
+The number of attributes encoded in this sparse accessor.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+==== accessor.sparse.indices &#x2705; 
+
+Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase.
+
+* **Type**: link:#reference-accessor-sparse-indices[`accessor.sparse.indices`]
+* **Required**: Yes
+
+==== accessor.sparse.values &#x2705; 
+
+Array of size `count` times number of components, storing the displaced accessor attributes pointed by `indices`. Substituted values must have the same `componentType` and number of components as the base accessor.
+
+* **Type**: link:#reference-accessor-sparse-values[`accessor.sparse.values`]
+* **Required**: Yes
+
+==== accessor.sparse.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== accessor.sparse.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-accessor-sparse-indices]
+=== accessor.sparse.indices
+
+Indices of those attributes that deviate from their initialization value.
+
+.`accessor.sparse.indices` Properties
+|===
+|   |Type|Description|Required
+
+|**bufferView**
+|`integer`
+|The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+| &#x2705; Yes
+
+|**byteOffset**
+|`integer`
+|The offset relative to the start of the bufferView in bytes. Must be aligned.
+|No, default: `0`
+
+|**componentType**
+|`integer`
+|The indices data type.
+| &#x2705; Yes
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/accessor.sparse.indices.schema.json[accessor.sparse.indices.schema.json]
+
+==== accessor.sparse.indices.bufferView &#x2705; 
+
+The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+==== accessor.sparse.indices.byteOffset
+
+The offset relative to the start of the bufferView in bytes. Must be aligned.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+==== accessor.sparse.indices.componentType &#x2705; 
+
+The indices data type.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `5123` (UNSIGNED_SHORT), `5125` (UNSIGNED_INT).
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Allowed values**:
+** `5121` UNSIGNED_BYTE
+** `5123` UNSIGNED_SHORT
+** `5125` UNSIGNED_INT
+
+==== accessor.sparse.indices.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== accessor.sparse.indices.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-accessor-sparse-values]
+=== accessor.sparse.values
+
+Array of size `accessor.sparse.count` times number of components storing the displaced accessor attributes pointed by link:#reference-accessor-sparse-indices[`accessor.sparse.indices`].
+
+.`accessor.sparse.values` Properties
+|===
+|   |Type|Description|Required
+
+|**bufferView**
+|`integer`
+|The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+| &#x2705; Yes
+
+|**byteOffset**
+|`integer`
+|The offset relative to the start of the bufferView in bytes. Must be aligned.
+|No, default: `0`
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/accessor.sparse.values.schema.json[accessor.sparse.values.schema.json]
+
+==== accessor.sparse.values.bufferView &#x2705; 
+
+The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+==== accessor.sparse.values.byteOffset
+
+The offset relative to the start of the bufferView in bytes. Must be aligned.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+==== accessor.sparse.values.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== accessor.sparse.values.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-animation]
+=== animation
+
+A keyframe animation.
+
+.`animation` Properties
+|===
+|   |Type|Description|Required
+
+|**channels**
+|link:#reference-animation-channel[`animation.channel`] `[1-*]`
+|An array of channels, each of which targets an animation's sampler at a node's property. Different channels of the same animation can't have equal targets.
+| &#x2705; Yes
+
+|**samplers**
+|link:#reference-animation-sampler[`animation.sampler`] `[1-*]`
+|An array of samplers that combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
+| &#x2705; Yes
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/animation.schema.json[animation.schema.json]
+
+==== animation.channels &#x2705; 
+
+An array of channels, each of which targets an animation's sampler at a node's property. Different channels of the same animation can't have equal targets.
+
+* **Type**: link:#reference-animation-channel[`animation.channel`] `[1-*]`
+* **Required**: Yes
+
+==== animation.samplers &#x2705; 
+
+An array of samplers that combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
+
+* **Type**: link:#reference-animation-sampler[`animation.sampler`] `[1-*]`
+* **Required**: Yes
+
+==== animation.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== animation.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== animation.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-animation-channel]
+=== animation.channel
+
+Targets an animation's sampler at a node's property.
+
+.`animation.channel` Properties
+|===
+|   |Type|Description|Required
+
+|**sampler**
+|`integer`
+|The index of a sampler in this animation used to compute the value for the target.
+| &#x2705; Yes
+
+|**target**
+|link:#reference-animation-channel-target[`animation.channel.target`]
+|The index of the node and TRS property to target.
+| &#x2705; Yes
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/animation.channel.schema.json[animation.channel.schema.json]
+
+==== animation.channel.sampler &#x2705; 
+
+The index of a sampler in this animation used to compute the value for the target, e.g., a node's translation, rotation, or scale (TRS).
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+==== animation.channel.target &#x2705; 
+
+The index of the node and TRS property to target.
+
+* **Type**: link:#reference-animation-channel-target[`animation.channel.target`]
+* **Required**: Yes
+
+==== animation.channel.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== animation.channel.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-animation-channel-target]
+=== animation.channel.target
+
+The index of the node and TRS property that an animation channel targets.
+
+.`animation.channel.target` Properties
+|===
+|   |Type|Description|Required
+
+|**node**
+|`integer`
+|The index of the node to target.
+|No
+
+|**path**
+|`string`
+|The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.
+| &#x2705; Yes
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/animation.channel.target.schema.json[animation.channel.target.schema.json]
+
+==== animation.channel.target.node
+
+The index of the node to target.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== animation.channel.target.path &#x2705; 
+
+The name of the node's TRS property to modify, or the "weights" of the Morph Targets it instantiates. For the "translation" property, the values that are provided by the sampler are the translation along the x, y, and z axes. For the "rotation" property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the "scale" property, the values are the scaling factors along the x, y, and z axes.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+** `"translation"`
+** `"rotation"`
+** `"scale"`
+** `"weights"`
+
+==== animation.channel.target.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== animation.channel.target.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-animation-sampler]
+=== animation.sampler
+
+Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).
+
+.`animation.sampler` Properties
+|===
+|   |Type|Description|Required
+
+|**input**
+|`integer`
+|The index of an accessor containing keyframe input values, e.g., time.
+| &#x2705; Yes
+
+|**interpolation**
+|`string`
+|Interpolation algorithm.
+|No, default: `"LINEAR"`
+
+|**output**
+|`integer`
+|The index of an accessor, containing keyframe output values.
+| &#x2705; Yes
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/animation.sampler.schema.json[animation.sampler.schema.json]
+
+==== animation.sampler.input &#x2705; 
+
+The index of an accessor containing keyframe input values, e.g., time. That accessor must have componentType `FLOAT`. The values represent time in seconds with `time[0] >= 0.0`, and strictly increasing values, i.e., `time[n + 1] > time[n]`.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+==== animation.sampler.interpolation
+
+Interpolation algorithm.
+
+* **Type**: `string`
+* **Required**: No, default: `"LINEAR"`
+* **Allowed values**:
+** `"LINEAR"` The animated values are linearly interpolated between keyframes. When targeting a rotation, spherical linear interpolation (slerp) should be used to interpolate quaternions. The number output of elements must equal the number of input elements.
+** `"STEP"` The animated values remain constant to the output of the first keyframe, until the next keyframe. The number of output elements must equal the number of input elements.
+** `"CUBICSPLINE"` The animation's interpolation is computed using a cubic spline with specified tangents. The number of output elements must equal three times the number of input elements. For each input element, the output stores three elements, an in-tangent, a spline vertex, and an out-tangent. There must be at least two keyframes when using this interpolation.
+
+==== animation.sampler.output &#x2705; 
+
+The index of an accessor containing keyframe output values. When targeting translation or scale paths, the `accessor.componentType` of the output values must be `FLOAT`. When targeting rotation or morph weights, the `accessor.componentType` of the output values must be `FLOAT` or normalized integer. For weights, each output element stores `SCALAR` values with a count equal to the number of morph targets.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+==== animation.sampler.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== animation.sampler.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-asset]
+=== asset
+
+Metadata about the glTF asset.
+
+.`asset` Properties
+|===
+|   |Type|Description|Required
+
+|**copyright**
+|`string`
+|A copyright message suitable for display to credit the content creator.
+|No
+
+|**generator**
+|`string`
+|Tool that generated this glTF model.  Useful for debugging.
+|No
+
+|**version**
+|`string`
+|The glTF version that this asset targets.
+| &#x2705; Yes
+
+|**minVersion**
+|`string`
+|The minimum glTF version that this asset targets.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/asset.schema.json[asset.schema.json]
+
+==== asset.copyright
+
+A copyright message suitable for display to credit the content creator.
+
+* **Type**: `string`
+* **Required**: No
+
+==== asset.generator
+
+Tool that generated this glTF model.  Useful for debugging.
+
+* **Type**: `string`
+* **Required**: No
+
+==== asset.version &#x2705; 
+
+The glTF version that this asset targets.
+
+* **Type**: `string`
+* **Required**: Yes
+
+==== asset.minVersion
+
+The minimum glTF version that this asset targets.
+
+* **Type**: `string`
+* **Required**: No
+
+==== asset.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== asset.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-buffer]
+=== buffer
+
+A buffer points to binary geometry, animation, or skins.
+
+.`buffer` Properties
+|===
+|   |Type|Description|Required
+
+|**uri**
+|`string`
+|The uri of the buffer.
+|No
+
+|**byteLength**
+|`integer`
+|The length of the buffer in bytes.
+| &#x2705; Yes
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/buffer.schema.json[buffer.schema.json]
+
+==== buffer.uri
+
+The uri of the buffer.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
+
+==== buffer.byteLength &#x2705; 
+
+The length of the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+==== buffer.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== buffer.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== buffer.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-bufferview]
+=== bufferView
+
+A view into a buffer generally representing a subset of the buffer.
+
+.`bufferView` Properties
+|===
+|   |Type|Description|Required
+
+|**buffer**
+|`integer`
+|The index of the buffer.
+| &#x2705; Yes
+
+|**byteOffset**
+|`integer`
+|The offset into the buffer in bytes.
+|No, default: `0`
+
+|**byteLength**
+|`integer`
+|The length of the bufferView in bytes.
+| &#x2705; Yes
+
+|**byteStride**
+|`integer`
+|The stride, in bytes.
+|No
+
+|**target**
+|`integer`
+|The target that the GPU buffer should be bound to.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/bufferView.schema.json[bufferView.schema.json]
+
+==== bufferView.buffer &#x2705; 
+
+The index of the buffer.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+==== bufferView.byteOffset
+
+The offset into the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+==== bufferView.byteLength &#x2705; 
+
+The length of the bufferView in bytes.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+==== bufferView.byteStride
+
+The stride, in bytes, between vertex attributes.  When this is not defined, data is tightly packed. When two or more accessors use the same bufferView, this field must be defined.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 4`
+* **Maximum**: ` <= 252`
+* **Related WebGL functions**: `vertexAttribPointer()` stride parameter
+
+==== bufferView.target
+
+The target that the GPU buffer should be bound to.
+
+* **Type**: `integer`
+* **Required**: No
+* **Allowed values**:
+** `34962` ARRAY_BUFFER
+** `34963` ELEMENT_ARRAY_BUFFER
+* **Related WebGL functions**: `bindBuffer()`
+
+==== bufferView.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== bufferView.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== bufferView.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-camera]
+=== camera
+
+A camera's projection.  A node can reference a camera to apply a transform to place the camera in the scene.
+
+.`camera` Properties
+|===
+|   |Type|Description|Required
+
+|**orthographic**
+|link:#reference-camera-orthographic[`camera.orthographic`]
+|An orthographic camera containing properties to create an orthographic projection matrix.
+|No
+
+|**perspective**
+|link:#reference-camera-perspective[`camera.perspective`]
+|A perspective camera containing properties to create a perspective projection matrix.
+|No
+
+|**type**
+|`string`
+|Specifies if the camera uses a perspective or orthographic projection.
+| &#x2705; Yes
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/camera.schema.json[camera.schema.json]
+
+==== camera.orthographic
+
+An orthographic camera containing properties to create an orthographic projection matrix.
+
+* **Type**: link:#reference-camera-orthographic[`camera.orthographic`]
+* **Required**: No
+
+==== camera.perspective
+
+A perspective camera containing properties to create a perspective projection matrix.
+
+* **Type**: link:#reference-camera-perspective[`camera.perspective`]
+* **Required**: No
+
+==== camera.type &#x2705; 
+
+Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's `perspective` or `orthographic` property will be defined.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+** `"perspective"`
+** `"orthographic"`
+
+==== camera.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== camera.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== camera.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-camera-orthographic]
+=== camera.orthographic
+
+An orthographic camera containing properties to create an orthographic projection matrix.
+
+.`camera.orthographic` Properties
+|===
+|   |Type|Description|Required
+
+|**xmag**
+|`number`
+|The floating-point horizontal magnification of the view. Must not be zero.
+| &#x2705; Yes
+
+|**ymag**
+|`number`
+|The floating-point vertical magnification of the view. Must not be zero.
+| &#x2705; Yes
+
+|**zfar**
+|`number`
+|The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.
+| &#x2705; Yes
+
+|**znear**
+|`number`
+|The floating-point distance to the near clipping plane.
+| &#x2705; Yes
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/camera.orthographic.schema.json[camera.orthographic.schema.json]
+
+==== camera.orthographic.xmag &#x2705; 
+
+The floating-point horizontal magnification of the view. Must not be zero.
+
+* **Type**: `number`
+* **Required**: Yes
+
+==== camera.orthographic.ymag &#x2705; 
+
+The floating-point vertical magnification of the view. Must not be zero.
+
+* **Type**: `number`
+* **Required**: Yes
+
+==== camera.orthographic.zfar &#x2705; 
+
+The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+==== camera.orthographic.znear &#x2705; 
+
+The floating-point distance to the near clipping plane.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+==== camera.orthographic.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== camera.orthographic.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-camera-perspective]
+=== camera.perspective
+
+A perspective camera containing properties to create a perspective projection matrix.
+
+.`camera.perspective` Properties
+|===
+|   |Type|Description|Required
+
+|**aspectRatio**
+|`number`
+|The floating-point aspect ratio of the field of view.
+|No
+
+|**yfov**
+|`number`
+|The floating-point vertical field of view in radians.
+| &#x2705; Yes
+
+|**zfar**
+|`number`
+|The floating-point distance to the far clipping plane.
+|No
+
+|**znear**
+|`number`
+|The floating-point distance to the near clipping plane.
+| &#x2705; Yes
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/camera.perspective.schema.json[camera.perspective.schema.json]
+
+==== camera.perspective.aspectRatio
+
+The floating-point aspect ratio of the field of view. When this is undefined, the aspect ratio of the canvas is used.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+
+==== camera.perspective.yfov &#x2705; 
+
+The floating-point vertical field of view in radians.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+==== camera.perspective.zfar
+
+The floating-point distance to the far clipping plane. When defined, `zfar` must be greater than `znear`. If `zfar` is undefined, runtime must use infinite projection matrix.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+
+==== camera.perspective.znear &#x2705; 
+
+The floating-point distance to the near clipping plane.
+
+* **Type**: `number`
+* **Required**: Yes
+* **Minimum**: ` > 0`
+
+==== camera.perspective.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== camera.perspective.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-extension]
+=== extension
+
+Dictionary object with extension-specific objects.
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/extension.schema.json[extension.schema.json]
+
+
+
+
+'''
+[#reference-extras]
+=== extras
+
+Application-specific data.
+
+**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+'''
+[#reference-gltf]
+=== glTF
+
+The root object for a glTF asset.
+
+.`glTF` Properties
+|===
+|   |Type|Description|Required
+
+|**extensionsUsed**
+|`string` `[1-*]`
+|Names of glTF extensions used somewhere in this asset.
+|No
+
+|**extensionsRequired**
+|`string` `[1-*]`
+|Names of glTF extensions required to properly load this asset.
+|No
+
+|**accessors**
+|link:#reference-accessor[`accessor`] `[1-*]`
+|An array of accessors.
+|No
+
+|**animations**
+|link:#reference-animation[`animation`] `[1-*]`
+|An array of keyframe animations.
+|No
+
+|**asset**
+|link:#reference-asset[`asset`]
+|Metadata about the glTF asset.
+| &#x2705; Yes
+
+|**buffers**
+|link:#reference-buffer[`buffer`] `[1-*]`
+|An array of buffers.
+|No
+
+|**bufferViews**
+|link:#reference-bufferview[`bufferView`] `[1-*]`
+|An array of bufferViews.
+|No
+
+|**cameras**
+|link:#reference-camera[`camera`] `[1-*]`
+|An array of cameras.
+|No
+
+|**images**
+|link:#reference-image[`image`] `[1-*]`
+|An array of images.
+|No
+
+|**materials**
+|link:#reference-material[`material`] `[1-*]`
+|An array of materials.
+|No
+
+|**meshes**
+|link:#reference-mesh[`mesh`] `[1-*]`
+|An array of meshes.
+|No
+
+|**nodes**
+|link:#reference-node[`node`] `[1-*]`
+|An array of nodes.
+|No
+
+|**samplers**
+|link:#reference-sampler[`sampler`] `[1-*]`
+|An array of samplers.
+|No
+
+|**scene**
+|`integer`
+|The index of the default scene.
+|No
+
+|**scenes**
+|link:#reference-scene[`scene`] `[1-*]`
+|An array of scenes.
+|No
+
+|**skins**
+|link:#reference-skin[`skin`] `[1-*]`
+|An array of skins.
+|No
+
+|**textures**
+|link:#reference-texture[`texture`] `[1-*]`
+|An array of textures.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/glTF.schema.json[glTF.schema.json]
+
+==== glTF.extensionsUsed
+
+Names of glTF extensions used somewhere in this asset.
+
+* **Type**: `string` `[1-*]`
+** Each element in the array must be unique.
+* **Required**: No
+
+==== glTF.extensionsRequired
+
+Names of glTF extensions required to properly load this asset.
+
+* **Type**: `string` `[1-*]`
+** Each element in the array must be unique.
+* **Required**: No
+
+==== glTF.accessors
+
+An array of accessors.  An accessor is a typed view into a bufferView.
+
+* **Type**: link:#reference-accessor[`accessor`] `[1-*]`
+* **Required**: No
+
+==== glTF.animations
+
+An array of keyframe animations.
+
+* **Type**: link:#reference-animation[`animation`] `[1-*]`
+* **Required**: No
+
+==== glTF.asset &#x2705; 
+
+Metadata about the glTF asset.
+
+* **Type**: link:#reference-asset[`asset`]
+* **Required**: Yes
+
+==== glTF.buffers
+
+An array of buffers.  A buffer points to binary geometry, animation, or skins.
+
+* **Type**: link:#reference-buffer[`buffer`] `[1-*]`
+* **Required**: No
+
+==== glTF.bufferViews
+
+An array of bufferViews.  A bufferView is a view into a buffer generally representing a subset of the buffer.
+
+* **Type**: link:#reference-bufferview[`bufferView`] `[1-*]`
+* **Required**: No
+
+==== glTF.cameras
+
+An array of cameras.  A camera defines a projection matrix.
+
+* **Type**: link:#reference-camera[`camera`] `[1-*]`
+* **Required**: No
+
+==== glTF.images
+
+An array of images.  An image defines data used to create a texture.
+
+* **Type**: link:#reference-image[`image`] `[1-*]`
+* **Required**: No
+
+==== glTF.materials
+
+An array of materials.  A material defines the appearance of a primitive.
+
+* **Type**: link:#reference-material[`material`] `[1-*]`
+* **Required**: No
+
+==== glTF.meshes
+
+An array of meshes.  A mesh is a set of primitives to be rendered.
+
+* **Type**: link:#reference-mesh[`mesh`] `[1-*]`
+* **Required**: No
+
+==== glTF.nodes
+
+An array of nodes.
+
+* **Type**: link:#reference-node[`node`] `[1-*]`
+* **Required**: No
+
+==== glTF.samplers
+
+An array of samplers.  A sampler contains properties for texture filtering and wrapping modes.
+
+* **Type**: link:#reference-sampler[`sampler`] `[1-*]`
+* **Required**: No
+
+==== glTF.scene
+
+The index of the default scene.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== glTF.scenes
+
+An array of scenes.
+
+* **Type**: link:#reference-scene[`scene`] `[1-*]`
+* **Required**: No
+
+==== glTF.skins
+
+An array of skins.  A skin is defined by joints and matrices.
+
+* **Type**: link:#reference-skin[`skin`] `[1-*]`
+* **Required**: No
+
+==== glTF.textures
+
+An array of textures.
+
+* **Type**: link:#reference-texture[`texture`] `[1-*]`
+* **Required**: No
+
+==== glTF.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== glTF.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+
+
+'''
+[#reference-image]
+=== image
+
+Image data used to create a texture. Image can be referenced by URI or link:#reference-bufferview[`bufferView`] index. `mimeType` is required in the latter case.
+
+.`image` Properties
+|===
+|   |Type|Description|Required
+
+|**uri**
+|`string`
+|The uri of the image.
+|No
+
+|**mimeType**
+|`string`
+|The image's MIME type. Required if link:#reference-bufferview[`bufferView`] is defined.
+|No
+
+|**bufferView**
+|`integer`
+|The index of the bufferView that contains the image. Use this instead of the image's uri property.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/image.schema.json[image.schema.json]
+
+==== image.uri
+
+The uri of the image.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.  The image format must be jpg or png.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
+
+==== image.mimeType
+
+The image's MIME type. Required if link:#reference-bufferview[`bufferView`] is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+** `"image/jpeg"`
+** `"image/png"`
+
+==== image.bufferView
+
+The index of the bufferView that contains the image. Use this instead of the image's uri property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== image.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== image.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== image.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-material]
+=== material
+
+The material appearance of a primitive.
+
+.`material` Properties
+|===
+|   |Type|Description|Required
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|**pbrMetallicRoughness**
+|link:#reference-material-pbrmetallicroughness[`material.pbrMetallicRoughness`]
+|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+|No
+
+|**normalTexture**
+|link:#reference-material-normaltextureinfo[`material.normalTextureInfo`]
+|The normal map texture.
+|No
+
+|**occlusionTexture**
+|link:#reference-material-occlusiontextureinfo[`material.occlusionTextureInfo`]
+|The occlusion map texture.
+|No
+
+|**emissiveTexture**
+|link:#reference-textureinfo[`textureInfo`]
+|The emissive map texture.
+|No
+
+|**emissiveFactor**
+|`number` `[3]`
+|The emissive color of the material.
+|No, default: `[0,0,0]`
+
+|**alphaMode**
+|`string`
+|The alpha rendering mode of the material.
+|No, default: `"OPAQUE"`
+
+|**alphaCutoff**
+|`number`
+|The alpha cutoff value of the material.
+|No, default: `0.5`
+
+|**doubleSided**
+|`boolean`
+|Specifies whether the material is double sided.
+|No, default: `false`
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/material.schema.json[material.schema.json]
+
+==== material.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== material.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== material.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+==== material.pbrMetallicRoughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+
+* **Type**: link:#reference-material-pbrmetallicroughness[`material.pbrMetallicRoughness`]
+* **Required**: No
+
+==== material.normalTexture
+
+A tangent space normal map. The texture contains RGB components in linear space. Each texel represents the XYZ components of a normal vector in tangent space. Red [0 to 255] maps to X [-1 to 1]. Green [0 to 255] maps to Y [-1 to 1]. Blue [128 to 255] maps to Z [1/255 to 1]. The normal vectors use OpenGL conventions where +X is right and +Y is up. +Z points toward the viewer. In GLSL, this vector would be unpacked like so: `vec3 normalVector = tex2D(<sampled normal map texture value>, texCoord) * 2 - 1`. Client implementations should normalize the normal vectors before using them in lighting equations.
+
+* **Type**: link:#reference-material-normaltextureinfo[`material.normalTextureInfo`]
+* **Required**: No
+
+==== material.occlusionTexture
+
+The occlusion map texture. The occlusion values are sampled from the R channel. Higher values indicate areas that should receive full indirect lighting and lower values indicate no indirect lighting. These values are linear. If other channels are present (GBA), they are ignored for occlusion calculations.
+
+* **Type**: link:#reference-material-occlusiontextureinfo[`material.occlusionTextureInfo`]
+* **Required**: No
+
+==== material.emissiveTexture
+
+The emissive map controls the color and intensity of the light being emitted by the material. This texture contains RGB components encoded with the sRGB transfer function. If a fourth component (A) is present, it is ignored.
+
+* **Type**: link:#reference-textureinfo[`textureInfo`]
+* **Required**: No
+
+==== material.emissiveFactor
+
+The RGB components of the emissive color of the material. These values are linear. If an emissiveTexture is specified, this value is multiplied with the texel values.
+
+* **Type**: `number` `[3]`
+** Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[0,0,0]`
+
+==== material.alphaMode
+
+The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.
+
+* **Type**: `string`
+* **Required**: No, default: `"OPAQUE"`
+* **Allowed values**:
+** `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
+** `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
+** `"BLEND"` The alpha value is used to composite the source and destination areas. The rendered output is combined with the background using the normal painting operation (i.e. the Porter and Duff over operator).
+
+==== material.alphaCutoff
+
+Specifies the cutoff threshold when in `MASK` mode. If the alpha value is greater than or equal to this value then it is rendered as fully opaque, otherwise, it is rendered as fully transparent. A value greater than 1.0 will render the entire material as fully transparent. This value is ignored for other modes.
+
+* **Type**: `number`
+* **Required**: No, default: `0.5`
+* **Minimum**: ` >= 0`
+
+==== material.doubleSided
+
+Specifies whether the material is double sided. When this value is false, back-face culling is enabled. When this value is true, back-face culling is disabled and double sided lighting is enabled. The back-face must have its normals reversed before the lighting equation is evaluated.
+
+* **Type**: `boolean`
+* **Required**: No, default: `false`
+
+
+
+
+'''
+[#reference-material-normaltextureinfo]
+=== material.normalTextureInfo
+
+Reference to a texture.
+
+.`material.normalTextureInfo` Properties
+|===
+|   |Type|Description|Required
+
+|**index**
+|`integer`
+|The index of the texture.
+| &#x2705; Yes
+
+|**texCoord**
+|`integer`
+|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.
+|No, default: `0`
+
+|**scale**
+|`number`
+|The scalar multiplier applied to each normal vector of the normal texture.
+|No, default: `1`
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/material.normalTextureInfo.schema.json[material.normalTextureInfo.schema.json]
+
+==== material.normalTextureInfo.index &#x2705; 
+
+The index of the texture.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+==== material.normalTextureInfo.texCoord
+
+This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+==== material.normalTextureInfo.scale
+
+The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+
+==== material.normalTextureInfo.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== material.normalTextureInfo.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-material-occlusiontextureinfo]
+=== material.occlusionTextureInfo
+
+Reference to a texture.
+
+.`material.occlusionTextureInfo` Properties
+|===
+|   |Type|Description|Required
+
+|**index**
+|`integer`
+|The index of the texture.
+| &#x2705; Yes
+
+|**texCoord**
+|`integer`
+|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.
+|No, default: `0`
+
+|**strength**
+|`number`
+|A scalar multiplier controlling the amount of occlusion applied.
+|No, default: `1`
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/material.occlusionTextureInfo.schema.json[material.occlusionTextureInfo.schema.json]
+
+==== material.occlusionTextureInfo.index &#x2705; 
+
+The index of the texture.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+==== material.occlusionTextureInfo.texCoord
+
+This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+==== material.occlusionTextureInfo.strength
+
+A scalar multiplier controlling the amount of occlusion applied. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion. This value affects the resulting color using the formula: `occludedColor = lerp(color, color * <sampled occlusion texture value>, <occlusion strength>)`. This value is ignored if the corresponding texture is not specified. This value is linear.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+==== material.occlusionTextureInfo.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== material.occlusionTextureInfo.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-material-pbrmetallicroughness]
+=== material.pbrMetallicRoughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
+
+.`material.pbrMetallicRoughness` Properties
+|===
+|   |Type|Description|Required
+
+|**baseColorFactor**
+|`number` `[4]`
+|The material's base color factor.
+|No, default: `[1,1,1,1]`
+
+|**baseColorTexture**
+|link:#reference-textureinfo[`textureInfo`]
+|The base color texture.
+|No
+
+|**metallicFactor**
+|`number`
+|The metalness of the material.
+|No, default: `1`
+
+|**roughnessFactor**
+|`number`
+|The roughness of the material.
+|No, default: `1`
+
+|**metallicRoughnessTexture**
+|link:#reference-textureinfo[`textureInfo`]
+|The metallic-roughness texture.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/material.pbrMetallicRoughness.schema.json[material.pbrMetallicRoughness.schema.json]
+
+==== material.pbrMetallicRoughness.baseColorFactor
+
+The RGBA components of the base color of the material. The fourth component (A) is the alpha coverage of the material. The `alphaMode` property specifies how alpha is interpreted. These values are linear. If a baseColorTexture is specified, this value is multiplied with the texel values.
+
+* **Type**: `number` `[4]`
+** Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[1,1,1,1]`
+
+==== material.pbrMetallicRoughness.baseColorTexture
+
+The base color texture. The first three components (RGB) are encoded with the sRGB transfer function. They specify the base color of the material. If the fourth component (A) is present, it represents the linear alpha coverage of the material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property specifies how alpha is interpreted. The stored texels must not be premultiplied.
+
+* **Type**: link:#reference-textureinfo[`textureInfo`]
+* **Required**: No
+
+==== material.pbrMetallicRoughness.metallicFactor
+
+The metalness of the material. A value of 1.0 means the material is a metal. A value of 0.0 means the material is a dielectric. Values in between are for blending between metals and dielectrics such as dirty metallic surfaces. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the metallic texel values.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+==== material.pbrMetallicRoughness.roughnessFactor
+
+The roughness of the material. A value of 1.0 means the material is completely rough. A value of 0.0 means the material is completely smooth. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the roughness texel values.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+==== material.pbrMetallicRoughness.metallicRoughnessTexture
+
+The metallic-roughness texture. The metalness values are sampled from the B channel. The roughness values are sampled from the G channel. These values are linear. If other channels are present (R or A), they are ignored for metallic-roughness calculations.
+
+* **Type**: link:#reference-textureinfo[`textureInfo`]
+* **Required**: No
+
+==== material.pbrMetallicRoughness.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== material.pbrMetallicRoughness.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-mesh]
+=== mesh
+
+A set of primitives to be rendered.  A node can contain one mesh.  A node's transform places the mesh in the scene.
+
+.`mesh` Properties
+|===
+|   |Type|Description|Required
+
+|**primitives**
+|link:#reference-mesh-primitive[`mesh.primitive`] `[1-*]`
+|An array of primitives, each defining geometry to be rendered with a material.
+| &#x2705; Yes
+
+|**weights**
+|`number` `[1-*]`
+|Array of weights to be applied to the Morph Targets.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/mesh.schema.json[mesh.schema.json]
+
+==== mesh.primitives &#x2705; 
+
+An array of primitives, each defining geometry to be rendered with a material.
+
+* **Type**: link:#reference-mesh-primitive[`mesh.primitive`] `[1-*]`
+* **Required**: Yes
+
+==== mesh.weights
+
+Array of weights to be applied to the Morph Targets.
+
+* **Type**: `number` `[1-*]`
+* **Required**: No
+
+==== mesh.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== mesh.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== mesh.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-mesh-primitive]
+=== mesh.primitive
+
+Geometry to be rendered with the given material.
+
+**Related WebGL functions**: `drawElements()` and `drawArrays()`
+
+.`mesh.primitive` Properties
+|===
+|   |Type|Description|Required
+
+|**attributes**
+|`object`
+|A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.
+| &#x2705; Yes
+
+|**indices**
+|`integer`
+|The index of the accessor that contains the indices.
+|No
+
+|**material**
+|`integer`
+|The index of the material to apply to this primitive when rendering.
+|No
+
+|**mode**
+|`integer`
+|The type of primitives to render.
+|No, default: `4`
+
+|**targets**
+|`object` `[1-*]`
+|An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/mesh.primitive.schema.json[mesh.primitive.schema.json]
+
+==== mesh.primitive.attributes &#x2705; 
+
+A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.
+
+* **Type**: `object`
+* **Required**: Yes
+* **Type of each property**: `integer`
+
+==== mesh.primitive.indices
+
+The index of the accessor that contains mesh indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.  When defined, the accessor must contain indices: the link:#reference-bufferview[`bufferView`] referenced by the accessor should have a `target` equal to 34963 (ELEMENT_ARRAY_BUFFER); `componentType` must be 5121 (UNSIGNED_BYTE), 5123 (UNSIGNED_SHORT) or 5125 (UNSIGNED_INT), the latter may require enabling additional hardware support; `type` must be `"SCALAR"`. For triangle primitives, the front face has a counter-clockwise (CCW) winding order. Values of the index accessor must not include the maximum value for the given component type, which triggers primitive restart in several graphics APIs and would require client implementations to rebuild the index buffer. Primitive restart values are disallowed and all index values must refer to actual vertices. As a result, the index accessor's values must not exceed the following maxima: BYTE `< 255`, UNSIGNED_SHORT `< 65535`, UNSIGNED_INT `< 4294967295`.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== mesh.primitive.material
+
+The index of the material to apply to this primitive when rendering.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== mesh.primitive.mode
+
+The type of primitives to render. All valid values correspond to WebGL enums.
+
+* **Type**: `integer`
+* **Required**: No, default: `4`
+* **Allowed values**:
+** `0` POINTS
+** `1` LINES
+** `2` LINE_LOOP
+** `3` LINE_STRIP
+** `4` TRIANGLES
+** `5` TRIANGLE_STRIP
+** `6` TRIANGLE_FAN
+
+==== mesh.primitive.targets
+
+An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.
+
+* **Type**: `object` `[1-*]`
+* **Required**: No
+
+==== mesh.primitive.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== mesh.primitive.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-node]
+=== node
+
+A node in the node hierarchy.  When the node contains link:#reference-skin[`skin`], all `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.
+
+.`node` Properties
+|===
+|   |Type|Description|Required
+
+|**camera**
+|`integer`
+|The index of the camera referenced by this node.
+|No
+
+|**children**
+|`integer` `[1-*]`
+|The indices of this node's children.
+|No
+
+|**skin**
+|`integer`
+|The index of the skin referenced by this node.
+|No
+
+|**matrix**
+|`number` `[16]`
+|A floating-point 4x4 transformation matrix stored in column-major order.
+|No, default: `[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]`
+
+|**mesh**
+|`integer`
+|The index of the mesh in this node.
+|No
+
+|**rotation**
+|`number` `[4]`
+|The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.
+|No, default: `[0,0,0,1]`
+
+|**scale**
+|`number` `[3]`
+|The node's non-uniform scale, given as the scaling factors along the x, y, and z axes.
+|No, default: `[1,1,1]`
+
+|**translation**
+|`number` `[3]`
+|The node's translation along the x, y, and z axes.
+|No, default: `[0,0,0]`
+
+|**weights**
+|`number` `[1-*]`
+|The weights of the instantiated Morph Target. Number of elements must match number of Morph Targets of used mesh.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/node.schema.json[node.schema.json]
+
+==== node.camera
+
+The index of the camera referenced by this node.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== node.children
+
+The indices of this node's children.
+
+* **Type**: `integer` `[1-*]`
+** Each element in the array must be unique.
+** Each element in the array must be greater than or equal to `0`.
+* **Required**: No
+
+==== node.skin
+
+The index of the skin referenced by this node. When a skin is referenced by a node within a scene, all joints used by the skin must belong to the same scene.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== node.matrix
+
+A floating-point 4x4 transformation matrix stored in column-major order.
+
+* **Type**: `number` `[16]`
+* **Required**: No, default: `[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]`
+* **Related WebGL functions**: `uniformMatrix4fv()` with the transpose parameter equal to false
+
+==== node.mesh
+
+The index of the mesh in this node.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== node.rotation
+
+The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.
+
+* **Type**: `number` `[4]`
+** Each element in the array must be greater than or equal to `-1` and less than or equal to `1`.
+* **Required**: No, default: `[0,0,0,1]`
+
+==== node.scale
+
+The node's non-uniform scale, given as the scaling factors along the x, y, and z axes.
+
+* **Type**: `number` `[3]`
+* **Required**: No, default: `[1,1,1]`
+
+==== node.translation
+
+The node's translation along the x, y, and z axes.
+
+* **Type**: `number` `[3]`
+* **Required**: No, default: `[0,0,0]`
+
+==== node.weights
+
+The weights of the instantiated Morph Target. Number of elements must match number of Morph Targets of used mesh.
+
+* **Type**: `number` `[1-*]`
+* **Required**: No
+
+==== node.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== node.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== node.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-sampler]
+=== sampler
+
+Texture sampler properties for filtering and wrapping modes.
+
+**Related WebGL functions**: `texParameterf()`
+
+.`sampler` Properties
+|===
+|   |Type|Description|Required
+
+|**magFilter**
+|`integer`
+|Magnification filter.
+|No
+
+|**minFilter**
+|`integer`
+|Minification filter.
+|No
+
+|**wrapS**
+|`integer`
+|s wrapping mode.
+|No, default: `10497`
+
+|**wrapT**
+|`integer`
+|t wrapping mode.
+|No, default: `10497`
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/sampler.schema.json[sampler.schema.json]
+
+==== sampler.magFilter
+
+Magnification filter.  Valid values correspond to WebGL enums: `9728` (NEAREST) and `9729` (LINEAR).
+
+* **Type**: `integer`
+* **Required**: No
+* **Allowed values**:
+** `9728` NEAREST
+** `9729` LINEAR
+* **Related WebGL functions**: `texParameterf()` with pname equal to TEXTURE_MAG_FILTER
+
+==== sampler.minFilter
+
+Minification filter.  All valid values correspond to WebGL enums.
+
+* **Type**: `integer`
+* **Required**: No
+* **Allowed values**:
+** `9728` NEAREST
+** `9729` LINEAR
+** `9984` NEAREST_MIPMAP_NEAREST
+** `9985` LINEAR_MIPMAP_NEAREST
+** `9986` NEAREST_MIPMAP_LINEAR
+** `9987` LINEAR_MIPMAP_LINEAR
+* **Related WebGL functions**: `texParameterf()` with pname equal to TEXTURE_MIN_FILTER
+
+==== sampler.wrapS
+
+S (U) wrapping mode.  All valid values correspond to WebGL enums.
+
+* **Type**: `integer`
+* **Required**: No, default: `10497`
+* **Allowed values**:
+** `33071` CLAMP_TO_EDGE
+** `33648` MIRRORED_REPEAT
+** `10497` REPEAT
+* **Related WebGL functions**: `texParameterf()` with pname equal to TEXTURE_WRAP_S
+
+==== sampler.wrapT
+
+T (V) wrapping mode.  All valid values correspond to WebGL enums.
+
+* **Type**: `integer`
+* **Required**: No, default: `10497`
+* **Allowed values**:
+** `33071` CLAMP_TO_EDGE
+** `33648` MIRRORED_REPEAT
+** `10497` REPEAT
+* **Related WebGL functions**: `texParameterf()` with pname equal to TEXTURE_WRAP_T
+
+==== sampler.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== sampler.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== sampler.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-scene]
+=== scene
+
+The root nodes of a scene.
+
+.`scene` Properties
+|===
+|   |Type|Description|Required
+
+|**nodes**
+|`integer` `[1-*]`
+|The indices of each root node.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/scene.schema.json[scene.schema.json]
+
+==== scene.nodes
+
+The indices of each root node.
+
+* **Type**: `integer` `[1-*]`
+** Each element in the array must be unique.
+** Each element in the array must be greater than or equal to `0`.
+* **Required**: No
+
+==== scene.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== scene.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== scene.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-skin]
+=== skin
+
+Joints and matrices defining a skin.
+
+.`skin` Properties
+|===
+|   |Type|Description|Required
+
+|**inverseBindMatrices**
+|`integer`
+|The index of the accessor containing the floating-point 4x4 inverse-bind matrices.  The default is that each matrix is a 4x4 identity matrix, which implies that inverse-bind matrices were pre-applied.
+|No
+
+|**skeleton**
+|`integer`
+|The index of the node used as a skeleton root.
+|No
+
+|**joints**
+|`integer` `[1-*]`
+|Indices of skeleton nodes, used as joints in this skin.
+| &#x2705; Yes
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/skin.schema.json[skin.schema.json]
+
+==== skin.inverseBindMatrices
+
+The index of the accessor containing the floating-point 4x4 inverse-bind matrices.  The default is that each matrix is a 4x4 identity matrix, which implies that inverse-bind matrices were pre-applied.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== skin.skeleton
+
+The index of the node used as a skeleton root. The node must be the closest common root of the joints hierarchy or a direct or indirect parent node of the closest common root.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== skin.joints &#x2705; 
+
+Indices of skeleton nodes, used as joints in this skin.  The array length must be the same as the `count` property of the `inverseBindMatrices` accessor (when defined).
+
+* **Type**: `integer` `[1-*]`
+** Each element in the array must be unique.
+** Each element in the array must be greater than or equal to `0`.
+* **Required**: Yes
+
+==== skin.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== skin.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== skin.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-texture]
+=== texture
+
+A texture and its sampler.
+
+**Related WebGL functions**: `createTexture()`, `deleteTexture()`, `bindTexture()`, `texImage2D()`, and `texParameterf()`
+
+.`texture` Properties
+|===
+|   |Type|Description|Required
+
+|**sampler**
+|`integer`
+|The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.
+|No
+
+|**source**
+|`integer`
+|The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/texture.schema.json[texture.schema.json]
+
+==== texture.sampler
+
+The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== texture.source
+
+The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== texture.name
+
+The user-defined name of this object.  This is not necessarily unique, e.g., an accessor and a buffer could have the same name, or two accessors could even have the same name.
+
+* **Type**: `string`
+* **Required**: No
+
+==== texture.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== texture.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-textureinfo]
+=== textureInfo
+
+Reference to a texture.
+
+.`textureInfo` Properties
+|===
+|   |Type|Description|Required
+
+|**index**
+|`integer`
+|The index of the texture.
+| &#x2705; Yes
+
+|**texCoord**
+|`integer`
+|The set index of texture's TEXCOORD attribute used for texture coordinate mapping.
+|No, default: `0`
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/textureInfo.schema.json[textureInfo.schema.json]
+
+==== textureInfo.index &#x2705; 
+
+The index of the texture.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 0`
+
+==== textureInfo.texCoord
+
+This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+==== textureInfo.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: extension
+
+==== textureInfo.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+

--- a/specification/2.0/schema/accessor.schema.json
+++ b/specification/2.0/schema/accessor.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Accessor",
+    "title": "accessor",
     "type": "object",
     "description": "A typed view into a bufferView.  A bufferView contains raw binary data.  An accessor provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/accessor.sparse.indices.schema.json
+++ b/specification/2.0/schema/accessor.sparse.indices.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Accessor Sparse Indices",
+    "title": "accessor.sparse.indices",
     "type": "object",
     "description": "Indices of those attributes that deviate from their initialization value.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/accessor.sparse.schema.json
+++ b/specification/2.0/schema/accessor.sparse.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Accessor Sparse",
+    "title": "accessor.sparse",
     "type": "object",
     "description": "Sparse storage of attributes that deviate from their initialization value.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/accessor.sparse.values.schema.json
+++ b/specification/2.0/schema/accessor.sparse.values.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Accessor Sparse Values",
+    "title": "accessor.sparse.values",
     "type": "object",
     "description": "Array of size `accessor.sparse.count` times number of components storing the displaced accessor attributes pointed by `accessor.sparse.indices`.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.channel.schema.json
+++ b/specification/2.0/schema/animation.channel.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Animation Channel",
+    "title": "animation.channel",
     "type": "object",
     "description": "Targets an animation's sampler at a node's property.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.channel.target.schema.json
+++ b/specification/2.0/schema/animation.channel.target.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Animation Channel Target",
+    "title": "animation.channel.target",
     "type": "object",
     "description": "The index of the node and TRS property that an animation channel targets.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.sampler.schema.json
+++ b/specification/2.0/schema/animation.sampler.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Animation Sampler",
+    "title": "animation.sampler",
     "type": "object",
     "description": "Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/animation.schema.json
+++ b/specification/2.0/schema/animation.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Animation",
+    "title": "animation",
     "type": "object",
     "description": "A keyframe animation.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/asset.schema.json
+++ b/specification/2.0/schema/asset.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Asset",
+    "title": "asset",
     "type": "object",
     "description": "Metadata about the glTF asset.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/buffer.schema.json
+++ b/specification/2.0/schema/buffer.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Buffer",
+    "title": "buffer",
     "type": "object",
     "description": "A buffer points to binary geometry, animation, or skins.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/bufferView.schema.json
+++ b/specification/2.0/schema/bufferView.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Buffer View",
+    "title": "bufferView",
     "type": "object",
     "description": "A view into a buffer generally representing a subset of the buffer.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/camera.orthographic.schema.json
+++ b/specification/2.0/schema/camera.orthographic.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Camera Orthographic",
+    "title": "camera.orthographic",
     "type": "object",
     "description": "An orthographic camera containing properties to create an orthographic projection matrix.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/camera.perspective.schema.json
+++ b/specification/2.0/schema/camera.perspective.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Camera Perspective",
+    "title": "camera.perspective",
     "type": "object",
     "description": "A perspective camera containing properties to create a perspective projection matrix.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/camera.schema.json
+++ b/specification/2.0/schema/camera.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Camera",
+    "title": "camera",
     "type": "object",
     "description": "A camera's projection.  A node can reference a camera to apply a transform to place the camera in the scene.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/extension.schema.json
+++ b/specification/2.0/schema/extension.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Extension",
+    "title": "extension",
     "type": "object",
     "description": "Dictionary object with extension-specific objects.",
     "properties": {

--- a/specification/2.0/schema/extras.schema.json
+++ b/specification/2.0/schema/extras.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Extras",
+    "title": "extras",
     "description": "Application-specific data.",
     "gltf_sectionDescription": "**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability."
 }

--- a/specification/2.0/schema/image.schema.json
+++ b/specification/2.0/schema/image.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Image",
+    "title": "image",
     "type": "object",
     "description": "Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/material.normalTextureInfo.schema.json
+++ b/specification/2.0/schema/material.normalTextureInfo.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Material Normal Texture Info",
+    "title": "material.normalTextureInfo",
     "type": "object",
     "allOf": [ { "$ref": "textureInfo.schema.json" } ],
     "properties": {

--- a/specification/2.0/schema/material.occlusionTextureInfo.schema.json
+++ b/specification/2.0/schema/material.occlusionTextureInfo.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Material Occlusion Texture Info",
+    "title": "material.occlusionTextureInfo",
     "type": "object",
     "allOf": [ { "$ref": "textureInfo.schema.json" } ],
     "properties": {

--- a/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
+++ b/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Material PBR Metallic Roughness",
+    "title": "material.pbrMetallicRoughness",
     "type": "object",
     "description": "A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Material",
+    "title": "material",
     "type": "object",
     "description": "The material appearance of a primitive.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/mesh.primitive.schema.json
+++ b/specification/2.0/schema/mesh.primitive.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Mesh Primitive",
+    "title": "mesh.primitive",
     "type": "object",
     "description": "Geometry to be rendered with the given material.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/specification/2.0/schema/mesh.schema.json
+++ b/specification/2.0/schema/mesh.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Mesh",
+    "title": "mesh",
     "type": "object",
     "description": "A set of primitives to be rendered.  A node can contain one mesh.  A node's transform places the mesh in the scene.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/node.schema.json
+++ b/specification/2.0/schema/node.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Node",
+    "title": "node",
     "type": "object",
     "description": "A node in the node hierarchy.  When the node contains `skin`, all `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/sampler.schema.json
+++ b/specification/2.0/schema/sampler.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Sampler",
+    "title": "sampler",
     "type": "object",
     "description": "Texture sampler properties for filtering and wrapping modes.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/scene.schema.json
+++ b/specification/2.0/schema/scene.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Scene",
+    "title": "scene",
     "type": "object",
     "description": "The root nodes of a scene.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/skin.schema.json
+++ b/specification/2.0/schema/skin.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Skin",
+    "title": "skin",
     "type": "object",
     "description": "Joints and matrices defining a skin.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/texture.schema.json
+++ b/specification/2.0/schema/texture.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Texture",
+    "title": "texture",
     "type": "object",
     "description": "A texture and its sampler.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/specification/2.0/schema/textureInfo.schema.json
+++ b/specification/2.0/schema/textureInfo.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "Texture Info",
+    "title": "textureInfo",
     "type": "object",
     "description": "Reference to a texture.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],


### PR DESCRIPTION
This is a big one.  We probably don't want to merge this until the AsciiDoctor transition is ready to go.

Things that changed:

- Schema titles have changed.  It was not feasible for wetzel to parse what "Material PBR Metallic Roughness" meant in terms of the specific type name.  So types like this now have a title of `material.pbrMetallicRoughess` to match the type name.

- The reference section in README.md is the raw output from wetzel (see commit descriptions below).

- A temporary `REFERENCE.adoc` has been added, to show what the AsciiDoctor version of the reference output looks like.

Ultimately I do want to commit the schema title changes.  But the README changes will become obsolete in the move to AsciiDoctor, and the REFERENCE section will be a temporary file during the AsciiDoctor build process, not preserved in git.