### PR TITLE
KHT_texture_float_rgb9e5: Float format for material textures

### DIFF
--- a/extensions/2.0/Khronos/KHR_texture_float_rgb9e5/README.md
+++ b/extensions/2.0/Khronos/KHR_texture_float_rgb9e5/README.md
@@ -1,0 +1,219 @@
+﻿# KHR_texture_float_rgb9e5
+
+## Contributors
+
+* Rickard Sahlin, mailto:rickard.sahlin@ikea.com  
+* Alexey Knyazev [@lexaknyazev](https://github.com/lexaknyazev)  
+* Don McCurdy, Google, [@donrmccurdy](https://twitter.com/donrmccurdy)  
+* Norbert Nopper, mailto:nopper@ux3d.io  
+
+Copyright (C) 2021 The Khronos Group Inc. All Rights Reserved. glTF is a trademark of The Khronos Group Inc.
+See [Appendix](#appendix-full-khronos-copyright-statement) for full Khronos Copyright Statement.
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension adds the ability to specify textures using KTX v2 images with float format as defined by VK_FORMAT_E5B9G9R9_UFLOAT_PACK32.
+
+When the extension is used, it's allowed to use value `image/ktx2` for the `mimeType` property of images that are referenced by the `source` property of `KHR_texture_float_rgb9e5` texture extension object.
+
+At runtime, engines are expected to check hardware support for VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, if not present the texture should be converted to a suitable supported format.
+[TBD - what should be done when there is no hw support for VK_FORMAT_E5B9G9R9_UFLOAT_PACK32?]
+
+## glTF Schema Updates
+
+The `KHR_texture_float_rgb9e5` extension is added to the `textures` object and specifies a `source` property that points to the index of the `image` which defines a reference to the KTX v2 image in VK_FORMAT_E5B9G9R9_UFLOAT_PACK32.
+
+The following glTF will load `image.ktx2` in clients that support this extension, and otherwise fall back to `image.png`.
+
+```json
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "extensionsUsed": [
+        "KHR_texture_float_rgb9e5"
+    ],
+    "textures": [
+        {
+            "source": 0,
+            "extensions": {
+                "KHR_texture_float_rgb9e5": {
+                    "source": 1
+                }
+            }
+        }
+    ],
+    "images": [
+        {
+            "uri": "image.png"
+        },
+        {
+            "uri": "image.ktx2"
+        }
+    ]
+}
+```
+
+When used in the glTF Binary (GLB) format the `image` that points to the KTX v2 resource uses the `mimeType` value of `image/ktx2`.
+
+```json
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "extensionsUsed": [
+        "KHR_texture_float_rgb9e5"
+    ],
+    "textures": [
+        {
+            "source": 0,
+            "extensions": {
+                "KHR_texture_float_rgb9e5": {
+                    "source": 1
+                }
+            }
+        }
+    ],
+    "images": [
+        {
+            "mimeType": "image/png",
+            "bufferView": 1
+        },
+        {
+            "mimeType": "image/ktx2",
+            "bufferView": 2
+        }
+    ]
+}
+```
+
+### Using Without a Fallback
+
+To use KTX v2 image with Basis Universal supercompression without a fallback, define `KHR_texture_float_rgb9e5` in both `extensionsUsed` and `extensionsRequired`. The `texture` object will then have its `source` property omitted as shown below.
+
+```json
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "extensionsUsed": [
+        "KHR_texture_float_rgb9e5"
+    ],
+    "extensionsRequired": [
+        "KHR_texture_float_rgb9e5"
+    ],
+    "textures": [
+        {
+            "extensions": {
+                "KHR_texture_float_rgb9e5": {
+                    "source": 0
+                }
+            }
+        }
+    ],
+    "images": [
+        {
+            "uri": "image.ktx2"
+        }
+    ]
+}
+```
+
+### JSON Schema
+
+[texture.KHR_texture_float_rgb9e5.schema.json](schema/texture.KHR_texture_float_rgb9e5.schema.json)
+
+## KTX v2 Images with VK_FORMAT_E5B9G9R9_UFLOAT_PACK32
+
+To cover usecases where a texture source shall have increased dynamic range
+
+- Swizzling metadata (`KTXswizzle`) MUST be `rgba` or omitted.
+- Orientation metadata (`KTXorientation`) MUST be `rd` or omitted.
+- Color space information in the DFD MUST match the expected usage, namely:
+  - For textures with **color data** (e.g., base color maps),
+    - `colorPrimaries` MUST be `KHR_DF_PRIMARIES_BT709`;
+    - `transferFunction` MUST be `KHR_DF_TRANSFER_SRGB`.
+  - For textures with **non-color data** (e.g., normal maps),
+    - `colorPrimaries` MUST be `KHR_DF_PRIMARIES_UNSPECIFIED`;
+    - `transferFunction` MUST be `KHR_DF_TRANSFER_LINEAR`.
+
+### Using KTX v2 Images with VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 for Material Textures
+
+When a texture referencing a KTX v2 image with VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 is used for glTF 2.0 material maps (both color and non-color), the KTX v2 image MUST be of **2D** type as defined in the KTX v2 Specification, Section 4.1.
+
+`KHR_DF_FLAG_ALPHA_PREMULTIPLIED` flag MUST NOT be set unless the material's specification requires premultiplied alpha.
+
+
+## Known Implementations
+
+Authoring:
+
+
+Viewing:
+
+
+## Resources
+
+[KTX File Format Specification, version 2](https://github.khronos.org/KTX-Specification/)
+
+[KTX Reference Software](https://github.com/KhronosGroup/KTX-Software/)
+
+## Appendix: Full Khronos Copyright Statement
+
+Copyright 2021 The Khronos Group Inc.
+
+Some parts of this Specification are purely informative and do not define requirements
+necessary for compliance and so are outside the Scope of this Specification. These
+parts of the Specification are marked as being non-normative, or identified as
+**Implementation Notes**.
+
+Where this Specification includes normative references to external documents, only the
+specifically identified sections and functionality of those external documents are in
+Scope. Requirements defined by external documents not created by Khronos may contain
+contributions from non-members of Khronos not covered by the Khronos Intellectual
+Property Rights Policy.
+
+This specification is protected by copyright laws and contains material proprietary
+to Khronos. Except as described by these terms, it or any components
+may not be reproduced, republished, distributed, transmitted, displayed, broadcast
+or otherwise exploited in any manner without the express prior written permission
+of Khronos.
+
+This specification has been created under the Khronos Intellectual Property Rights
+Policy, which is Attachment A of the Khronos Group Membership Agreement available at
+www.khronos.org/files/member_agreement.pdf. Khronos grants a conditional
+copyright license to use and reproduce the unmodified specification for any purpose,
+without fee or royalty, EXCEPT no licenses to any patent, trademark or other
+intellectual property rights are granted under these terms. Parties desiring to
+implement the specification and make use of Khronos trademarks in relation to that
+implementation, and receive reciprocal patent license protection under the Khronos
+IP Policy must become Adopters and confirm the implementation as conformant under
+the process defined by Khronos for this specification;
+see https://www.khronos.org/adopters.
+
+Khronos makes no, and expressly disclaims any, representations or warranties,
+express or implied, regarding this specification, including, without limitation:
+merchantability, fitness for a particular purpose, non-infringement of any
+intellectual property, correctness, accuracy, completeness, timeliness, and
+reliability. Under no circumstances will Khronos, or any of its Promoters,
+Contributors or Members, or their respective partners, officers, directors,
+employees, agents or representatives be liable for any damages, whether direct,
+indirect, special or consequential damages for lost revenues, lost profits, or
+otherwise, arising from or in connection with these materials.
+
+Khronos® and Vulkan® are registered trademarks, and ANARI™, WebGL™, glTF™, NNEF™, OpenVX™,
+SPIR™, SPIR-V™, SYCL™, OpenVG™ and 3D Commerce™ are trademarks of The Khronos Group Inc.
+OpenXR™ is a trademark owned by The Khronos Group Inc. and is registered as a trademark in
+China, the European Union, Japan and the United Kingdom. OpenCL™ is a trademark of Apple Inc.
+and OpenGL® is a registered trademark and the OpenGL ES™ and OpenGL SC™ logos are trademarks
+of Hewlett Packard Enterprise used under license by Khronos. ASTC is a trademark of
+ARM Holdings PLC. All other product names, trademarks, and/or company names are used solely
+for identification and belong to their respective owners.

--- a/extensions/2.0/Khronos/KHR_texture_float_rgb9e5/schema/texture.KHR_texture_float_rgb9e5.schema.json
+++ b/extensions/2.0/Khronos/KHR_texture_float_rgb9e5/schema/texture.KHR_texture_float_rgb9e5.schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_texture_float_rgb9e5 glTF extension",
+    "type": "object",
+    "description": "glTF extension to specify textures using the KTX v2 images in VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 format.",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "source": {
+          "allOf": [ { "$ref": "glTFid.schema.json" } ],
+          "description": "The index of the image which points to a KTX v2 resource in VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 format."
+        },
+        "extensions": {},
+        "extras": {}
+      }
+}


### PR DESCRIPTION
The purpose of this extension is to enable use of HDR material textures by means of texture float format VK_FORMAT_E5B9G9R9_UFLOAT_PACK32.  
KTX v2 shall be used as a container, the extension is defined in a way that follows the paradigm of KHR_texture_basisu.  

The intended usecase for this extension is any usecase where HDR image resources needs to be specified, for instance in an environment map (IBL) but it could be relevant for _any_ material texture where increased range is wanted.  

The format VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 is chosen based on previous discussions with input from, Alexey, Don, Norbert and others.  


