### PR TITLE
Convert links README links from relative to absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ glTF™ (GL Transmission Format) is a royalty-free specification for the efficie
 
 ## Specification
 
-* [glTF Specification, 2.0](specification/2.0/README.md) (or [all specification versions](specification/README.md))
-* [glTF Extension Registry](extensions/README.md)
+* [glTF Specification, 2.0](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md) (or [all specification versions](https://github.com/KhronosGroup/glTF/blob/master/specification/README.md))
+* [glTF Extension Registry](https://github.com/KhronosGroup/glTF/blob/master/extensions/README.md)
 
 Please provide spec feedback by submitting [issues](https://github.com/KhronosGroup/glTF/issues). For technical or art workflow questions, or to showcase your work, [join the glTF forum](https://community.khronos.org/c/gltf-general). For quick questions, use the `#gltf` channel in the Khronos Group [Slack](https://www.khr.io/slack).
 


### PR DESCRIPTION
When the README.md is imported to Khronos.org/gltf, although the links don't appear on the khronos.org/gltf landing page, they are in the source, and produce a 404 error for search engines. Converting the links to absolute resolves this issue. 

This PR is a 'nice to have', not required to approve.