### PR TITLE
Add VRM to "Formats Built on glTF"

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Tools, applications and libraries for working with glTF can be found in the [glT
 ## Formats Built on glTF
 
 * [3D Tiles](https://github.com/AnalyticalGraphicsInc/3d-tiles) - An open standard for streaming and rendering massive heterogenous 3D content.
+* [VRM](https://vrm.dev/) - A 3D avatar format for VR applications.
 
 ## Stack Overflow
 


### PR DESCRIPTION
Seems like a relevant addition here? Wouldn't generally list third-party extensions as formats, but I think this is sufficiently notable, and has its own ecosystem and file extension.