### PR TITLE
Material Variants: Modify "extras" to use same convention as elsewhere in glTF.

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_variants/schema/glTF.KHR_materials_variants.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_variants/schema/glTF.KHR_materials_variants.schema.json
@@ -18,9 +18,7 @@
                         "description": "The name of the material variant",
                         "gltf_detailedDescription": "The name of the material variant."
                     },
-                    "extras": {
-                        "type": "object"
-                    },
+                    "extras": { },
                     "extensions": { }
                 },
                 "required": [ "name" ]

--- a/extensions/2.0/Khronos/KHR_materials_variants/schema/mesh.primitive.KHR_materials_variants.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_variants/schema/mesh.primitive.KHR_materials_variants.schema.json
@@ -32,9 +32,7 @@
                         "description": "The user-defined name of this variant material mapping.",
                         "gltf_detailedDescription": "The optional user-defined name of this variant material mapping.  This is not necessarily unique."
                     },
-                    "extras": {
-                        "type": "object"
-                    },
+                    "extras": { },
                     "extensions": { }
                 },
                 "required": [ "variants", "material" ]


### PR DESCRIPTION
I'm not a fan of this, as I'd rather see all "extras" everywhere get tightened to be an object, rather than the lone object get loosened to be "any".  But the former is too big a breaking change to be considered for glTF 2.0, and conformance will help the glTF Validator enforce uniform behavior, so here we are.

For https://github.com/KhronosGroup/glTF-Validator/issues/149#issuecomment-739353647

One question though, is this change itself too big a breaking change for a released extension?

/cc @lexaknyazev @bghgary @jercytryn