### PR TITLE
Flip credits & copyrights

### DIFF
--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -31,36 +31,58 @@ toc::[]
 
 :leveloffset: 1
 
-[[preamble]]
-= Preamble
+[[copyright-statement]]
+= Copyright Statement
 
-The GL Transmission Format (glTF) is an API-neutral runtime asset delivery format.  glTF bridges the gap between 3D content creation tools and modern 3D applications by providing an efficient, extensible, interoperable format for the transmission and loading of 3D content.
+Copyright 2013-2020 The Khronos Group Inc.
 
-Editors
+Some parts of this Specification are purely informative and do not define requirements
+necessary for compliance and so are outside the Scope of this Specification. These
+parts of the Specification are marked as being non-normative, or identified as
+*Implementation Notes*.
 
-* Saurabh Bhatia, Microsoft
-* Patrick Cozzi, Cesium
-* Alexey Knyazev, Individual Contributor
-* Tony Parisi, Unity
+Where this Specification includes normative references to external documents, only the
+specifically identified sections and functionality of those external documents are in
+Scope. Requirements defined by external documents not created by Khronos may contain
+contributions from non-members of Khronos not covered by the Khronos Intellectual
+Property Rights Policy.
 
-Khronos 3D Formats Working Group and Alumni
+This specification is protected by copyright laws and contains material proprietary
+to Khronos. Except as described by these terms, it or any components
+may not be reproduced, republished, distributed, transmitted, displayed, broadcast
+or otherwise exploited in any manner without the express prior written permission
+of Khronos.
 
-* Remi Arnaud, Starbreeze Studios
-* Emiliano Gambaretto, Adobe
-* Gary Hsu, Microsoft
-* Max Limper, Fraunhofer IGD
-* Scott Nagy, Microsoft
-* Marco Hutter, Individual Contributor
-* Uli Klumpp, Individual Contributor
-* Ed Mackey, Analytical Graphics, Inc.
-* Don McCurdy, Google
-* Norbert Nopper, UX3D
-* Fabrice Robinet, Individual Contributor (Previous Editor and Incubator)
-* Neil Trevett, NVIDIA
-* Jan Paul Van Waveren, Oculus
-* Amanda Watson, Oculus
+This specification has been created under the Khronos Intellectual Property Rights
+Policy, which is Attachment A of the Khronos Group Membership Agreement available at
+www.khronos.org/files/member_agreement.pdf. Khronos grants a conditional
+copyright license to use and reproduce the unmodified specification for any purpose,
+without fee or royalty, EXCEPT no licenses to any patent, trademark or other
+intellectual property rights are granted under these terms. Parties desiring to
+implement the specification and make use of Khronos trademarks in relation to that
+implementation, and receive reciprocal patent license protection under the Khronos
+IP Policy must become Adopters and confirm the implementation as conformant under
+the process defined by Khronos for this specification;
+see https://www.khronos.org/adopters.
 
-Copyright 2013-2020 The Khronos Group Inc. All Rights Reserved. glTF is a trademark of The Khronos Group Inc.
+Khronos makes no, and expressly disclaims any, representations or warranties,
+express or implied, regarding this specification, including, without limitation:
+merchantability, fitness for a particular purpose, non-infringement of any
+intellectual property, correctness, accuracy, completeness, timeliness, and
+reliability. Under no circumstances will Khronos, or any of its Promoters,
+Contributors or Members, or their respective partners, officers, directors,
+employees, agents or representatives be liable for any damages, whether direct,
+indirect, special or consequential damages for lost revenues, lost profits, or
+otherwise, arising from or in connection with these materials.
+
+Khronos® and Vulkan® are registered trademarks, and ANARI™, WebGL™, glTF™, NNEF™, OpenVX™,
+SPIR™, SPIR-V™, SYCL™, OpenVG™ and 3D Commerce™ are trademarks of The Khronos Group Inc.
+OpenXR™ is a trademark owned by The Khronos Group Inc. and is registered as a trademark in
+China, the European Union, Japan and the United Kingdom. OpenCL™ is a trademark of Apple Inc.
+and OpenGL® is a registered trademark and the OpenGL ES™ and OpenGL SC™ logos are trademarks
+of Hewlett Packard Enterprise used under license by Khronos. ASTC is a trademark of
+ARM Holdings PLC. All other product names, trademarks, and/or company names are used solely
+for identification and belong to their respective owners.
 
 
 [[introduction]]
@@ -2095,6 +2117,39 @@ include::PropertiesReference.adoc[]
 [[acknowledgments]]
 = Acknowledgments
 
