### PR TITLE
Fixed sample code in KHR_materials_transmission extension specification

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_transmission/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_transmission/README.md
@@ -74,7 +74,9 @@ materials: [
     "extensions": {
        "KHR_materials_transmission": {
          "transmissionFactor": 0.8,
-         "transmissionTexture": 0
+         "transmissionTexture": {
+           "index": 0
+         }
        }
     }
   }


### PR DESCRIPTION
Fix sample code for the KHR_materials_transmission extension as discussed in the issue #1924 