### PR TITLE
KHR_lights_area

### DIFF
--- a/extensions/2.0/Khronos/KHR_lights_area/README.md
+++ b/extensions/2.0/Khronos/KHR_lights_area/README.md
@@ -19,9 +19,9 @@ Written against the glTF 2.0 spec.
 
 This extension defines common area lights for use with glTF 2.0.
 
-Many 3D tools and engines support built-in implementations of area types. Using this extension, tools can export and engines can import these lights.
+Many 3D tools and engines support built-in implementations of area shapes. Using this extension, tools can export and engines can import these lights.
 
-This extension defines three "area" light types: `sphere`, `disk` and `rect`.
+This extension defines three area light shapes: `sphere`, `disk` and `rect`.
 
 These lights are referenced by nodes and inherit the transform of that node.
 
@@ -46,7 +46,7 @@ The following example defines 3 area lights:
                     1.0,
                     1.0
                 ],
-                "type": "sphere",
+                "shape": "sphere",
                 "radius": 1.0,
             },
             {
@@ -56,7 +56,7 @@ The following example defines 3 area lights:
                     1.0,
                     1.0
                 ],
-                "type": "disk",
+                "shape": "disk",
                 "radius": 1.0,
             },
             {
@@ -66,7 +66,7 @@ The following example defines 3 area lights:
                     1.0,
                     1.0
                 ],
-                "type": "rect",
+                "shape": "rect",
                 "width": 1.0,
                 "height": 1.0,
             },
@@ -99,8 +99,8 @@ The light will inherit the transform of the node.
 |:-----------------------|:------------------------------------------| :--------------------------|
 | `name` | Name of the light. | No, Default: `""` |
 | `color` | RGB value for light's color in linear space. | No, Default: `[1.0, 1.0, 1.0]` |
-| `intensity` | Brightness of light in. The units that this is defined in depend on the type of light in terms of nits (1 nit = 1 lm/sr/m^2) | No, Default: `1.0` |
-| `type` | Declares the type of the light. | :white_check_mark: Yes |
+| `intensity` | Brightness of light in. The units that this is defined in depend on the shape of light in terms of nits (1 nit = 1 lm/sr/m^2) | No, Default: `1.0` |
+| `shape` | Declares the shape of the light. | :white_check_mark: Yes |
 | `width` | The centered width of a rect light. Supported only for `rect` lights. | No, Default: `1.0` |
 | `height` | The centered height of a rect light. Supported only for `rect` lights. | No, Default: `1.0` |
 | `radius` | The radius of a disk or sphere light. Supported only for `disk` and `sphere` lights. | No, Default: `1.0` |

--- a/extensions/2.0/Khronos/KHR_lights_area/README.md
+++ b/extensions/2.0/Khronos/KHR_lights_area/README.md
@@ -1,4 +1,4 @@
-# KHR\_lights\_rect\_area
+# KHR\_lights\_area
 
 ## Contributors
 
@@ -17,60 +17,77 @@ Written against the glTF 2.0 spec.
 
 ## Overview
 
-This extension defines a rectangular area light for use with glTF 2.0.
+This extension defines common area lights for use with glTF 2.0.
 
-Many 3D tools and engines support built-in implementations of rect area types. Using this extension, tools can export and engines can import these lights. 
+Many 3D tools and engines support built-in implementations of area types. Using this extension, tools can export and engines can import these lights.
 
-This extension defines a single "rect" area light type: `rect`.
+This extension defines three "area" light types: `sphere`, `disk` and `rect`.
 
 These lights are referenced by nodes and inherit the transform of that node.
 
-A conforming implementation of this extension must be able to load light data defined in the asset and has to render the asset using those lights. 
+A conforming implementation of this extension must be able to load light data defined in the asset and has to render the asset using those lights.
 
 ## Defining Rect Area Lights
 
 Lights are defined within a dictionary property in the glTF scene description file, by adding an `extensions` property to the top-level glTF 2.0 object and defining a `KHR_lights_rect_area` property with a `lights` array inside it.
 
-The area light is assumed to point down the -Z axis.
+If the area lights are flat, then it is assumed that light is only emitted on the surface facing in the -Z direction.
 
-`width` is along the X-axis, and assumed to be centered.
-
-`height` is defined along the y-axis, and assumed to be centered.
-
-The following example defines a white-colored rect area light.
+The following example defines 3 area lights:
 
 ```javascript
 "extensions": {
-    "KHR_lights_rect_area" : {
+    "KHR_lights_area" : {
         "lights": [
             {
-                "width": 1.0,
-                "height": 1.0,
                 "intensity": 1.0,
                 "color": [
                     1.0,
                     1.0,
                     1.0
                 ],
-            }
-        ]
+                "type": "sphere",
+                "radius": 1.0,
+            },
+            {
+                "intensity": 1.0,
+                "color": [
+                    1.0,
+                    1.0,
+                    1.0
+                ],
+                "type": "disk",
+                "radius": 1.0,
+            },
+            {
+                "intensity": 1.0,
+                "color": [
+                    1.0,
+                    1.0,
+                    1.0
+                ],
+                "type": "rect",
+                "width": 1.0,
+                "height": 1.0,
+            },
+         ]
     }
 }
 ```
 
 ## Adding Light Instances to Nodes
 