+[[editors]]
+== Editors
+
+* Saurabh Bhatia, Microsoft
+* Patrick Cozzi, Cesium
+* Alexey Knyazev, Individual Contributor
+* Tony Parisi, Unity
+
+[[working-group-and-alumni]]
+== Khronos 3D Formats Working Group and Alumni
+
+* Remi Arnaud, Starbreeze Studios
+* Mike Bond, Adobe
+* Leonard Daly, Individual Contributor
+* Emiliano Gambaretto, Adobe
+* Tobias Häußler, Dassault Systèmes
+* Gary Hsu, Microsoft
+* Marco Hutter, Individual Contributor
+* Uli Klumpp, Individual Contributor
+* Max Limper, Fraunhofer IGD
+* Ed Mackey, Analytical Graphics, Inc.
+* Don McCurdy, Google
+* Scott Nagy, Microsoft
+* Norbert Nopper, UX3D
+* Fabrice Robinet, Individual Contributor (Previous Editor and Incubator)
+* Bastian Sdorra, Dassault Systèmes
+* Neil Trevett, NVIDIA
+* Jan Paul Van Waveren, Oculus
+* Amanda Watson, Oculus
+
+[[special-thanks]]
+== Special Thanks
+
 * Sarah Chow, Cesium
 * Tom Fili, Cesium
 * Darryl Gough
@@ -2116,7 +2171,7 @@ include::PropertiesReference.adoc[]
 * Steven Vergenz, AltspaceVR
 * Corentin Wallez, Google
 * Alex Wood, Analytical Graphics, Inc
-
+* Jon Leech
 
 [appendix]
 [[appendix-a-json-schema-reference]]
@@ -2490,58 +2545,3 @@ When writing out rotation output values, exporters should take care to not write
 The first in-tangent *a*~1~ and last out-tangent *b*~*n*~ should be zeros as they are not used in the spline calculations.
 ====
 
-
-[appendix]
-[[appendix-d-copyright]]
-= Full Khronos Copyright Statement
-
-Copyright 2013-2020 The Khronos Group Inc.
-
-Some parts of this Specification are purely informative and do not define requirements
-necessary for compliance and so are outside the Scope of this Specification. These
-parts of the Specification are marked as being non-normative, or identified as
-*Implementation Notes*.
-
-Where this Specification includes normative references to external documents, only the
-specifically identified sections and functionality of those external documents are in
-Scope. Requirements defined by external documents not created by Khronos may contain
-contributions from non-members of Khronos not covered by the Khronos Intellectual
-Property Rights Policy.
-
-This specification is protected by copyright laws and contains material proprietary
-to Khronos. Except as described by these terms, it or any components
-may not be reproduced, republished, distributed, transmitted, displayed, broadcast
-or otherwise exploited in any manner without the express prior written permission
-of Khronos.
-
-This specification has been created under the Khronos Intellectual Property Rights
-Policy, which is Attachment A of the Khronos Group Membership Agreement available at
-www.khronos.org/files/member_agreement.pdf. Khronos grants a conditional
-copyright license to use and reproduce the unmodified specification for any purpose,
-without fee or royalty, EXCEPT no licenses to any patent, trademark or other
-intellectual property rights are granted under these terms. Parties desiring to
-implement the specification and make use of Khronos trademarks in relation to that
-implementation, and receive reciprocal patent license protection under the Khronos
-IP Policy must become Adopters and confirm the implementation as conformant under
-the process defined by Khronos for this specification;
-see https://www.khronos.org/adopters.
-
-Khronos makes no, and expressly disclaims any, representations or warranties,
-express or implied, regarding this specification, including, without limitation:
-merchantability, fitness for a particular purpose, non-infringement of any
-intellectual property, correctness, accuracy, completeness, timeliness, and
-reliability. Under no circumstances will Khronos, or any of its Promoters,
-Contributors or Members, or their respective partners, officers, directors,
-employees, agents or representatives be liable for any damages, whether direct,
-indirect, special or consequential damages for lost revenues, lost profits, or
-otherwise, arising from or in connection with these materials.
-
-Vulkan is a registered trademark and Khronos, OpenXR, SPIR, SPIR-V, SYCL, WebGL,
-WebCL, OpenVX, OpenVG, EGL, COLLADA, glTF, NNEF, OpenKODE, OpenKCAM, StreamInput,
-OpenWF, OpenSL ES, OpenMAX, OpenMAX AL, OpenMAX IL, OpenMAX DL, OpenML and DevU are
-trademarks of The Khronos Group Inc. ASTC is a trademark of ARM Holdings PLC,
-OpenCL is a trademark of Apple Inc. and OpenGL and OpenML are registered trademarks
-and the OpenGL ES and OpenGL SC logos are trademarks of Silicon Graphics
-International used under license by Khronos. All other product names, trademarks,
-and/or company names are used solely for identification and belong to their
-respective owners.


### PR DESCRIPTION
This moves the copyright up top, and puts all credits at the end.  Neil requested this on a recent call.