### PR TITLE
Add missing contributor for KHR_materials_variants extension

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_variants/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_variants/README.md
@@ -10,6 +10,7 @@
 - Edgar Simson, OLV, [@Edzis](https://github.com/edzis)
 - Daniel Beauchamp, Shopify, [@pushmatrix](http://github.com/pushmatrix)
 - Stephan Leroux, Shopify, [@sleroux](http://github.com/sleroux)
+- Mikko Haapoja, [@mikkoh](http://github.com/mikkoh)
 - Eric Chadwick, Wayfair, [@echadwick-wayfair](https://github.com/echadwick-wayfair)
 
 Copyright (C) 2018-2020 The Khronos Group Inc. All Rights Reserved. glTF is a trademark of The Khronos Group Inc.


### PR DESCRIPTION
Looking over the contributor list for the KHR_material_variants, we forgot to include Mikko who worked on the spec and also built the prototype viewer. This PR adds him to the contributor list.