### PR TITLE
Mark EXT_meshopt_compression as complete

### DIFF
--- a/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+++ b/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-Draft
+Complete
 
 ## Dependencies
 


### PR DESCRIPTION
This extension is now supported by gltfpack on the tooling side and by Three.js, Babylon.js on the renderer side, with additional support in cgltf (which is a parsing library).

Since no issues came up during implementation for these libraries, it would make sense to mark the extension as complete.