-Lights must be attached to a node by defining the `extensions.KHR_lights_rect_area` property and, within that, an index into the `lights` array using the `light` property.
+Lights must be attached to a node by defining the `extensions.KHR_lights_area` property and, within that, an index into the `lights` array using the `light` property.
 
 ```javascript
 "nodes" : [
     {
         "extensions" : {
-            "KHR_lights_rect_area" : {
+            "KHR_lights_area" : {
                 "light" : 0
             }
         }
-    }            
+    }
 ]
 ```
 
@@ -83,8 +100,10 @@ The light will inherit the transform of the node.
 | `name` | Name of the light. | No, Default: `""` |
 | `color` | RGB value for light's color in linear space. | No, Default: `[1.0, 1.0, 1.0]` |
 | `intensity` | Brightness of light in. The units that this is defined in depend on the type of light in terms of luminous flux per unit area (1 lux = 1 lumen/m^2 = 1 candela * sr / m^2) | No, Default: `1.0` |
-| `width` | The centered width of the light along the X-axis. | :white_check_mark: Yes |
-| `height` | The centered height of the light along the Y-axis. | :white_check_mark: Yes |
+| `type` | Declares the type of the light. | :white_check_mark: Yes |
+| `width` | The centered width of a rect light. Supported only for `rect` lights. | No, Default: `1.0` |
+| `height` | The centered height of a rect light. Supported only for `rect` lights. | No, Default: `1.0` |
+| `radius` | The radius of a disk or sphere light. Supported only for `disk` and `sphere` lights. | No, Default: `1.0` |
 
 QUESTION: If an area light is scaled down by parent transforms, does it emit less light because it has less world space area?  Currently this would be the behavior given the current definition.  This seems intuitively like it makes sense.
 

--- a/extensions/2.0/Khronos/KHR_lights_area/README.md
+++ b/extensions/2.0/Khronos/KHR_lights_area/README.md
@@ -99,7 +99,7 @@ The light will inherit the transform of the node.
 |:-----------------------|:------------------------------------------| :--------------------------|
 | `name` | Name of the light. | No, Default: `""` |
 | `color` | RGB value for light's color in linear space. | No, Default: `[1.0, 1.0, 1.0]` |
-| `intensity` | Brightness of light in. The units that this is defined in depend on the type of light in terms of luminous flux per unit area (1 lux = 1 lumen/m^2 = 1 candela * sr / m^2) | No, Default: `1.0` |
+| `intensity` | Brightness of light in. The units that this is defined in depend on the type of light in terms of nits (1 nit = 1 lm/sr/m^2) | No, Default: `1.0` |
 | `type` | Declares the type of the light. | :white_check_mark: Yes |
 | `width` | The centered width of a rect light. Supported only for `rect` lights. | No, Default: `1.0` |
 | `height` | The centered height of a rect light. Supported only for `rect` lights. | No, Default: `1.0` |

