### PR TITLE
KHR_materials_variants: Relax index uniqueness restrictions

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_variants/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_variants/README.md
@@ -64,7 +64,7 @@ Viewer-specific logic defines, for a given instance of a glTF asset, up to one s
 
 For a given primitive, each mapping item represents a material that should be applied to the primitive when one of its _variants_ is active. Available _mappings_ are defined on the primitive node as an array of objects. Each object specifies a material by its index in the root level `materials` array and an array of variants each by their respective indices in the root level `variants` array, defined above.
 
-Across the entire _mappings_ array, each variant index and each material must be used no more than one time.
+Across the entire _mappings_ array, each variant index must be used no more than one time.
 
 When the active variant is referenced in a mapping, a compliant viewer will apply its material to the primitive.
 


### PR DESCRIPTION
KHR_materials_variants currently restricts both variant and material index to be unique within each mapping

It makes sense that the variant index must be used no more than one time - duplicate indices would create ambiguity.
However, the specification should restrict the duplicate occurrence of materials.

Per #1937, mappings are represented as objects to allow for application extensibility - to specify data with extras.
The restriction above maintains that an application must use the same extras data for any two variants that happen to have an identical material (or duplicate the material).

This is overly restrictive; if the extras data contains variant/mesh-specific annotations, this data doesn't have to match between different variants even if they use the same material.

This change removes the uniqueness requirement for material index while maintaining it for variant indices.

Since this is a relaxation of the current requirements, it shouldn't present compatibility issues wrt assets, assuming that existing implementations don't have the same restriction internally.

Fixes #1941.