--- a/extensions/2.0/Khronos/KHR_lights_rect_area/README.md
+++ b/extensions/2.0/Khronos/KHR_lights_rect_area/README.md
@@ -1,0 +1,142 @@
+# KHR\_lights\_rect\_area
+
+## Contributors
+
+* Ben Houston, Threekit, <https://twitter.com/BenHouston3D>
+
+Copyright (C) 2021 The Khronos Group Inc. All Rights Reserved. glTF is a trademark of The Khronos Group Inc.
+See [Appendix](#appendix-full-khronos-copyright-statement) for full Khronos Copyright Statement.
+
+## Status
+
+Proposed
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension defines a rectangular area light for use with glTF 2.0.
+
+Many 3D tools and engines support built-in implementations of rect area types. Using this extension, tools can export and engines can import these lights. 
+
+This extension defines a single "rect" area light type: `rect`.
+
+These lights are referenced by nodes and inherit the transform of that node.
+
+A conforming implementation of this extension must be able to load light data defined in the asset and has to render the asset using those lights. 
+
+## Defining Rect Area Lights
+
+Lights are defined within a dictionary property in the glTF scene description file, by adding an `extensions` property to the top-level glTF 2.0 object and defining a `KHR_lights_rect_area` property with a `lights` array inside it.
+
+The area light is assumed to point down the -Z axis.
+
+`width` is along the X-axis, and assumed to be centered.
+
+`height` is defined along the y-axis, and assumed to be centered.
+
+The following example defines a white-colored rect area light.
+
+```javascript
+"extensions": {
+    "KHR_lights_rect_area" : {
+        "lights": [
+            {
+                "width": 1.0,
+                "height": 1.0,
+                "intensity": 1.0,
+                "color": [
+                    1.0,
+                    1.0,
+                    1.0
+                ],
+            }
+        ]
+    }
+}
+```
+
+## Adding Light Instances to Nodes
+
+Lights must be attached to a node by defining the `extensions.KHR_lights_rect_area` property and, within that, an index into the `lights` array using the `light` property.
+
+```javascript
+"nodes" : [
+    {
+        "extensions" : {
+            "KHR_lights_rect_area" : {
+                "light" : 0
+            }
+        }
+    }            
+]
+```
+
+The light will inherit the transform of the node.
+
+## Rect Area Properties
+
+| Property | Description | Required |
+|:-----------------------|:------------------------------------------| :--------------------------|
+| `name` | Name of the light. | No, Default: `""` |
+| `color` | RGB value for light's color in linear space. | No, Default: `[1.0, 1.0, 1.0]` |
+| `intensity` | Brightness of light in. The units that this is defined in depend on the type of light in terms of luminous flux per unit area (1 lux = 1 lumen/m^2 = 1 candela * sr / m^2) | No, Default: `1.0` |
+| `width` | The centered width of the light along the X-axis. | :white_check_mark: Yes |
+| `height` | The centered height of the light along the Y-axis. | :white_check_mark: Yes |
+
+QUESTION: If an area light is scaled down by parent transforms, does it emit less light because it has less world space area?  Currently this would be the behavior given the current definition.  This seems intuitively like it makes sense.
+
+## Appendix: Full Khronos Copyright Statement
+
+Copyright 2017-2018 The Khronos Group Inc.
+
+Some parts of this Specification are purely informative and do not define requirements
+necessary for compliance and so are outside the Scope of this Specification. These
+parts of the Specification are marked as being non-normative, or identified as
+**Implementation Notes**.
+
+Where this Specification includes normative references to external documents, only the
+specifically identified sections and functionality of those external documents are in
+Scope. Requirements defined by external documents not created by Khronos may contain
+contributions from non-members of Khronos not covered by the Khronos Intellectual
+Property Rights Policy.
+
+This specification is protected by copyright laws and contains material proprietary
+to Khronos. Except as described by these terms, it or any components
+may not be reproduced, republished, distributed, transmitted, displayed, broadcast
+or otherwise exploited in any manner without the express prior written permission
+of Khronos.
+
+This specification has been created under the Khronos Intellectual Property Rights
+Policy, which is Attachment A of the Khronos Group Membership Agreement available at
+www.khronos.org/files/member_agreement.pdf. Khronos grants a conditional
+copyright license to use and reproduce the unmodified specification for any purpose,
+without fee or royalty, EXCEPT no licenses to any patent, trademark or other
+intellectual property rights are granted under these terms. Parties desiring to
+implement the specification and make use of Khronos trademarks in relation to that
+implementation, and receive reciprocal patent license protection under the Khronos
+IP Policy must become Adopters and confirm the implementation as conformant under
+the process defined by Khronos for this specification;
+see https://www.khronos.org/adopters.
+
+Khronos makes no, and expressly disclaims any, representations or warranties,
+express or implied, regarding this specification, including, without limitation:
+merchantability, fitness for a particular purpose, non-infringement of any
+intellectual property, correctness, accuracy, completeness, timeliness, and
+reliability. Under no circumstances will Khronos, or any of its Promoters,
+Contributors or Members, or their respective partners, officers, directors,
+employees, agents or representatives be liable for any damages, whether direct,
+indirect, special or consequential damages for lost revenues, lost profits, or
+otherwise, arising from or in connection with these materials.
+
+Vulkan is a registered trademark and Khronos, OpenXR, SPIR, SPIR-V, SYCL, WebGL,
+WebCL, OpenVX, OpenVG, EGL, COLLADA, glTF, NNEF, OpenKODE, OpenKCAM, StreamInput,
+OpenWF, OpenSL ES, OpenMAX, OpenMAX AL, OpenMAX IL, OpenMAX DL, OpenML and DevU are
+trademarks of The Khronos Group Inc. ASTC is a trademark of ARM Holdings PLC,
+OpenCL is a trademark of Apple Inc. and OpenGL and OpenML are registered trademarks
+and the OpenGL ES and OpenGL SC logos are trademarks of Silicon Graphics
+International used under license by Khronos. All other product names, trademarks,
+and/or company names are used solely for identification and belong to their
+respective owners.


### PR DESCRIPTION
here is a quick proposal for a rect area light (expanded to include sphere and circle per requests below.)  This specification does not determine its implementation, just its specification and intended behavior.

Real-time rect area lights are though generally implementing using the 2016 SIGGRAPH LTC method described here: https://eheitzresearch.wordpress.com/415-2/

Three.js area light:
* Docs: https://threejs.org/examples/webgl_lights_rectarealight.html
* Example: https://threejs.org/docs/#api/en/lights/RectAreaLight

One extra thought: Maybe this should have been build upon the existing ```KHR_lights_punctual``` extension and just add another light type to it called "rect"?