### PR TITLE
Update normative language

### DIFF
--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -100,9 +100,9 @@ glTF is an API-neutral runtime asset delivery format.  glTF bridges the gap betw
 [[introduction-conventions]]
 == Document Conventions
 
-The glTF Specification is intended for use by both implementors of the asset exporters or converters (e.g. digital content creation tools) and application developers seeking to import or load glTF assets, forming a contract between these parties.
+The glTF Specification is intended for use by both implementors of the asset exporters or converters (e.g. digital content creation tools) and application developers seeking to import or load glTF assets, forming a basis for interoperability between these parties.
 
-Specification text may address either party; typically the intended audience can be inferred from context, though some sections are defined to address only one of these parties.
+Specification text can address either party; typically the intended audience can be inferred from context, though some sections are defined to address only one of these parties.
 
 Any requirements, prohibitions, recommendations or options defined by <<introduction-normative-terminology, normative terminology>> are imposed only on the audience of that text.
 
@@ -321,15 +321,13 @@ Future extensions may include more compression methods including those for anima
 
 
 [[versioning]]
-== Versioning (Informative)
+== Versioning
 
-This section is marked as informative as there is no binding responsibility on implementations of the glTF — these guarantees are however a contract between the 3D Formats Working Group and developers using this Specification.
+Any updates made to the glTF Specification in a minor version **MUST** be backwards and forwards compatible. Backwards compatibility means that any client implementation that supports loading a glTF 2.x asset will also be able to load a glTF 2.0 asset. Forwards compatibility means that a client implementation that only supports glTF 2.0 is able to load glTF 2.x assets while gracefully ignoring any new features it does not understand.
 
-Any updates made to glTF in a minor version must be backwards and forwards compatible. Backwards compatibility means that any client implementation that supports loading a glTF 2.x asset will also be able to load a glTF 2.0 asset. Forwards compatibility means that a client implementation that only supports glTF 2.0 is able to load glTF 2.x assets while gracefully ignoring any new features it does not understand.
+A minor version update **MAY** introduce new features but **MUST NOT** change any previously existing behavior. Existing functionality **MAY** be deprecated in a minor version update, but it **MUST NOT** be removed.
 
-A minor version update may introduce new features but must not change any previously existing behavior. Existing functionality may be deprecated in a minor version update, but it must not be removed.
-
-Major version updates may be incompatible with previous versions.
+Major version updates **MAY** be incompatible with previous versions.
 
 
 [[file-extensions-and-media-types]]

--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -1889,6 +1889,16 @@ Normal vectors **MUST** be normalized before being used in lighting equations. W
 The texture binding for occlusion maps **MAY** optionally contain a scalar `strength` value that is used to reduce the occlusion effect. When present, it affects the occlusion value as `1.0 + strength * (occlusionTexture - 1.0)`.
 
 - *emissive* : The emissive texture and factor control the color and intensity of the light being emitted by the material. The texture **MUST** contain 8-bit values encoded with the <<srgb, sRGB opto-electronic transfer function>> so RGB values **MUST** be decoded to real linear values before they are used for any computations. To achieve correct filtering, the transfer function **SHOULD** be decoded before performing linear interpolation.
++
+For implementations where a physical light unit is needed, the units for the multiplicative product of the emissive texture and factor are candela per square meter (**cd / m^2^**), sometimes called *nits*.
++
+[NOTE]
+.Implementation Note
+====
+Because the value is specified per square meter, it indicates the brightness of any given point along the surface.  However, the exact conversion from physical light units to the brightness of rendered pixels requires knowledge of the camera's exposure settings, which are left as an implementation detail unless otherwise defined by a glTF extension.
+
+Many rendering engines simplify this calculation by assuming that an emissive factor of `1.0` results in a fully exposed pixel.
+====
 
 The following example shows a material that is defined using `pbrMetallicRoughness` parameters as well as additional textures:
 

--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -91,7 +91,7 @@ for identification and belong to their respective owners.
 [[introduction-general]]
 == General
 
-This document, referred to as the “glTF Specification” or just the “Specification” hereafter, describes the glTF file format.
+This document, referred to as the "`glTF Specification`" or just the "`Specification`" hereafter, describes the glTF file format.
 
 glTF is an API-neutral runtime asset delivery format.  glTF bridges the gap between 3D content creation tools and modern graphics applications by providing an efficient, extensible, interoperable format for the transmission and loading of 3D content.
 
@@ -99,7 +99,7 @@ glTF is an API-neutral runtime asset delivery format.  glTF bridges the gap betw
 [[introduction-conventions]]
 == Document Conventions
 
-The glTF Specification is intended for use by both implementors of the asset exporters or converters (e.g. DCC tools) and application developers seeking to import or load glTF assets, forming a contract between these parties.
+The glTF Specification is intended for use by both implementors of the asset exporters or converters (e.g. digital content creation tools) and application developers seeking to import or load glTF assets, forming a contract between these parties.
 
 Specification text may address either party; typically the intended audience can be inferred from context, though some sections are defined to address only one of these parties.
 
@@ -129,7 +129,7 @@ Unless otherwise noted in the section heading, all sections and appendices in th
 [[introduction-technical-terminology]]
 === Technical Terminology
 
-The glTF Specification makes use of common engineering and graphics terms such as *Vertex*, *Normal*, *Texture*, etc to identify and describe certain GPU constructs and their attributes, states, and behaviors.
+The glTF Specification makes use of common engineering and graphics terms such as *Vertex*, *Normal*, *Texture*, etc. to identify and describe certain GPU constructs and their attributes, states, and behaviors.
 
 [[introduction-normative-references]]
 === Normative References
@@ -140,84 +140,119 @@ The following documents are referenced by normative sections of the specificatio
 
 ==== External Specifications
 
-[[bcp14]]
+* [[bcp14]]
 Bradner, S., _Key words for use in RFCs to Indicate Requirement Levels_, BCP 14, RFC 2119, March 1997. Leiba, B., _Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words_, BCP 14, RFC 8174, May 2017.
 <https://www.rfc-editor.org/info/bcp14>
 
-[[utf8]
+* [[utf8]]
 The Unicode Consortium, _The Unicode Standard_
 <https://www.unicode.org/versions/latest/>
 
-[[json]]
+* [[json]]
 Bray, T., Ed., _The JavaScript Object Notation (JSON) Data Interchange Format_, STD 90, RFC 8259, DOI 10.17487/RFC8259, December 2017, <https://www.rfc-editor.org/info/rfc8259>
 
-[[ieee-754]]
+* [[ieee-754]]
 ISO/IEC 60559:2020
 _Floating-point arithmetic_
 <https://www.iso.org/standard/80985.html>
 
-[[png]]
+* [[png]]
 ISO/IEC 15948:2004
 _Portable Network Graphics (PNG): Functional specification_
 <https://www.iso.org/standard/29581.html>
++
+[NOTE]
+.Note
+====
+A free version of this standard is available from W3C: https://www.w3.org/TR/PNG/
+====
 
-[[jpeg]]
+
+
+* [[jpeg]]
 ISO/IEC 10918-1:1994
 _Digital compression and coding of continuous-tone still images: Requirements and guidelines_
 <https://www.iso.org/standard/18902.html>
++
+[NOTE]
+.Note
+====
+An earlier edition of this standard called ITU Recommendation T.81 is available from W3C: https://www.w3.org/Graphics/JPEG/itu-t81.pdf
+====
 
-[[jfif]]
+* [[jfif]]
 ISO/IEC 10918-5:2013
 _Digital compression and coding of continuous-tone still images: JPEG File Interchange Format (JFIF)_
 <https://www.iso.org/standard/54989.html>
++
+[NOTE]
+.Note
+====
+An earlier edition of this standard is available from W3C: https://www.w3.org/Graphics/JPEG/jfif3.pdf
+====
 
-[[data-uri]]
+* [[exif]]
+CIPA DC-008-Translation-2019
+_Exchangeable image file format for digital still cameras_
+<https://www.cipa.jp/std/documents/download_e.html?DC-008-Translation-2019-E>
+
+* [[data-uri]]
 Masinter, L., _The "data" URL scheme_, RFC 2397, DOI 10.17487/RFC2397, August 1998, <https://www.rfc-editor.org/info/rfc2397>
 
-[[uri]]
+* [[uri]]
 Berners-Lee, T., Fielding, R., and L. Masinter, _Uniform Resource Identifier (URI): Generic Syntax_, STD 66, RFC 3986, DOI 10.17487/RFC3986, January 2005, <https://www.rfc-editor.org/info/rfc3986>
 
-[[iri]]
+* [[iri]]
 Duerst, M. and M. Suignard, _Internationalized Resource Identifiers (IRIs)_, RFC 3987, DOI 10.17487/RFC3987, January 2005, <https://www.rfc-editor.org/info/rfc3987>
 
-[[http]]
+* [[http]]
 Fielding, R., Ed., and J. Reschke, Ed., _Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing_, RFC 7230, DOI 10.17487/RFC7230, June 2014, <https://www.rfc-editor.org/info/rfc7230>
 
-[[srgb]]
-IEC 61966-2-1:1999.
+* [[srgb]]
+IEC 61966-2-1:1999
 _Default RGB colour space - sRGB_
 https://webstore.iec.ch/publication/6169
++
+[NOTE]
+.Note
+====
+The encoding characteristics of sRGB are freely available from ICC: https://www.color.org/chardata/rgb/srgb.xalter
+====
 
-[[mikktspace]]
+* [[bt709]]
+Recommendation ITU-R BT.709-6 _Parameter values for the HDTV standards for production and international programme exchange_
+https://www.itu.int/rec/R-REC-BT.709-6-201506-I
+
+* [[mikktspace]]
 _MikkTSpace_
 https://github.com/mmikk/MikkTSpace
 
 ==== Media Type Registrations
 
-[[gltf-json]]
+* [[gltf-json]]
 IANA.
 _model/gltf+json Media Type_.
 https://www.iana.org/assignments/media-types/model/gltf+json
 
-[[gltf-binary]]
+* [[gltf-binary]]
 IANA.
 _model/gltf-binary Media Type_.
 https://www.iana.org/assignments/media-types/model/gltf-binary
 
-[[gltf-buffer]]
+* [[gltf-buffer]]
 IANA.
 _application/gltf-buffer Media Type_.
 https://www.iana.org/assignments/media-types/application/gltf-buffer
 
-[[octet-stream]]
+* [[octet-stream]]
 IANA.
 _application/octet-stream Media Type_.
 https://www.iana.org/assignments/media-types/application/octet-stream
 
-[[image-jpeg]]
+* [[image-jpeg]]
 Freed, N. and N. Borenstein, _Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types_, RFC 2046, DOI 10.17487/RFC2046, November 1996, <https://www.rfc-editor.org/info/rfc2046>
 
-[[image-png]]
+* [[image-png]]
 IANA.
 _image/png Media Type_.
 https://www.iana.org/assignments/media-types/image/png
@@ -244,9 +279,9 @@ A glTF asset is represented by:
 * Binary files (`.bin`) containing geometry, animation, and other buffer-based data.
 * Image files (`.jpg`, `.png`) containing texture images.
 
-Binary and image resources **MAY** also be embedded directly in JSON using <<data-uri,Data URI>> or stored side-by-side with JSON in GLB container.
+Binary and image resources **MAY** also be embedded directly in JSON using <<data-uri,Data URI>> or stored side-by-side with JSON in <<glb-file-format-specification,GLB>> container.
 
-Valid glTF asset **MUST** specify its version.
+A valid glTF asset **MUST** specify its version.
 
 image:figures/files.png[pdfwidth=4in,align=left]
 
@@ -270,6 +305,7 @@ The following are outside the scope of the initial design of glTF:
 * *glTF is not intended to be human-readable,* though by virtue of being represented in JSON, it is developer-friendly.
 
 While version 2.0 of glTF does not define compression for geometry and other rich data, there are extensions providing such options.
+
 * https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md[KHR_draco_mesh_compression] for geometry.
 * https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_texture_basisu/README.md[KHR_texture_basisu] for GPU-compatible block-compressed textures.
 
@@ -291,8 +327,8 @@ Major version updates **MAY** be incompatible with previous versions.
 [[file-extensions-and-media-types]]
 == File Extensions and Media Types
 
-* JSON glTF files **SHOULD** use `.gltf` extension and <<gltf-json,`model/gltf+json`>> Media Type.
-* glTF files stored in GLB container **SHOULD** use `.glb` extension and <<gltf-binary,`model/gltf-binary`>> Media Type.
+* <<json,JSON>> glTF files **SHOULD** use `.gltf` extension and <<gltf-json,`model/gltf+json`>> Media Type.
+* glTF files stored in <<glb-file-format-specification,GLB>> container **SHOULD** use `.glb` extension and <<gltf-binary,`model/gltf-binary`>> Media Type.
 * Files representing binary buffers **SHOULD** use either:
 ** `.bin` file extension with <<octet-stream,`application/octet-stream`>> Media Type;
 ** `.bin`, `.glbin`, or `.glbuf` file extensions with <<gltf-buffer,`application/gltf-buffer`>> Media Type.
@@ -309,7 +345,7 @@ Major version updates **MAY** be incompatible with previous versions.
 
 Although glTF Specification does not define any subset of the <<json,JSON>> format, implementations **SHOULD** be aware of its peculiar properties that could affect asset interoperability.
 
-1. glTF JSON data **SHOULD** be written with UTF-8 encoding without BOM. This requirement is not applied when a glTF implementation does not control string encoding. glTF implementations **SHOULD** adhere to the <<json,RFC 8259>>, Section 8.1. with regards to treating BOM presence.
+1. glTF JSON data **SHOULD** be written with UTF-8 encoding without BOM. This requirement is not applied when a glTF implementation does not control string encoding. glTF implementations **SHOULD** adhere to <<json,RFC 8259>>, Section 8.1. with regards to treating BOM presence.
 
 2. ASCII characters stored in glTF JSON **SHOULD** be written unescaped.
 +
@@ -426,7 +462,7 @@ The image above shows relations between top-level arrays in a glTF asset.  See t
 [[asset]]
 == Asset
 
-Each glTF asset **MUST** have an `asset` property. The `asset` object **MUST** contain `version` property which specifies the target glTF version of the asset. Additionally, an optional `minVersion` property **MAY** be used to specify the minimum glTF version support required to load the asset. The `minVersion` property allows asset creators to specify a minimum version that a client implementation **MUST** support in order to load the asset. This is very similar to the `extensionsRequired` concept described in <<specifying-extensions>>, where an asset **SHOULD NOT** be loaded if the client does not support the specified extension. Additional metadata **MAY** be stored in optional properties such as `generator` or `copyright`.  For example,
+Each glTF asset **MUST** have an `asset` property. The `asset` object **MUST** contain a `version` property which specifies the target glTF version of the asset. Additionally, an optional `minVersion` property **MAY** be used to specify the minimum glTF version support required to load the asset. The `minVersion` property allows asset creators to specify a minimum version that a client implementation **MUST** support in order to load the asset. This is very similar to the `extensionsRequired` concept described in <<specifying-extensions>>, where an asset **SHOULD NOT** be loaded if the client does not support the specified extension. Additional metadata **MAY** be stored in optional properties such as `generator` or `copyright`.  For example,
 
 [source,json]
 ----
@@ -498,7 +534,7 @@ RGB color values **MUST** use <<srgb,sRGB>> color primaries.
 [NOTE]
 .Implementation Note
 ====
-Color primaries define the interpretation of each color channel of the color model, particularly with respect to the RGB color model. In the context of a typical display, color primaries describe the color of the red, green and blue phosphors or filters. The same primaries are also defined in Recommendation ITU-R BT.709. Since the overwhelming majority of currently used consumer displays are using the same primaries as default, client implementations usually do not need to convert color values. Future specification versions or extensions may allow other color primaries (such as P3).
+Color primaries define the interpretation of each color channel of the color model, particularly with respect to the RGB color model. In the context of a typical display, color primaries describe the color of the red, green and blue phosphors or filters. The same primaries are also defined in <<bt709,Recommendation ITU-R BT.709>>. Since the overwhelming majority of currently used consumer displays are using the same primaries as default, client implementations usually do not need to convert color values. Future specification versions or extensions may allow other color primaries (such as P3).
 ====
 
 
@@ -543,7 +579,7 @@ The following example defines a glTF asset with a single scene, that contains a 
 
 glTF assets **MAY** define _nodes_, that is, the objects comprising the scene to render.
 
-Nodes **MAY** have transform properties, as described in the next section.
+Nodes **MAY** have transform properties, as described later.
 
 Nodes are organized in a parent-child hierarchy known informally as the _node hierarchy_. A node is called a _root node_ when it doesn't have a parent.
 
@@ -1103,7 +1139,7 @@ Each attribute is defined as a property of the `attributes` object. The name of 
 
 Valid attribute semantic property names include `POSITION`, `NORMAL`, `TANGENT`, `TEXCOORD_0`, `TEXCOORD_1`, `COLOR_0`, `JOINTS_0`, and `WEIGHTS_0`.
 
-Application-specific attribute semantics **MUST** start with an underscore, e.g., `_TEMPERATURE`. Application-specific attribute semantics **MUST NOT** use _unsigned int__ component type.
+Application-specific attribute semantics **MUST** start with an underscore, e.g., `_TEMPERATURE`. Application-specific attribute semantics **MUST NOT** use __unsigned int__ component type.
 
 Valid accessor type and component type for each attribute semantic property are defined below.
 
@@ -1125,20 +1161,26 @@ Valid accessor type and component type for each attribute semantic property are 
                                   _unsigned short_ normalized | RGB or RGBA vertex color linear multiplier
 | `JOINTS_0`  | `"VEC4"`        | _unsigned byte_
                                   _unsigned short_            | See <<skinned-mesh-attributes,Skinned Mesh Attributes>>
-| `WEIGHTS_0` | `"VEC4"`        | _float_) +
+| `WEIGHTS_0` | `"VEC4"`        | _float_ +
                                   _unsigned byte_ normalized +
                                   _unsigned short_ normalized | See <<skinned-mesh-attributes,Skinned Mesh Attributes>>
 |====
 
 `POSITION` accessor **MUST** have its `min` and `max` properties defined.
 
-`TEXCOORD`, `COLOR`, `JOINTS`, and `WEIGHTS` attribute semantic property names **MUST** be of the form `[semantic]_[set_index]`, e.g., `TEXCOORD_0`, `TEXCOORD_1`, `COLOR_0`. All indices for indexed attribute semantics **MUST** start with 0 and be continuous positive integers: `TEXCOORD_0`, `TEXCOORD_1`, etc. Indices **MUST NOT** use leading zeroes to pad the number of digits (e.g. `TEXCOORD_01`).
+`TEXCOORD`, `COLOR`, `JOINTS`, and `WEIGHTS` attribute semantic property names **MUST** be of the form `[semantic]_[set_index]`, e.g., `TEXCOORD_0`, `TEXCOORD_1`, `COLOR_0`. All indices for indexed attribute semantics **MUST** start with 0 and be consecutive positive integers: `TEXCOORD_0`, `TEXCOORD_1`, etc. Indices **MUST NOT** use leading zeroes to pad the number of digits (e.g. `TEXCOORD_01`).
 
 Client implementations **SHOULD** support at least two UV texture coordinate sets, one vertex color, and one joints/weights set.
 
-All attribute accessors for a given primitive **MUST** have the same `count`. When `indices` property is not defined, accessors' `count` indicates the number of vertices to render; when `indices` property is defined, it indicates the upper (exclusive) bound on the index values in the `indices` accessor.
+All attribute accessors for a given primitive **MUST** have the same `count`. When `indices` property is not defined, attribute accessors' `count` indicates the number of vertices to render; when `indices` property is defined, it indicates the upper (exclusive) bound on the index values in the `indices` accessor, i.e. all index values **MUST** be less than attribute accessors' `count`.
 
 `indices` accessor **MUST NOT** contain the maximum possible value for the component type used (i.e. 255 for unsigned bytes, 65535 for unsigned shorts, 4294967295 for unsigned ints).
+
+[NOTE]
+.Implementation Note
+====
+The maximum values trigger primitive restart in some graphics APIs and would require client implementations to rebuild the index buffer.
+====
 
 When `indices` property is not defined, the number of vertex indices to render is defined by `count` of attribute accessors (with the implied values from range `[0..count)`); when `indices` property is defined, the number of vertex indices to render is defined by `count` of accessor referred to by `indices`. In either case, the number of vertex indices **MUST** be valid for the topology type used:
 
@@ -1205,11 +1247,11 @@ Extensions **MAY** add additional property names, accessor types and/or componen
 [[morph-targets]]
 ==== Morph Targets
 
-Morph Targets are defined by extending the Mesh concept.
+Morph targets are defined by extending the Mesh concept.
 
-A Morph Target is a morphable Mesh where primitives' attributes are obtained by adding the original attributes to a weighted sum of targets attributes.
+A morph target is a morphable Mesh where primitives' attributes are obtained by adding the original attributes to a weighted sum of targets attributes.
 
-For instance, the Morph Target vertices `POSITION` for the primitive at index *i* are computed in this way:
+For instance, the morph target vertices `POSITION` for the primitive at index *i* are computed in this way:
 
 [source,c]
 ----
@@ -1219,7 +1261,7 @@ primitives[i].attributes.POSITION +
   weights[2] * primitives[i].targets[2].POSITION + ...
 ----
 
-Morph Targets are specified via the `targets` property defined in the Mesh `primitives`. Each target in the `targets` array is a dictionary mapping a primitive attribute to an accessor containing Morph Target displacement data.
+Morph targets are specified via the `targets` property defined in the Mesh `primitives`. Each target in the `targets` array is a plain JSON object mapping a primitive attribute to an accessor containing morph target displacement data.
 
 Client implementations **SHOULD** support at least three attributes -- `POSITION`, `NORMAL`, and `TANGENT` -- for morphing. If morph targets contain application-specific semantics, their names **MUST** be prefixed with an underscore (e.g. `_TEMPERATURE`) like the associated attribute semantic.
 
@@ -1237,11 +1279,11 @@ Accessor type and component type for each morphed attribute semantic property **
 
 `POSITION` accessor **MUST** have `min` and `max` properties defined.
 
-All Morph Target's accessors **MUST** have the same `count` as the accessors of the original primitive.
+All morph target's accessors **MUST** have the same `count` as the accessors of the original primitive.
 
-A mesh with Morph Targets **MAY** also define an optional `mesh.weights` property that stores the default targets weights. In the absence of a `node.weights` property, the primitives attributes are resolved using these weights. When this property is missing, the default targets weights are zeros.
+A mesh with morph targets **MAY** also define an optional `mesh.weights` property that stores the default targets weights. These weights **MUST** be used when `node.weights` is undefined. When `mesh.weights` is undefined, the default targets weights are zeros.
 
-The following example extends the Mesh defined in the previous example to a morphable one by adding two Morph Targets:
+The following example extends the Mesh defined in the previous example to a morphable one by adding two morph targets:
 
 [source,json]
 ----
@@ -1274,7 +1316,7 @@ The following example extends the Mesh defined in the previous example to a morp
 }
 ----
 
-The number of morph targets is not limited. Client implementations **SHOULD** support at least eight morphed attributes. This means that they **SHOULD** support at least eight morph targets that contain a `POSITION` attribute, or four morph targets that contain a `POSITION` and a `NORMAL` attribute, or two morph targets that contain `POSITION`, `NORMAL` and `TANGENT` attributes.
+The number of morph targets is not limited. Client implementations **SHOULD** support at least eight morphed attributes. This means that they **SHOULD** support eight morph targets when each morph target has one attribute, four morph targets where each morph target has two attributes, or two morph targets where each morph target has three or four attributes.
 
 For assets that contain a higher number of morphed attributes, client implementations **MAY** choose to only use the eight attributes of the morph targets with the highest weights.
 
@@ -1387,7 +1429,7 @@ The mesh for a skin is defined with vertex attributes that are used in skinning 
 The number of joints that influence one vertex is limited to 4 per set, so referenced accessors **MUST** have `VEC4` type and following component types:
 
 * *`JOINTS_0`*: _unsigned byte_ or _unsigned short_
-* *`WEIGHTS_0`*: _float_, or _normalized unsigned byte_, or _normalized unsigned short_`
+* *`WEIGHTS_0`*: _float_, or _normalized unsigned byte_, or _normalized unsigned short_
 
 The joint weights for each vertex **MUST** be non-negative.
 
@@ -1395,7 +1437,7 @@ Joints **MUST NOT** contain more than one non-zero weight for a given vertex.
 
 When the weights are stored using _float_ component type, their linear sum **SHOULD** be as close as reasonably possible to `1.0` for a given vertex.
 
-When the weights are stored using _normalized unsigned byte_, or _normalized unsigned short_` component types, their linear sum before normalization **MUST** be `255` or `65535` respectively. Without these requirements, vertices would be deformed significantly because the weight error would get multiplied by the joint position. For example, an error of `1/255` in the weight sum would result in an unacceptably large difference in the joint position.
+When the weights are stored using _normalized unsigned byte_, or _normalized unsigned short_ component types, their linear sum before normalization **MUST** be `255` or `65535` respectively. Without these requirements, vertices would be deformed significantly because the weight error would get multiplied by the joint position. For example, an error of `1/255` in the weight sum would result in an unacceptably large difference in the joint position.
 
 [NOTE]
 .Implementation Note
@@ -1483,7 +1525,7 @@ The example below instantiates a Morph Target with non-default weights.
 }
 ----
 
-A skin is instanced within a node using a combination of the node's `mesh` and `skin` properties. The mesh for a skin instance is defined in the `mesh` property. The `skin` property contains the index of the skin to instance.
+A skin is instantiated within a node using a combination of the node's `mesh` and `skin` properties. The mesh for a skin instance is defined in the `mesh` property. The `skin` property contains the index of the skin to instance.
 
 [source,json]
 ----
@@ -1608,7 +1650,7 @@ The origin of the UV coordinates (0, 0) corresponds to the upper left corner of 
 
 image:figures/texcoords.jpg[pdfwidth=4in,align=left]
 
-Any colorspace information (such as ICC profiles, intents, gamma values, etc) from PNG or JPEG images **MUST** be ignored. Effective transfer function (encoding) is defined by a glTF object that refers to the image (in most cases it's a texture that is used by a material).
+Any colorspace information (such as ICC profiles, intents, gamma values, etc.) from PNG or JPEG images **MUST** be ignored. Effective transfer function (encoding) is defined by a glTF object that refers to the image (in most cases it's a texture that is used by a material).
 
 [NOTE]
 .Web Implementation Note
@@ -1653,7 +1695,16 @@ Minification modes include:
 
 * _Linear-mipmap-linear_. For each requested texel coordinates, the sampler first selects two pre-minified versions of the original image, computes a weighted sum of several adjacent texels from each of them, and performs final linear interpolation between these two intermediate results. This process is sometimes called "trilinear interpolation".
 
-To support mipmap modes, client implementations **MUST** be able to generate mipmaps at runtime.
+To properly support mipmap modes, client implementations **SHOULD** generate mipmaps at runtime. When runtime mipmap generation is not possible, client implementations **SHOULD** override the minification filtering mode as follows:
+
+[options="header"]
+|====
+| Mipmap minification mode   | Fallback mode
+| _Nearest-mipmap-nearest_ +
+  _Nearest-mipmap-linear_    | _Nearest_
+| _Linear-mipmap-nearest_ +
+  _Linear-mipmap-linear_     | _Linear_
+|====
 
 
 ==== Wrapping
@@ -1699,7 +1750,7 @@ The following example defines a sampler with _linear_ magnification filtering, _
 
 ==== Non-power-of-two Textures
 
-Client implementations **SHOULD** resize non power-of-two textures when running on certain platforms that have limited support for such texture dimensions.
+Client implementations **SHOULD** resize non power-of-two textures (so that their horizontal and vertical sizes are powers of two) when running on certain platforms that have limited support for such texture dimensions.
 
 [NOTE]
 .Implementation Note
@@ -1747,7 +1798,7 @@ All parameters related to the metallic-roughness material model are defined unde
 The metallic-roughness material model is defined by the following properties:
 
 * _base color_ - The base color of the material.
-* _metalness_ - The metalness of the material; values range from `0.0` (non-metal) to `1.0` (metal).
+* _metalness_ - The metalness of the material; values range from `0.0` (non-metal) to `1.0` (metal); see <<appendix-b-brdf-implementation, Appendix B>> for the interpretation of intermediate values.
 * _roughness_ - The roughness of the material; values range from `0.0` (smooth) to `1.0` (rough).
 
 The _base color_ has two different interpretations depending on the value of _metalness_. When the material is a metal, the base color is the specific measured reflectance value at normal incidence (F0). For a non-metal the base color represents the reflected diffuse color of the material. In this model it is not possible to specify a F0 value for non-metals, and a linear value of 4% (0.04) is used.
@@ -1812,7 +1863,9 @@ The following additional textures are supported:
 This mapping is usually implemented as `sampledValue * 2.0 - 1.0`.
 ====
 +
-The texture binding for normal textures **MAY** additionally contain a scalar `scale` value that linearly scales X and Y components of the normal vector. After scaling, the normal vector **MUST** be re-normalized.
+The texture binding for normal textures **MAY** additionally contain a scalar `scale` value that linearly scales X and Y components of the normal vector.
++
+Normal vectors **MUST** be normalized before being used in lighting equations. When scaling is used, vector normalization happens after scaling.
 
 - *occlusion* : The occlusion texture; it indicates areas that receive less diffuse lighting from ambient sources. Direct lighting is not affected. The _red_ channel of the texture encodes the occlusion value, where `0.0` means fully-occluded area (no indirect lighting) and `1.0` means not occluded area (full indirect lighting). Other texture channels (if present) do not affect occlusion.
 +
@@ -2049,7 +2102,7 @@ glTF 2.0 only supports animating node transforms and morph target weights. Exten
 [NOTE]
 .Note
 ====
-glTF 2.0 defines only storage of animation keyframes, so this specification doesn't define any particular runtime behavior, such as: order of playing, auto-start, loops, mapping of timelines, etc... When loading a glTF 2.0 asset, client implementations may select an animation entry and pause it on the first frame, play it automatically, or ignore all animations until further user requests. When a playing animation is stopped, client implementations may reset the scene to the initial state or to freeze it at the current frame.
+glTF 2.0 defines only storage of animation keyframes, so this specification doesn't define any particular runtime behavior, such as: order of playing, auto-start, loops, mapping of timelines, etc... When loading a glTF 2.0 asset, client implementations may select an animation entry and pause it on the first frame, play it automatically, or ignore all animations until further user requests. When a playing animation is stopped, client implementations may reset the scene to the initial state or freeze it at the current frame.
 ====
 
 [NOTE]
@@ -2346,7 +2399,7 @@ For example, an application that wants to download textures on demand may embed 
 
 This binary blob (which can be a file, for example) has the following structure:
 
-* A 12-byte preamble, entitled the _header_.
+* A 12-byte preamble, called the _header_.
 * One or more _chunks_ that contain JSON content and binary data.
 
 The _chunk_ containing JSON **MAY** refer to external resources as usual, and **MAY** also reference resources stored within other _chunks_.
@@ -2520,31 +2573,41 @@ include::PropertiesReference.adoc[]
 
 [appendix]
 [[appendix-a-json-schema-reference]]
-= JSON Schema Reference
+= JSON Schema Reference (Informative)
 
 // Generated with wetzel
 include::JsonSchemaReference.adoc[]
 
 [appendix]
 [[appendix-b-brdf-implementation]]
-= BRDF Implementation (Informative)
+= BRDF Implementation
 
 [[appendix-b-brdf-implementation-general]]
 == General
 
-In this chapter we present the bidirectional scattering distribution function (BRDF) of the glTF 2.0 metallic-roughness material. The BRDF describes the reflective properties of the surface of a physically-based material. For a pair of directions, the BRDF returns how much light from the incoming direction is scattered from the surface in the outgoing direction. See <<Pharr2016,Pharr et al. (2016), Chapter 5.6 "Surface Reflection">>, for an introduction to radiometry and the BRDF.
+In this chapter we present the bidirectional scattering distribution function (BRDF) of the glTF 2.0 metallic-roughness material. The BRDF describes the reflective properties of the surface of a physically-based material. For a pair of directions, the BRDF returns how much light from the incoming direction is scattered from the surface in the outgoing direction.
+
+[NOTE]
+.Note
+====
+See <<Pharr2016,Pharr et al. (2016), Chapter 5.6 "Surface Reflection">>, for an introduction to radiometry and the BRDF.
+====
 
 The BRDF of the metallic-roughness material is a linear interpolation of a metallic BRDF and a dielectric BRDF. The BRDFs share the parameters for roughness and base color. The blending factor `metallic` describes the metalness of the material.
 
 [source,c]
 ----
 material = mix(dielectric_brdf, metal_brdf, metallic)
-         = (1 - metallic) * dielectric_brdf + metallic * metal_brdf
+         = (1.0 - metallic) * dielectric_brdf + metallic * metal_brdf
 ----
 
+[NOTE]
+.Note
+====
 Such a material model based on a linear interpolation of metallic and dielectric components was introduced by <<Burley2012,Burley (2012)>> and adapted by many renderers, resulting in a wide-range of applications supporting it.
 
-Usually, a material is either metallic or dielectric. A texture provided for `metallic` with either 1 or 0 separates metallic from dielectric regions on the mesh. There are situations in which there is no clear separation. It may happen that due to anti-alising or mip-mapping there is a portion of metal and a portion of dielectric within a texel. Futhermore, a material composed of several semi-transparent layers may be represented as a blend between several single-layered materials (layering via parameter blending).
+Usually, a material is either metallic or dielectric. A texture provided for `metallic` with either `1.0` or `0.0` separates metallic from dielectric regions on the mesh. There are situations in which there is no clear separation. It may happen that due to anti-alising or mip-mapping there is a portion of metal and a portion of dielectric within a texel. Futhermore, a material composed of several semi-transparent layers may be represented as a blend between several single-layered materials (layering via parameter blending).
+====
 
 In this chapter, we will first sketch the logical structure of the material. We use an abstract notation that describes the material as a directed acyclic graph (DAG). The vertices correspond to the basic building blocks of the material model: BRDFs, mixing operators, input parameters, and constants. In the second part we will provide a sample implementation as a set of equations and source code for the BRDFs and mixing operators. In contrast to the logical structure the implementation is not normative.
 
@@ -2556,7 +2619,15 @@ In this chapter, we will first sketch the logical structure of the material. We 
 [[metals]]
 === Metals
 
-Metallic surfaces reflect back most of the illumination, only a small portion of the light is absorbed by the material (<<Pharr2016,Pharr et al. (2016), Chapter 8.2 "Specular Reflection and Transmission">>). This effect is described by the Fresnel term `conductor_fresnel` with the wavelength-dependent refractive index and extinction coefficient. To make parameterization simple, the metallic-roughness material combines the two quantities into a single, user-defined color value `baseColor` that defines the reflection color at normal incidence, also referred to as `f0`. The reflection color at grazing incidence is called `f90`. It is set to 1 because the grazing angle reflectance for any material approaches pure white in the limit. The conductor Fresnel term modulates the contribution of a specular BRDF parameterized by the `roughness` parameter.
+Metallic surfaces reflect back most of the illumination, only a small portion of the light is absorbed by the material.
+
+[NOTE]
+.Note
+====
+See <<Pharr2016,Pharr et al. (2016), Chapter 8.2 "Specular Reflection and Transmission">>.
+====
+
+This effect is described by the Fresnel term `conductor_fresnel` with the wavelength-dependent refractive index and extinction coefficient. To make parameterization simple, the metallic-roughness material combines the two quantities into a single, user-defined color value `baseColor` that defines the reflection color at normal incidence, also referred to as `f0`. The reflection color at grazing incidence is called `f90`. It is set to `1.0` because the grazing angle reflectance for any material approaches pure white in the limit. The conductor Fresnel term modulates the contribution of a specular BRDF parameterized by the `roughness` parameter.
 
 [source,c]
 ----
@@ -2564,16 +2635,24 @@ metal_brdf =
   conductor_fresnel(
     f0 = baseColor,
     bsdf = specular_brdf(
-      α = roughness^2))
+      α = roughness ^ 2))
 ----
 
 
 [[dielectrics]]
 === Dielectrics
 
-Unlike metals, dielectric materials transmit most of the incident illumination into the interior of the object and the Fresnel term is parameterized only by the refractive index (<<Pharr2016,Pharr et al. (2016), Chapter 8.2 "Specular Reflection and Transmission">>). This makes dielectrics like glass, oil, water or air transparent. Other dielectrics, like the majority of plastic materials, are filled with particles that absorb or scatter most or all of the transmitted light, reducing the transparency and giving the surface its colorful appearance.
+Unlike metals, dielectric materials transmit most of the incident illumination into the interior of the object and the Fresnel term is parameterized only by the refractive index.
 
-As a result, dielectric materials are modeled as a Fresnel-weighted combination of a specular BRDF, simulating the reflection at the surface, and a diffuse BRDF, simulating the transmitted portion of the light that is absorbed and scattered inside the object. The reflection roughness is given by the squared `roughness` of the material. The color of the diffuse BRDF comes from the `baseColor`. The amount of reflection compared to transmission is directional-dependent and as such determined by the Fresnel term. Its index of refraction is set to a fixed value of 1.5, a good compromise for the majority of opaque, dielectric materials.
+[NOTE]
+.Note
+====
+See <<Pharr2016,Pharr et al. (2016), Chapter 8.2 "Specular Reflection and Transmission">>.
+====
+
+This makes dielectrics like glass, oil, water or air transparent. Other dielectrics, like the majority of plastic materials, are filled with particles that absorb or scatter most or all of the transmitted light, reducing the transparency and giving the surface its colorful appearance.
+
+As a result, dielectric materials are modeled as a Fresnel-weighted combination of a specular BRDF, simulating the reflection at the surface, and a diffuse BRDF, simulating the transmitted portion of the light that is absorbed and scattered inside the object. The reflection roughness is given by the squared `roughness` of the material. The color of the diffuse BRDF comes from the `baseColor`. The amount of reflection compared to transmission is directional-dependent and as such determined by the Fresnel term. Its index of refraction is set to a fixed value of `1.5`, a good compromise for the majority of opaque, dielectric materials.
 
 [source,c]
 ----
@@ -2583,20 +2662,48 @@ dielectric_brdf =
     base = diffuse_brdf(
       color = baseColor),
     layer = specular_brdf(
-      α = roughness^2))
+      α = roughness ^ 2))
 ----
 
 
 [[microfacet-surfaces]]
 === Microfacet Surfaces
 
-The metal BRDF and the dielectric BRDF are based on a microfacet model. The theory behind microfacet models was developed in early works by <<TorranceSparrow1967,Torrance and Sparrow (1967)>>, <<CookTorrance1982,Cook and Torrance (1982)>> and others. A microfacet model describes the orientation of tiny facets (microfacets) on the surface as a statistical distribution. The distribution determines the orientation of the facets as a random perturbation around the normal direction of the surface. The perturbation strength depends on the `roughness` parameter and varies between 0 (smooth surface) and 1 (rough surface). A number of distribution functions have been proposed in the last decades. We use the Trowbridge-Reitz distribution first described by <<TrowbridgeReitz1975,Trowbridge and Reitz (1975)>>. Later <<Walter2007,Walter et al. (2007)>> independently developed the same distribution and called it "GGX". They show that it is a better fit for measured data than the Beckmann distribution used by <<CookTorrance1982,Cook and Torrance (1982)>> due to its stronger tails.
+The metal BRDF and the dielectric BRDF are based on a microfacet model.
 
-The Trowbridge-Reitz/GGX microfacet distribution describes the microsurface as being composed of perfectly specular, infinitesimal oblate ellipsoids, whose half-height in the normal direction is α times the radius in the tangent plane. α = 1 gives spheres, which results in uniform reflection in all directions. This reflection behavior corresponds to a rough surface. α = 0 gives a perfectly specular surface. As suggested by <<Burley2012,Burley (2012)>> we use the mapping α = `roughness`^2^ which results in more perceptually linear changes in the roughness.
+[NOTE]
+.Note
+====
+The theory behind microfacet models was developed in early works by <<TorranceSparrow1967,Torrance and Sparrow (1967)>>, <<CookTorrance1982,Cook and Torrance (1982)>> and others.
+====
 
-The distribution only describes the proportion of each normal on the microsurface. It does not describe how the normals are organized. For this we need a microsurface profile. The difference between distribution and profile is detailed by <<Heitz2014,Heitz (2014)>>, where he in addition provides an extensive study of common microfacet profiles. Based on this work, we suggest using the Smith microsurface profile (originally developed by <<Smith1967,Smith (1967)>>) and its corresponding masking-shadowing function. Heitz describes the Smith profile as the most accurate model for reflection from random height fields. It assumes that height and normal between neighboring points are not correlated, implying a random set of microfacets instead of a continuous surface.
+A microfacet model describes the orientation of tiny facets (microfacets) on the surface as a statistical distribution. The distribution determines the orientation of the facets as a random perturbation around the normal direction of the surface. The perturbation strength depends on the `roughness` parameter and varies between `0.0` (smooth surface) and `1.0` (rough surface). A number of distribution functions have been proposed in the last decades.
+
+We use the Trowbridge-Reitz / GGX microfacet distribution that describes the microsurface as being composed of perfectly specular, infinitesimal oblate ellipsoids, whose half-height in the normal direction is α times the radius in the tangent plane. α = 1 gives spheres, which results in uniform reflection in all directions. This reflection behavior corresponds to a rough surface. α = 0 gives a perfectly specular surface.
+
+[NOTE]
+.Note
+====
+The Trowbridge-Reitz distribution was first described by <<TrowbridgeReitz1975,Trowbridge and Reitz (1975)>>. Later <<Walter2007,Walter et al. (2007)>> independently developed the same distribution and called it "GGX". They show that it is a better fit for measured data than the Beckmann distribution used by <<CookTorrance1982,Cook and Torrance (1982)>> due to its stronger tails.
+====
+
+We use the mapping α = `roughness`^2^ which results in more perceptually linear changes in the roughness.
+
+[NOTE]
+.Note
+====
+This mapping was suggested by <<Burley2012,Burley (2012)>>. 
+====
+
+The distribution only describes the proportion of each normal on the microsurface. It does not describe how the normals are organized. For this we need a microsurface profile.
+
+[NOTE]
+.Note
+====
+The difference between distribution and profile is detailed by <<Heitz2014,Heitz (2014)>>, where he in addition provides an extensive study of common microfacet profiles. Based on this work, we suggest using the Smith microsurface profile (originally developed by <<Smith1967,Smith (1967)>>) and its corresponding masking-shadowing function. Heitz describes the Smith profile as the most accurate model for reflection from random height fields. It assumes that height and normal between neighboring points are not correlated, implying a random set of microfacets instead of a continuous surface.
 
 Microfacet models often do not consider multiple scattering. The shadowing term suppresses light that intersects the microsurface a second time. <<Heitz2016,Heitz et al. (2016)>> extended the Smith-based microfacet models to include a multiple scattering component, which significantly improves accuracy of predictions of the model. We suggest to incorporate multiple scattering whenever possible, either by making use of the unbiased stochastic evaluation introduced by Heitz, or one of the approximations presented later, for example by <<KullaConty2017,Kulla and Conty (2017)>> or <<Turquin2019,Turquin (2019)>>.
+====
 
 
 [[complete-model]]
@@ -2606,20 +2713,18 @@ The BRDFs and mixing operators used in the metallic-roughness material are summa
 
 image:figures/pbr.png[pdfwidth=4in,align=left]
 
-The glTF spec is designed to allow applications to choose different lighting implementations based on their requirements. Some implementations may focus on an accurate simulation of light transport while others may choose to deliver real-time performance. Therefore, any implementation that adheres to the rules for mixing BRDFs is conformant to the glTF spec.
+The glTF Specification is designed to allow applications to choose different lighting implementations based on their requirements. Some implementations **MAY** focus on an accurate simulation of light transport while others **MAY** choose to deliver real-time performance. Therefore, any implementation that adheres to the rules for mixing BRDFs is conformant to the glTF Specification.
 
-In a physically-accurate light simulation, the BRDFs have to follow some basic principles: the BRDF has to be positive, reciprocal and energy conserving. This ensures that the visual output of the simulation is independent of the underlying rendering algorithm, as long as it is unbiased.
+In a physically-accurate light simulation, the BRDFs **MUST** follow some basic principles: the BRDF has to be positive, reciprocal and energy conserving. This ensures that the visual output of the simulation is independent of the underlying rendering algorithm, as long as it is unbiased.
 
 The unbiased light simulation with physically realistic BRDFs will be the ground-truth for approximations in real-time renderers that are often biased, but still give visually pleasing results. Usually, these renderers take shortcuts to solve the rendering equation, like the split-sum approximation for image based lighting, or simplify the math to save instructions and reduce register pressure. However, there are many ways to achieve good approximations, depending on the platform (mobile or web applications, desktop applications on low or high-end hardware, VR) different constraints have to be taken into account.
 
 
 [[implementation]]
-== Implementation
+== Implementation (Informative)
 
 [[implementation-overview]]
 === Overview
-
-*This section is non-normative.*
 
 An implementation sample is available at https://github.com/KhronosGroup/glTF-Sample-Viewer/ and provides an example of a WebGL implementation of a standard BRDF based on the glTF material parameters. In order to achieve high performance in real-time applications, this implementation takes some short-cuts and uses non-physical simplifications that break energy-conservation and reciprocity.
 

--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -111,7 +111,7 @@ Any requirements, prohibitions, recommendations or options defined by <<introduc
 
 Some language in the specification is purely informative, intended to give background or suggestions to implementors or developers.
 
-If an entire chapter or section contains only informative language, its title will be suffixed with "`(Informative)`".
+If an entire chapter or section contains only informative language, its title is suffixed with "`(Informative)`".
 
 All NOTEs are implicitly informative.
 
@@ -119,7 +119,7 @@ All NOTEs are implicitly informative.
 [[introduction-normative-terminology]]
 === Normative Terminology
 
-The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**,  **MAY**, and **OPTIONAL** in this document are to be interpreted as described in https://tools.ietf.org/rfc/bcp/bcp14.html[BCP 14 - Key words for use in RFCs to Indicate Requirement Levels].
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**,  **MAY**, and **OPTIONAL** in this document are to be interpreted as described in <<bcp14,BCP 14>>.
 
 These key words are highlighted in the specification for clarity.
 
@@ -225,6 +225,15 @@ https://www.itu.int/rec/R-REC-BT.709-6-201506-I
 _MikkTSpace_
 https://github.com/mmikk/MikkTSpace
 
+* [[compositing]]
+Thomas Porter and Tom Duff. 1984. _Compositing digital images._ SIGGRAPH Comput. Graph. 18, 3 (July 1984), 253–259. DOI: https://doi.org/10.1145/964965.808606
++
+[NOTE]
+.Note
+====
+A free version of this paper is available from Pixar: https://graphics.pixar.com/library/Compositing/
+====
+
 ==== Media Type Registrations
 
 * [[gltf-json]]
@@ -269,7 +278,7 @@ glTF solves these problems by providing a vendor- and runtime-neutral format tha
 
 
 [[gltf-basics]]
-== glTF Basics (Informative)
+== glTF Basics
 
 A glTF asset is represented by:
 
@@ -307,19 +316,19 @@ While version 2.0 of glTF does not define compression for geometry and other ric
 * https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md[KHR_draco_mesh_compression] for geometry.
 * https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_texture_basisu/README.md[KHR_texture_basisu] for GPU-compatible block-compressed textures.
 
-Future extensions **MAY** include more compression methods including those for animation data.
+Future extensions may include more compression methods including those for animation data.
 
 
 [[versioning]]
 == Versioning (Informative)
 
-This section is marked as informal as there is no binding responsibility on implementations of the glTF — these guarantees are however a contract between the 3D Formats Working Group and developers using this Specification.
+This section is marked as informative as there is no binding responsibility on implementations of the glTF — these guarantees are however a contract between the 3D Formats Working Group and developers using this Specification.
 
-Any updates made to glTF in a minor version **MUST** be backwards and forwards compatible. Backwards compatibility means that any client implementation that supports loading a glTF 2.x asset will also be able to load a glTF 2.0 asset. Forwards compatibility means that a client implementation that only supports glTF 2.0 is able to load glTF 2.x assets while gracefully ignoring any new features it does not understand.
+Any updates made to glTF in a minor version must be backwards and forwards compatible. Backwards compatibility means that any client implementation that supports loading a glTF 2.x asset will also be able to load a glTF 2.0 asset. Forwards compatibility means that a client implementation that only supports glTF 2.0 is able to load glTF 2.x assets while gracefully ignoring any new features it does not understand.
 
-A minor version update **MAY** introduce new features but **MUST NOT** change any previously existing behavior. Existing functionality **MAY** be deprecated in a minor version update, but it **MUST NOT** be removed.
+A minor version update may introduce new features but must not change any previously existing behavior. Existing functionality may be deprecated in a minor version update, but it must not be removed.
 
-Major version updates **MAY** be incompatible with previous versions.
+Major version updates may be incompatible with previous versions.
 
 
 [[file-extensions-and-media-types]]
@@ -1924,8 +1933,20 @@ The `alphaMode` property defines how the alpha value is interpreted. The alpha v
 `alphaMode` can be one of the following values:
 
 * `OPAQUE` - The rendered output is fully opaque and any alpha value is ignored.
-* `MASK` - The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified _alpha cutoff_ value. This mode is used to simulate geometry such as tree leaves or wire fences.
-* `BLEND` - The rendered output is combined with the background using the normal painting operation (i.e. the Porter and Duff over operator). This mode is used to simulate geometry such as guaze cloth or animal fur.
+* `MASK` - The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified _alpha cutoff_ value.
++
+[NOTE]
+.Note
+====
+This mode is used to simulate geometry such as tree leaves or wire fences.
+====
+* `BLEND` - The rendered output is combined with the background using the "`over`" operator as described in <<compositing,Compositing digital images>>.
++
+[NOTE]
+.Note
+====
+This mode is used to simulate geometry such as guaze cloth or animal fur.
+====
 
 When `alphaMode` is set to `MASK` the `alphaCutoff` property specifies the cutoff threshold. If the alpha value is greater than or equal to the `alphaCutoff` value then it is rendered as fully opaque, otherwise, it is rendered as fully transparent. `alphaCutoff` value is ignored for other modes.
 
@@ -1978,13 +1999,28 @@ This specification does not define size and style of non-triangular primitives (
 [[cameras-overview]]
 === Overview
 
-A camera defines the projection matrix that transforms from view to clip coordinates. The projection can be perspective or orthographic. Cameras are contained in nodes and thus can be transformed. Their world-space transformation matrix is used for calculating view-space transformation. The camera is defined such that the local +X axis is to the right, the lens looks towards the local -Z axis, and the top of the camera is aligned with the local +Y axis. If no transformation is specified, the location of the camera is at the origin.
+Cameras are stored in the asset's `cameras` array. Each camera defines a `type` property that designates the type of projection (perspective or orthographic), and either a `perspective` or `orthographic` property that defines the details. A camera is instantiated within a node using `node.camera` property.
 
-Cameras are stored in the asset's `cameras` array. Each camera defines a `type` property that designates the type of projection (perspective or orthographic), and either a `perspective` or `orthographic` property that defines the details.
+A camera object defines the projection matrix that transforms from view to clip coordinates.
 
-There are two subtypes of perspective projections: finite and infinite. When `zfar` property is undefined, infinite projection is used. Otherwise the camera defines a finite projection.
+A node containing the camera instance defines the view matrix that transforms from world to view coordinates.
 
-For orthographic and finite perspective cameras, `zfar` **MUST** be greater than `znear`.
+[[view-matrix]]
+=== View Matrix
+
+The camera is defined such that the local +X axis is to the right, the "`lens`" looks towards the local -Z axis, and the top of the camera is aligned with the local +Y axis.
+
+The view matrix is derived from the world transform of the node containing the camera with the scaling ignored. If no transformation is specified, the location of the camera is at the origin.
+
+[[projection-matrices]]
+=== Projection Matrices
+
+[[projection-matrices-overview]]
+==== Overview
+
+The projection can be perspective or orthographic.
+
+There are two subtypes of perspective projections: finite and infinite. When `zfar` property is undefined, the camera defines an infinite projection. Otherwise the camera defines a finite projection.
 
 The following example defines two perspective cameras with supplied values for Y field of view, aspect ratio, and clipping information.
 
@@ -2014,13 +2050,6 @@ The following example defines two perspective cameras with supplied values for Y
     ]
 }
 ----
-
-
-[[projection-matrices]]
-=== Projection Matrices
-
-[[projection-matrices-overview]]
-==== Overview
 
 Client implementations **SHOULD** use the following projection matrices.
 
@@ -2524,7 +2553,7 @@ include::PropertiesReference.adoc[]
 * Tony Parisi, Unity
 
 [[working-group-and-alumni]]
-== Khronos 3D Formats Working Group and Alumni
+== Khronos 3D Formats Working Group and Alumni (Informative)
 
 * Remi Arnaud, Starbreeze Studios
 * Mike Bond, Adobe

--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2020 Khronos Group.
+// Copyright (c) 2013-2021 Khronos Group.
 //
 // SPDX-License-Identifier: CC-BY-4.0
 
@@ -34,7 +34,7 @@ toc::[]
 [[copyright-statement]]
 = Copyright Statement
 
-Copyright 2013-2020 The Khronos Group Inc.
+Copyright 2013-2021 The Khronos Group Inc.
 
 Some parts of this Specification are purely informative and do not define requirements
 necessary for compliance and so are outside the Scope of this Specification. These
@@ -91,45 +91,168 @@ for identification and belong to their respective owners.
 [[introduction-general]]
 == General
 
-The GL Transmission Format (glTF) is an API-neutral runtime asset delivery format.  glTF bridges the gap between 3D content creation tools and modern graphics applications by providing an efficient, extensible, interoperable format for the transmission and loading of 3D content.
+This document, referred to as the “glTF Specification” or just the “Specification” hereafter, describes the glTF file format.
+
+glTF is an API-neutral runtime asset delivery format.  glTF bridges the gap between 3D content creation tools and modern graphics applications by providing an efficient, extensible, interoperable format for the transmission and loading of 3D content.
+
+
+[[introduction-conventions]]
+== Document Conventions
+
+The glTF Specification is intended for use by both implementors of the asset exporters or converters (e.g. DCC tools) and application developers seeking to import or load glTF assets, forming a contract between these parties.
+
+Specification text may address either party; typically the intended audience can be inferred from context, though some sections are defined to address only one of these parties.
+
+Any requirements, prohibitions, recommendations or options defined by <<introduction-normative-terminology, normative terminology>> are imposed only on the audience of that text.
+
+
+[[introduction-informative-language]]
+=== Informative Language
+
+Some language in the specification is purely informative, intended to give background or suggestions to implementors or developers.
+
+If an entire chapter or section contains only informative language, its title will be suffixed with "`(Informative)`".
+
+All NOTEs are implicitly informative.
+
+
+[[introduction-normative-terminology]]
+=== Normative Terminology
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**,  **MAY**, and **OPTIONAL** in this document are to be interpreted as described in https://tools.ietf.org/rfc/bcp/bcp14.html[BCP 14 - Key words for use in RFCs to Indicate Requirement Levels].
+
+These key words are highlighted in the specification for clarity.
+
+Unless otherwise noted in the section heading, all sections and appendices in this document are normative.
+
+
+[[introduction-technical-terminology]]
+=== Technical Terminology
+
+The glTF Specification makes use of common engineering and graphics terms such as *Vertex*, *Normal*, *Texture*, etc to identify and describe certain GPU constructs and their attributes, states, and behaviors.
+
+[[introduction-normative-references]]
+=== Normative References
+
+References to external documents are considered normative references if the Specification uses any of the normative terms defined in <<introduction-normative-terminology>> to refer to them or their requirements, either as a whole or in part.
+
+The following documents are referenced by normative sections of the specification:
+
+==== External Specifications
+
+[[bcp14]]
+Bradner, S., _Key words for use in RFCs to Indicate Requirement Levels_, BCP 14, RFC 2119, March 1997. Leiba, B., _Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words_, BCP 14, RFC 8174, May 2017.
+<https://www.rfc-editor.org/info/bcp14>
+
+[[utf8]
+The Unicode Consortium, _The Unicode Standard_
+<https://www.unicode.org/versions/latest/>
+
+[[json]]
+Bray, T., Ed., _The JavaScript Object Notation (JSON) Data Interchange Format_, STD 90, RFC 8259, DOI 10.17487/RFC8259, December 2017, <https://www.rfc-editor.org/info/rfc8259>
+
+[[ieee-754]]
+ISO/IEC 60559:2020
+_Floating-point arithmetic_
+<https://www.iso.org/standard/80985.html>
+
+[[png]]
+ISO/IEC 15948:2004
+_Portable Network Graphics (PNG): Functional specification_
+<https://www.iso.org/standard/29581.html>
+
+[[jpeg]]
+ISO/IEC 10918-1:1994
+_Digital compression and coding of continuous-tone still images: Requirements and guidelines_
+<https://www.iso.org/standard/18902.html>
+
+[[jfif]]
+ISO/IEC 10918-5:2013
+_Digital compression and coding of continuous-tone still images: JPEG File Interchange Format (JFIF)_
+<https://www.iso.org/standard/54989.html>
+
+[[data-uri]]
+Masinter, L., _The "data" URL scheme_, RFC 2397, DOI 10.17487/RFC2397, August 1998, <https://www.rfc-editor.org/info/rfc2397>
+
+[[uri]]
+Berners-Lee, T., Fielding, R., and L. Masinter, _Uniform Resource Identifier (URI): Generic Syntax_, STD 66, RFC 3986, DOI 10.17487/RFC3986, January 2005, <https://www.rfc-editor.org/info/rfc3986>
+
+[[iri]]
+Duerst, M. and M. Suignard, _Internationalized Resource Identifiers (IRIs)_, RFC 3987, DOI 10.17487/RFC3987, January 2005, <https://www.rfc-editor.org/info/rfc3987>
+
+[[http]]
+Fielding, R., Ed., and J. Reschke, Ed., _Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing_, RFC 7230, DOI 10.17487/RFC7230, June 2014, <https://www.rfc-editor.org/info/rfc7230>
+
+[[srgb]]
+IEC 61966-2-1:1999.
+_Default RGB colour space - sRGB_
+https://webstore.iec.ch/publication/6169
+
+[[mikktspace]]
+_MikkTSpace_
+https://github.com/mmikk/MikkTSpace
+
+==== Media Type Registrations
+
+[[gltf-json]]
+IANA.
+_model/gltf+json Media Type_.
+https://www.iana.org/assignments/media-types/model/gltf+json
+
+[[gltf-binary]]
+IANA.
+_model/gltf-binary Media Type_.
+https://www.iana.org/assignments/media-types/model/gltf-binary
+
+[[gltf-buffer]]
+IANA.
+_application/gltf-buffer Media Type_.
+https://www.iana.org/assignments/media-types/application/gltf-buffer
+
+[[octet-stream]]
+IANA.
+_application/octet-stream Media Type_.
+https://www.iana.org/assignments/media-types/application/octet-stream
+
+[[image-jpeg]]
+Freed, N. and N. Borenstein, _Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types_, RFC 2046, DOI 10.17487/RFC2046, November 1996, <https://www.rfc-editor.org/info/rfc2046>
+
+[[image-png]]
+IANA.
+_image/png Media Type_.
+https://www.iana.org/assignments/media-types/image/png
 
 
 [[motivation]]
-== Motivation
-
-*This section is non-normative.*
+== Motivation (Informative)
 
 Traditional 3D modeling formats have been designed to store data for offline use, primarily to support authoring workflows on desktop systems. Industry-standard 3D interchange formats allow for sharing assets between different modeling tools, and within the content pipeline in general. However, neither of these types of formats is optimized for download speed or fast loading at runtime. Files tend to grow very large, and applications need to do a significant amount of processing to load such assets into GPU-accelerated applications.
 
 Applications seeking high performance rarely load modeling formats directly; instead, they process models offline as part of a custom content pipeline, converting the assets into a proprietary format optimized for their runtime application.  This has led to a fragmented market of incompatible proprietary runtime formats and duplicated efforts in the content creation pipeline. 3D assets exported for one application cannot be reused in another application without going back to the original modeling, tool-specific source and performing another proprietary export step.
 
-With the advent of mobile- and web-based 3D computing, new classes of applications have emerged that require fast, dynamic loading of standardized 3D assets. Digital marketing solutions, e-commerce product visualizations, and online model-sharing sites are just a few of the connected 3D applications being built today using WebGL or OpenGL ES. Beyond the need for efficient delivery, many of these online applications can benefit from a standard, interoperable format to enable sharing and reuse of assets between users, between applications, and within heterogeneous, distributed content pipelines.
+With the advent of mobile- and web-based 3D computing, new classes of applications have emerged that require fast, dynamic loading of standardized 3D assets. Digital marketing solutions, e-commerce product visualizations, and online model-sharing sites are just a few of the connected 3D applications being built today using GPU APIs. Beyond the need for efficient delivery, many of these online applications can benefit from a standard, interoperable format to enable sharing and reuse of assets between users, between applications, and within heterogeneous, distributed content pipelines.
 
-glTF solves these problems by providing a vendor- and runtime-neutral format that can be loaded and rendered with minimal processing. The format combines an easily parseable JSON scene description with one or more binary files representing geometry, animations, and other rich data. Binary data is stored in such a way that it can be loaded directly into GPU buffers without additional parsing or other manipulation. Using this approach, glTF is able to faithfully preserve full hierarchical scenes with nodes, meshes, cameras, materials, and animations, while enabling efficient delivery and fast loading.
+glTF solves these problems by providing a vendor- and runtime-neutral format that can be loaded and rendered with minimal processing. The format combines an easily parsable JSON scene description with one or more binary resources representing geometry, animations, and other rich data. Binary data is stored in such a way that it can be in most cases loaded directly into GPU buffers without additional parsing or other manipulation. Using this approach, glTF is able to faithfully preserve full hierarchical scenes with nodes, meshes, cameras, materials, and animations, while enabling efficient delivery and fast loading.
 
 
 [[gltf-basics]]
-== glTF Basics
+== glTF Basics (Informative)
 
-*This section is non-normative.*
+A glTF asset is represented by:
 
-glTF assets are JSON files plus supporting external data. Specifically, a glTF asset is represented by:
+* A JSON-formatted file (`.gltf`) containing a full scene description: node hierarchy, materials, cameras, as well as descriptor information for meshes, animations, and other constructs.
+* Binary files (`.bin`) containing geometry, animation, and other buffer-based data.
+* Image files (`.jpg`, `.png`) containing texture images.
 
-* A JSON-formatted file (`.gltf`) containing a full scene description: node hierarchy, materials, cameras, as well as descriptor information for meshes, animations, and other constructs
-* Binary files (`.bin`) containing geometry and animation data, and other buffer-based data
-* Image files (`.jpg`, `.png`) for textures
+Binary and image resources **MAY** also be embedded directly in JSON using <<data-uri,Data URI>> or stored side-by-side with JSON in GLB container.
 
-Assets defined in other formats, such as images, may be stored in external files referenced via URI, stored side-by-side in GLB container, or embedded directly into the JSON using https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs[data URIs].
-
-Valid glTF asset must specify its version.
+Valid glTF asset **MUST** specify its version.
 
 image:figures/files.png[pdfwidth=4in,align=left]
 
 
 [[design-goals]]
-== Design Goals
-
-*This section is non-normative.*
+== Design Goals (Informative)
 
 glTF has been designed to meet the following goals:
 
@@ -146,91 +269,146 @@ The following are outside the scope of the initial design of glTF:
 * *glTF is not a streaming format.* The binary data in glTF is inherently streamable, and the buffer design allows for fetching data incrementally. But there are no other streaming constructs in the format, and no conformance requirements for an implementation to stream data versus downloading it in its entirety before rendering.
 * *glTF is not intended to be human-readable,* though by virtue of being represented in JSON, it is developer-friendly.
 
-While version 2.0 of glTF does not define compression for geometry and other rich data, the https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md[KHR_draco_mesh_compression extension] provides that option. Future extensions may include compression methods for textures and animation data.
+While version 2.0 of glTF does not define compression for geometry and other rich data, there are extensions providing such options.
+* https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md[KHR_draco_mesh_compression] for geometry.
+* https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_texture_basisu/README.md[KHR_texture_basisu] for GPU-compatible block-compressed textures.
+
+Future extensions **MAY** include more compression methods including those for animation data.
 
 
 [[versioning]]
-== Versioning
+== Versioning (Informative)
 
-Any updates made to glTF in a minor version will be backwards and forwards compatible. Backwards compatibility will ensure that any client implementation that supports loading a glTF 2.x asset will also be able to load a glTF 2.0 asset. Forwards compatibility will allow a client implementation that only supports glTF 2.0 to load glTF 2.x assets while gracefully ignoring any new features it does not understand.
+This section is marked as informal as there is no binding responsibility on implementations of the glTF — these guarantees are however a contract between the 3D Formats Working Group and developers using this Specification.
 
-A minor version update can introduce new features but will not change any previously existing behavior. Existing functionality can be deprecated in a minor version update, but it will not be removed.
+Any updates made to glTF in a minor version **MUST** be backwards and forwards compatible. Backwards compatibility means that any client implementation that supports loading a glTF 2.x asset will also be able to load a glTF 2.0 asset. Forwards compatibility means that a client implementation that only supports glTF 2.0 is able to load glTF 2.x assets while gracefully ignoring any new features it does not understand.
 
-Major version updates are not expected to be compatible with previous versions.
+A minor version update **MAY** introduce new features but **MUST NOT** change any previously existing behavior. Existing functionality **MAY** be deprecated in a minor version update, but it **MUST NOT** be removed.
+
+Major version updates **MAY** be incompatible with previous versions.
 
 
-[[file-extensions-and-mime-types]]
-== File Extensions and MIME Types
+[[file-extensions-and-media-types]]
+== File Extensions and Media Types
 
-* `*.gltf` files use `model/gltf+json`
-* `*.bin` files use `application/octet-stream` or `application/gltf-buffer`
-  - When using MIME type `application/gltf-buffer`, the binary file extension may be `*.bin`, `*.glbin`, or `*.glbuf`.  See the https://www.iana.org/assignments/media-types/application/gltf-buffer[gltf-buffer registration].
-* Texture files use the official `image/*` type based on the specific image format. For compatibility with modern web browsers, the following image formats are supported: `image/jpeg`, `image/png`.
-+
-[NOTE]
-.Implementation Note
-====
-Implementations should use the image type pattern matching algorithm from the https://mimesniff.spec.whatwg.org/#matching-an-image-type-pattern[MIME Sniffing Standard] to detect PNG and JPEG images as file extensions may be unavailable in some contexts.
-====
+* JSON glTF files **SHOULD** use `.gltf` extension and <<gltf-json,`model/gltf+json`>> Media Type.
+* glTF files stored in GLB container **SHOULD** use `.glb` extension and <<gltf-binary,`model/gltf-binary`>> Media Type.
+* Files representing binary buffers **SHOULD** use either:
+** `.bin` file extension with <<octet-stream,`application/octet-stream`>> Media Type;
+** `.bin`, `.glbin`, or `.glbuf` file extensions with <<gltf-buffer,`application/gltf-buffer`>> Media Type.
 
+* <<png,PNG>> images **SHOULD** use `.png` file extension with <<image-png,`image/png`>> Media Type;
+** PNG images **SHOULD NOT** contain animations, non-square pixel ratios, or embedded ICC profiles. Such features if present **MUST** be ignored by client implementations.
+
+* <<jpeg,JPEG>> images **SHOULD** use `.jpeg` or `.jpg` file extensions with <<image-jpeg,`image/jpeg`>> Media Type
+** JPEG images **SHOULD** use <<jfif,JPEG File Interchange Format>>.
+** Client implementations **MAY** support JPEG images that use <<exif,Exchangeable image file format (Exif)>>.
 
 [[json-encoding]]
 == JSON Encoding
 
-To simplify client-side implementation, glTF has additional restrictions on JSON format and encoding.
+Although glTF Specification does not define any subset of the <<json,JSON>> format, implementations **SHOULD** be aware of its peculiar properties that could affect asset interoperability.
 
-1. JSON must use UTF-8 encoding without BOM.
+1. glTF JSON data **SHOULD** be written with UTF-8 encoding without BOM. This requirement is not applied when a glTF implementation does not control string encoding. glTF implementations **SHOULD** adhere to the <<json,RFC 8259>>, Section 8.1. with regards to treating BOM presence.
+
+2. ASCII characters stored in glTF JSON **SHOULD** be written unescaped.
++
+[NOTE]
+.Example
+====
+`"buffer"` instead of `"\u0062\u0075\u0066\u0066\u0065\u0072"`.
+====
+
+3. Non-ASCII characters stored in glTF JSON **MAY** be escaped.
++
+[NOTE]
+.Example
+====
+These two examples represent the same glTF JSON data.
+
+[source,json]
+-----
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "nodes": [
+        {
+            "name": "куб"
+        },
+        {
+            "name": "立方體"
+        }
+    ]
+}
+-----
+
+[source,json]
+-----
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "nodes": [
+        {
+            "name": "\u043a\u0443\u0431"
+        },
+        {
+            "name": "\u7acb\u65b9\u9ad4"
+        }
+    ]
+}
+-----
+
+====
+
+4. Property names (keys) within JSON objects **SHOULD** be unique. glTF client implementations **SHOULD** override lexically preceding values for the same key.
+
+5. Some of glTF properties are defined as integers in the schema. Such values **MAY** be stored as decimals with a zero fractional part or by using exponent notation. Regardless of encoding, such properties **MUST NOT** contain any non-zero fractional value.
++
+[NOTE]
+.Example
+====
+`100`, `100.0`, and `1e2` represent the same value. See <<json,RFC 8259>>, Section 6 for more details.
+====
+
+6. Non-integer numbers **SHOULD** be written in a way that preserves original values when these numbers are read back, i.e. they **SHOULD NOT** be altered by JSON serialization / deserialization roundtrip.
 +
 [NOTE]
 .Implementation Note
 ====
-glTF exporters must not add a byte order mark to the beginning of JSON text. In the interests of interoperability, client implementations may ignore the presence of a byte order mark rather than treating it as an error. See https://tools.ietf.org/html/rfc8259#section-8[RFC8259, section 8] for more information.
+This is typically achieved with algorithms like Grisu2 used by common JSON libraries.
 ====
-
-2. All strings defined in this spec (properties names, enums) use only ASCII charset and must be written as plain text, e.g., `"buffer"` instead of `"\u0062\u0075\u0066\u0066\u0065\u0072"`.
-+
-[NOTE]
-.Implementation Note
-====
-This allows generic glTF client implementations to not have full Unicode support. Application-specific strings (e.g., values of `"name"` properties or content of `extras` fields) may use any symbols.
-====
-
-3. Names (keys) within JSON objects must be unique, i.e., duplicate keys aren't allowed.
-
 
 [[uris]]
 == URIs
 
-glTF uses URIs to reference buffers and image resources. Clients must support at least these two URI types:
+glTF assets use <<uri,URIs>> or <<iri,IRIs>> to reference buffers and image resources. Assets **MAY** contain at least these two URI types:
 
-- **Data URIs** that embed resources in the JSON. They use syntax defined by https://tools.ietf.org/html/rfc2397[RFC 2397].
+- **Data URIs** that embed binary resources in the glTF JSON as defined by the <<data-uri,RFC 2397>>. The Data URI's `mediatype` field **MUST** match the encoded content.
 +
 [NOTE]
 .Implementation Note
 ====
-Data URIs could be https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding[decoded with JavaScript] or consumed directly by web browsers in HTML tags.
+Base64 encoding used in Data URI increases the payload's byte length by 33%.
 ====
 
-- **Relative URI paths** -- or `path-noscheme` as defined by RFC 3986, https://tools.ietf.org/html/rfc3986#section-4.2[Section 4.2] -- without scheme, authority, or parameters. Reserved characters must be percent-encoded, per RFC 3986, https://tools.ietf.org/html/rfc3986#section-2.2[Section 2.2].
-+
-[NOTE]
-.Implementation Note
-====
-Clients can optionally support additional URI components. For example `http://` or `file://` schemes, authorities/hostnames, absolute paths, and query or fragment parameters. Assets containing these additional URI components may be less portable.
-====
-+
-[NOTE]
-.Implementation Note
-====
-This allows the application to decide the best approach for delivery: if different assets share many of the same geometries, animations, or textures, separate files may be preferred to reduce the total amount of data requested. With separate files, applications can progressively load data and do not need to load data for parts of a model that are not visible. If an application cares more about single-file deployment, embedding data may be preferred even though it increases the overall size due to base64 encoding and does not support progressive or on-demand loading. Alternatively, an asset could use GLB container to store JSON and binary data in one file without base64 encoding. See <<glb-file-format-specification,GLB File Format Specification>> for details.
-====
+- **Relative paths** -- `path-noscheme` or `ipath-noscheme` as defined by <<uri,RFC 3986>>, Section 4.2 or <<iri,RFC 3987>>, Section 2.2 -- without scheme, authority, or parameters. Reserved characters **MUST** be percent-encoded, per <<uri,RFC 3986>>, Section 2.2.
 
-Applications should consider applying syntax-based normalization to URIs as defined by https://tools.ietf.org/html/rfc3986#section-6.2.2[RFC 3986, Section 6.2.2.], https://tools.ietf.org/html/rfc3987#section-5.3.2[RFC 3987, Section 5.3.2.], and applicable schema rules (e.g., https://tools.ietf.org/html/rfc7230#section-2.7.3[RFC 7230, Section 2.7.3.] for HTTP) on export and/or import.
+Client implementations **MAY** optionally support additional URI components. For example `http://` or `file://` schemes, authorities, hostnames, absolute paths, and query or fragment parameters. Assets containing these additional URI components would be less portable.
 
 [NOTE]
 .Implementation Note
 ====
-While the spec does not explicitly disallow non-normalized URIs, their use may be unsupported or lead to unwanted side-effects -- such as security warnings or cache misses -- on some platforms.
+This allows the application to decide the best approach for delivery: if different assets share many of the same geometries, animations, or textures, separate files may be preferred to reduce the total amount of data requested. With separate files, applications may progressively load data and do not need to load data for parts of a model that are not visible. If an application cares more about single-file deployment, embedding data may be preferred even though it increases the overall size due to base64 encoding and does not support progressive or on-demand loading. Alternatively, an asset could use GLB container to store JSON and binary data in one file without base64 encoding. See <<glb-file-format-specification,GLB File Format Specification>> for details.
+====
+
+URIs **SHOULD** undergo syntax-based normalization as defined by <<uri,RFC 3986>>, Section 6.2.2, <<iri,RFC 3987>>, Section 5.3.2, and applicable schema rules (e.g., <<http,RFC 7230>>, Section 2.7.3 for HTTP) on export and/or import.
+
+[NOTE]
+.Implementation Note
+====
+While the specification does not explicitly disallow non-normalized URIs, their use may be unsupported or lead to unwanted side-effects -- such as security warnings or cache misses -- on some platforms.
 ====
 
 
@@ -242,13 +420,13 @@ While the spec does not explicitly disallow non-normalized URIs, their use may b
 
 image:figures/dictionary-objects.png[pdfwidth=4in,align=left]
 
-The top-level arrays in a glTF asset.  See the <<properties-reference, Properties Reference>>.
+The image above shows relations between top-level arrays in a glTF asset.  See the <<properties-reference, Properties Reference>>.
 
 
 [[asset]]
 == Asset
 
-Each glTF asset must have an `asset` property. In fact, it's the only required top-level property for JSON to be a valid glTF. The `asset` object must contain glTF version which specifies the target glTF version of the asset. Additionally, an optional `minVersion` property can be used to specify the minimum glTF version support required to load the asset. The `minVersion` property allows asset creators to specify a minimum version that a client implementation must support in order to load the asset. This is very similar to the `extensionsRequired` concept, where an asset should only be loaded if the client supports the specified extension. Additional metadata can be stored in optional properties such as `generator` or `copyright`.  For example,
+Each glTF asset **MUST** have an `asset` property. The `asset` object **MUST** contain `version` property which specifies the target glTF version of the asset. Additionally, an optional `minVersion` property **MAY** be used to specify the minimum glTF version support required to load the asset. The `minVersion` property allows asset creators to specify a minimum version that a client implementation **MUST** support in order to load the asset. This is very similar to the `extensionsRequired` concept described in <<specifying-extensions>>, where an asset **SHOULD NOT** be loaded if the client does not support the specified extension. Additional metadata **MAY** be stored in optional properties such as `generator` or `copyright`.  For example,
 
 [source,json]
 ----
@@ -293,17 +471,19 @@ Entities of a glTF asset are referenced by their indices in corresponding arrays
 }
 ----
 
-In this example, `buffers` and `bufferViews` have only one element each. The bufferView refers to the buffer using the buffer's index: `"buffer": 0`.
+In this example, `buffers` and `bufferViews` arrays have only one element each. The bufferView refers to the buffer using the buffer's index: `"buffer": 0`.
 
-Whereas indices are used for internal glTF references, _names_ are used for application-specific uses such as display. Any top-level glTF object can have a `name` string property for this purpose. These property values are not guaranteed to be unique as they are intended to contain values created when the asset was authored.
+Indices **MUST** be non-negative integer numbers. Indices **MUST** always point to existing elements.
 
-For property names, glTF uses https://en.wikipedia.org/wiki/CamelCase[camel case] `likeThis`. Camel case is a common naming convention in JSON and WebGL.
+Whereas indices are used for internal glTF references, optional _names_ are used for application-specific uses such as display. Any top-level glTF object **MAY** have a `name` string property for this purpose. These property values are not guaranteed to be unique as they are intended to contain values created when the asset was authored.
+
+For property names, glTF usually uses camel case, `likeThis`.
 
 
 [[coordinate-system-and-units]]
 == Coordinate System and Units
 
-glTF uses a right-handed coordinate system, that is, the cross product of +X and +Y yields +Z. glTF defines +Y as up. The front of a glTF asset faces +Z.
+glTF uses a right-handed coordinate system. glTF defines +Y as up, -X as right, the front of a glTF asset faces +Z.
 
 image:figures/coordinate-system.png[pdfwidth=4in,align=left]
 
@@ -313,18 +493,12 @@ All angles are in radians.
 
 Positive rotation is counterclockwise.
 
-The <<transformations,node transformations>> and <<animations,animation channel paths>> are 3D vectors or quaternions with the following data types and semantics:
-
-* translation: A 3D vector containing the translation along the x, y and z axes
-* rotation: A quaternion (x, y, z, w), where w is the scalar
-* scale: A 3D vector containing the scaling factors along the x, y and z axes
-
-RGB color values use sRGB color primaries.
+RGB color values **MUST** use <<srgb,sRGB>> color primaries.
 
 [NOTE]
 .Implementation Note
 ====
-Color primaries define the interpretation of each color channel of the color model, particularly with respect to the RGB color model. In the context of a typical display, color primaries describe the color of the red, green and blue phosphors or filters. The same primaries are also defined in Recommendation ITU-R BT.709. Since the overwhelming majority of currently used consumer displays are using the same primaries as default, client implementations usually do not need to convert color values. Future specification versions or extensions may allow other color primaries (such as P3) or even provide a way of embedding custom color profiles.
+Color primaries define the interpretation of each color channel of the color model, particularly with respect to the RGB color model. In the context of a typical display, color primaries describe the color of the red, green and blue phosphors or filters. The same primaries are also defined in Recommendation ITU-R BT.709. Since the overwhelming majority of currently used consumer displays are using the same primaries as default, client implementations usually do not need to convert color values. Future specification versions or extensions may allow other color primaries (such as P3).
 ====
 
 
@@ -335,17 +509,11 @@ Color primaries define the interpretation of each color channel of the color mod
 [[scenes-overview]]
 === Overview
 
-The glTF asset contains zero or more *scenes*, the set of visual objects to render. Scenes are defined in a `scenes` array. An additional property, `scene` (note singular), identifies which of the scenes in the array is to be displayed at load time.
+glTF 2.0 assets **MAY** contain zero or more _scenes_, the set of visual objects to render. Scenes are defined in a `scenes` array. All nodes listed in `scene.nodes` array **MUST** be root nodes (see the next section for details).
 
-All nodes listed in `scene.nodes` array must be root nodes (see the next section for details).
+An additional root-level property, `scene` (note singular), identifies which of the scenes in the array **SHOULD** be displayed at load time. When `scene` is undefined, client implementations **MAY** delay rendering until a particular scene is requested.
 
-When `scene` is undefined, runtime is not required to render anything at load time.
-
-[NOTE]
-.Implementation Note
-====
-This allows applications to use glTF assets as libraries of individual entities such as materials or meshes.
-====
+A glTF asset that does not contain any scenes **SHOULD** be treated as a library of individual entities such as materials or meshes.
 
 The following example defines a glTF asset with a single scene, that contains a single node.
 
@@ -373,13 +541,13 @@ The following example defines a glTF asset with a single scene, that contains a 
 [[nodes-and-hierarchy]]
 === Nodes and Hierarchy
 
-The glTF asset can define *nodes*, that is, the objects comprising the scene to render.
+glTF assets **MAY** define _nodes_, that is, the objects comprising the scene to render.
 
-Nodes have an optional `name` property.
+Nodes **MAY** have transform properties, as described in the next section.
 
-Nodes also have transform properties, as described in the next section.
+Nodes are organized in a parent-child hierarchy known informally as the _node hierarchy_. A node is called a _root node_ when it doesn't have a parent.
 
-Nodes are organized in a parent-child hierarchy known informally as the *node hierarchy*. A node is called a *root node* when it doesn't have a parent.
+The node hierarchy **MUST** be a set of disjoint strict trees. That is node hierarchy **MUST NOT** contain cycles and each node **MUST** have zero or one parent node.
 
 The node hierarchy is defined using a node's `children` property, as in the following example:
 
@@ -409,28 +577,22 @@ The node hierarchy is defined using a node's `children` property, as in the foll
 
 The node named `Car` has four children. Each of those nodes could in turn have its own children, creating a hierarchy of nodes.
 
-[NOTE]
-====
-For Version 2.0 conformance, the glTF node hierarchy is not a directed acyclic graph (DAG) or *scene graph*, but a disjoint union of strict trees. That is, no node may be a direct descendant of more than one node. This restriction is meant to simplify implementation and facilitate conformance.
-====
-
 
 [[transformations]]
 === Transformations
 
-Any node can define a local space transformation either by supplying a `matrix` property, or any of `translation`, `rotation`, and `scale`  properties (also known as *TRS properties*). `translation` and `scale` are `FLOAT_VEC3` values in the local coordinate system. `rotation` is a `FLOAT_VEC4` unit quaternion value, `(x, y, z, w)`, in the local coordinate system.
+Any node **MAY** define a local space transformation either by supplying a `matrix` property, or any of `translation`, `rotation`, and `scale`  properties (also known as _TRS properties_). `translation` and `scale` are 3D vectors in the local coordinate system. `rotation` is a unit quaternion value, XYZW, in the local coordinate system, where W is the scalar.
 
-When `matrix` is defined, it must be decomposable to TRS. This implies that transformation matrices cannot skew or shear.
-
-TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation.
-
-When a node is targeted for animation (referenced by an `animation.channel.target`), only TRS properties may be present; `matrix` will not be present.
-
+When `matrix` is defined, it **MUST** be decomposable to TRS properties.
 [NOTE]
 .Implementation Note
 ====
-If the determinant of the transform is a negative value, the winding order of the mesh triangle faces should be reversed. This supports negative scales for mirroring geometry.
+Transformation matrices cannot skew or shear.
 ====
+
+When a node is targeted for animation (referenced by an `animation.channel.target`), only TRS properties **MAY** be present; `matrix` **MUST NOT** be present.
+
+To compose the local transformation matrix, TRS properties **MUST** be converted to matrices and postmultiplied in the `T * R * S` order; first the scale is applied to the vertices, then the rotation, and then the translation.
 
 [NOTE]
 .Implementation Note
@@ -511,22 +673,17 @@ The next example defines the transformation for a node with attached camera usin
 [[buffers-and-buffer-views-overview]]
 ==== Overview
 
-A *buffer* is data stored as a binary blob. The buffer can contain a combination of geometry, animation, and skins.
+A *buffer* is arbitrary data stored as a binary blob. The buffer **MAY** contain any combination of geometry, animation, skins, and images.
 
-Binary blobs allow efficient creation of GPU buffers and textures since they require no additional parsing, except perhaps decompression. An asset can have any number of buffer files for flexibility for a wide array of applications.
+Binary blobs allow efficient creation of GPU buffers and textures since they require no additional parsing, except perhaps decompression.
 
-[NOTE]
-.Implementation Note
-====
-While there's no upper limit on buffer's size, implementations should be aware that JSON parsers may support integers only up to 2^53^ when running on certain platforms. Also there's an implicit limit of 2^32^-1 bytes when a buffer is stored as <<glb-file-format-specification,GLB>> binary chunk.
-====
+glTF assets **MAY** have any number of buffer resources. Buffers are defined in the asset's `buffers` array.
 
-Buffer data is little endian.
+While there's no hard upper limit on buffer's size, glTF assets **SHOULD NOT** use buffers bigger than 2^53^ bytes because some JSON parsers may be unable to parse their `byteLength` correctly. Buffers stored as <<glb-file-format-specification,GLB>> binary chunk have an implicit limit of 2^32^-1 bytes.
 
-All buffers are stored in the asset's `buffers` array.
+All buffer data defined in this specification (i.e. geometry attributes, geometry indices, sparse accessor data, animation inputs and outputs, inverse bind matrices) **MUST** use little endian byte order.
 
-The following example defines a buffer. The `byteLength` property specifies the size of the buffer file. The `uri` property is the URI to the buffer data. Buffer data may also be stored within the glTF file as base64-encoded data and reference via data URI.
-
+The following example defines a buffer. The `byteLength` property specifies the size of the buffer file. The `uri` property is the URI to the buffer data.
 [source,json]
 ----
 {
@@ -539,17 +696,23 @@ The following example defines a buffer. The `byteLength` property specifies the 
 }
 ----
 
-A *bufferView* represents a subset of data in a buffer, defined by a byte offset into the buffer specified in the `byteOffset` property and a total byte length specified by the `byteLength` property of the buffer view.
+The byte length of the referenced resource **MUST** be greater than or equal to the `buffer.byteLength` property.
 
-When a buffer view contain vertex indices or attributes, they must be its only content, i.e., it's invalid to have more than one kind of data in the same buffer view.
+Buffer data **MAY** alternatively be embedded in the glTF file via `data:` URI with base64 encoding. When `data:` URI is used for buffer storage, its `mediatype` field **MUST** be set to `application/octet-stream` or `application/gltf-buffer`. The byte length of the base64-encoded data **MUST** be equal to the `buffer.byteLength` property.
+
+A _buffer view_ represents a contiguous segment of data in a buffer, defined by a byte offset into the buffer specified in the `byteOffset` property and a total byte length specified by the `byteLength` property of the buffer view.
+
+Buffer views used for images, vertex indices, vertex attributes, or inverse bind matrices **MUST** contain only one kind of data, i.e. the same buffer view **MUST NOT** be used both for vertex indices and vertex attributes.
+
+When a buffer view is used by vertex indices or attribute accessors it **SHOULD** specify `bufferView.target` with a value of `34963` or `34962` respectively.
 
 [NOTE]
 .Implementation Note
 ====
-This allows a runtime to upload buffer view data to the GPU without any additional processing. When `bufferView.target` is defined, runtime must use it to determine data usage, otherwise it could be inferred from mesh' accessor objects.
+This allows client implementations to early designate each buffer view to a proper processing step, e.g, buffer views with vertex indices and attributes would be copied to the appropriate GPU buffers, while buffer views with image data would be passed to format-specific image decoders.
 ====
 
-The following example defines two buffer views: the first is an ELEMENT_ARRAY_BUFFER, which holds the indices for an indexed triangle set, and the second is an ARRAY_BUFFER that holds the vertex data for the triangle set.
+The following example defines two buffer views: the first holds the indices for an indexed triangle set, and the second holds the vertex data for the triangle set.
 
 [source,json]
 ----
@@ -572,20 +735,26 @@ The following example defines two buffer views: the first is an ELEMENT_ARRAY_BU
 }
 ----
 
-When a buffer view is used for vertex attribute data, it may have a `byteStride` property. This property defines the stride in bytes between each vertex.
+When a buffer view is used for vertex attribute data, it **MAY** have a `byteStride` property. This property defines the stride in bytes between each vertex. Buffer views with other types of data **MUST NOT** not define `byteStride`.
 
-Buffers and buffer views do not contain type information. They simply define the raw data for retrieval from the file. Objects within the glTF file (meshes, skins, animations) access buffers or buffer views via *accessors*.
+Buffers and buffer views do not contain type information. They simply define the raw data for retrieval from the file. Objects within the glTF asset (meshes, skins, animations) access buffers or buffer views via *accessors*.
 
 
 [[glb-stored-buffer]]
 ==== GLB-stored Buffer
 
-glTF asset could use GLB file container to pack all resources into one file. glTF Buffer referring to GLB-stored `BIN` chunk, must have `buffer.uri` property undefined, and it must be the first element of `buffers` array; byte length of `BIN` chunk could be up to 3 bytes bigger than JSON-defined `buffer.byteLength` to satisfy GLB padding requirements. Any glTF Buffer with undefined `buffer.uri` property that is not the first element of `buffers` array does not refer to the GLB-stored BIN chunk, and the behavior of such buffers is left undefined to accommodate future extensions and specification versions.
+glTF asset **MAY** use GLB file container to pack glTF JSON and one glTF buffer into one file. Data for such buffer is provided via GLB-stored `BIN` chunk.
+
+A buffer with data provided by the GLB-stored `BIN` chunk, **MUST** be the first element of `buffers` array and it **MUST** have its `buffer.uri` property undefined.
+
+Any glTF buffer with undefined `buffer.uri` property that is not the first element of `buffers` array does not refer to the GLB-stored BIN chunk, and the behavior of such buffers is left undefined to accommodate future extensions and specification versions.
+
+Byte length of `BIN` chunk **MAY** be up to 3 bytes bigger than JSON-defined `buffer.byteLength` value to satisfy GLB padding requirements.
 
 [NOTE]
 .Implementation Note
 ====
-Not requiring strict equality of chunk's and buffer's lengths simplifies glTF to GLB conversion a bit: implementations don't need to update `buffer.byteLength` after applying GLB padding.
+Not requiring strict equality of chunk's and buffer's lengths slightly simplifies glTF to GLB conversion: `buffer.byteLength` does not need to be updated after applying GLB padding.
 ====
 
 In the following example, the first buffer objects refers to GLB-stored data, while the second points to external resource:
@@ -614,9 +783,9 @@ See <<glb-file-format-specification,GLB File Format Specification>> for details 
 [[accessors-overview]]
 ==== Overview
 
-All large data for meshes, skins, and animations is stored in buffers and retrieved via accessors.
+All binary data for meshes, skins, and animations is stored in buffers and retrieved via accessors.
 
-An *accessor* defines a method for retrieving data as typed arrays from within a `bufferView`. The accessor specifies a component type (e.g. `5126 (FLOAT)`) and a data type (e.g. `VEC3`), which when combined define the complete data type for each array element. The accessor also specifies the location and size of the data within the `bufferView` using the properties `byteOffset` and `count`. The latter specifies the number of elements within the `bufferView`, *not* the number of bytes. Elements could be, e.g., vertex indices, vertex attributes, animation keyframes, etc.
+An _accessor_ defines a method for retrieving data as typed arrays from within a `bufferView`. The accessor specifies a component type (e.g. _float_) and a data type (e.g. `VEC3` for 3D vectors), which when combined define the complete data type for each array element. The accessor also specifies the location and size of the data within the `bufferView` using the properties `byteOffset` and `count`. The latter specifies the number of elements within the `bufferView`, _not_ the number of bytes. Elements could be, e.g., vertex indices, vertex attributes, animation keyframes, etc.
 
 All accessors are stored in the asset's `accessors` array.
 
@@ -660,30 +829,25 @@ The following fragment shows two accessors, the first is a scalar accessor for r
 }
 ----
 
-
-[[floating-point-data]]
-==== Floating-Point Data
-
-Data of `5126 (FLOAT)` componentType must use IEEE-754 single precision format.
-
-Values of `NaN`, `+Infinity`, and `-Infinity` are not allowed.
-
-
-[[accessor-element-size]]
-==== Accessor Element Size
-
-The following tables can be used to compute the size of element accessible by accessor.
+[[accessor-data-types]]
+==== Accessor Data Types
 
 [options="header"]
 |====
-| `componentType`         | Size in bytes
-| `5120` (BYTE)           | 1
-| `5121`(UNSIGNED_BYTE)   | 1
-| `5122` (SHORT)          | 2
-| `5123` (UNSIGNED_SHORT) | 2
-| `5125` (UNSIGNED_INT)   | 4
-| `5126` (FLOAT)          | 4
+| `componentType` | Data Type | Signed | Bits
+| `5120` | _signed byte_ | Signed, two's complement | 8
+| `5121` | _unsigned byte_ | Unsigned | 8
+| `5122` | _signed short_ | Signed, two's complement | 16
+| `5123` | _unsigned short_ | Unsigned | 16
+| `5125` | _unsigned int_ | Unsigned | 32
+| `5126` | _float_ | Signed | 32
 |====
+
+Signed 32-bit integer components are not supported.
+
+Floating-point data **MUST** use <<ieee-754,IEEE-754>> single precision format.
+
+Values of `NaN`, `+Infinity`, and `-Infinity` **MUST NOT** be present.
 
 [options="header"]
 |====
@@ -710,28 +874,14 @@ For example:
             "bufferView": 1,
             "byteOffset": 7032,
             "componentType": 5126,
-            "count": 586,
+            "count": 585,
             "type": "VEC3"
         }
     ]
 }
 ----
 
-In this accessor, the `componentType` is `5126` (FLOAT), so each component is four bytes.  The `type` is `"VEC3"`, so there are three components.  The size of each element is 12 bytes (`4 * 3`).
-
-
-[[accessors-bounds]]
-==== Accessors Bounds
-
-`accessor.min` and `accessor.max` properties are arrays that contain per-component minimum and maximum values, respectively. Exporters and loaders must treat these values as having the same data type as accessor's `componentType`, i.e., use integers (JSON number without fractional part) for integer types and use floating-point decimals for `5126` (FLOAT).
-
-[NOTE]
-.Implementation Note
-====
-JavaScript client implementations should convert JSON-parsed floating-point doubles to single precision, when `componentType` is `5126` (FLOAT). This could be done with `Math.fround` function.
-====
-
-While these properties are not required for all accessor usages, there are cases when minimum and maximum must be defined. Refer to other sections of this specification for details.
+In this accessor, the `componentType` is `5126` (_float_), so each component is four bytes.  The `type` is `"VEC3"`, so there are three components.  The size of each element is 12 bytes (`4 * 3`). Thus the accessor takes 7020 bytes (`[7032 ... 14051]` inclusive range of the buffer view).
 
 
 [[sparse-accessors]]
@@ -740,12 +890,15 @@ While these properties are not required for all accessor usages, there are cases
 Sparse encoding of arrays is often more memory-efficient than dense encoding when describing incremental changes with respect to a reference array.
 This is often the case when encoding morph targets (it is, in general, more efficient to describe a few displaced vertices in a morph target than transmitting all morph target vertices).
 
-glTF 2.0 extends the accessor structure to enable efficient transfer of sparse arrays.
-Similarly to a standard accessor, a sparse accessor initializes an array of typed elements from data stored in a `bufferView` . On top of that, a sparse accessor includes a `sparse` dictionary describing the elements that deviate from their initialization value. The `sparse` dictionary contains the following mandatory properties:
+Similarly to a standard accessor, a sparse accessor initializes an array of typed elements from data stored in a `bufferView`. When `accessor.bufferView` is undefined, the sparse accessor is initialized as an array of zeros of size `(size of the accessor element) * (accessor.count)` bytes.
+
+On top of that, a sparse accessor includes a `sparse` JSON object describing the elements that deviate from their initialization values. The `sparse` object contains the following **REQUIRED** properties:
 
 - `count`: number of displaced elements.
-- `indices`: strictly increasing array of integers of size `count` and specific `componentType` that stores the indices of those elements that deviate from the initialization value.
-- `values`: array of displaced elements corresponding to the indices in the `indices` array.
+
+- `indices`: object describing the location and the component type of indices of deviating values. The indices **MUST** form a strictly increasing sequence.
+
+- `values`: object describing the location of displaced elements corresponding to the indices referred from the `indices`.
 
 The following fragment shows an example of `sparse` accessor with 10 elements deviating from the initialization array.
 
@@ -776,24 +929,28 @@ The following fragment shows an example of `sparse` accessor with 10 elements de
 }
 ----
 
-A sparse accessor differs from a regular one in that `bufferView` property isn't required. When it's omitted, the sparse accessor is initialized as an array of zeros of size `(size of the accessor element) * (accessor.count)` bytes.
-A sparse accessor `min` and `max` properties correspond, respectively, to the minimum and maximum component values once the sparse substitution is applied.
-
-When neither `sparse` nor `bufferView` is defined, `min` and `max` properties could have any values. This is intended for use cases when binary data is supplied by external means (e.g., via extensions).
-
 
 [[data-alignment]]
 ==== Data Alignment
 
-The offset of an `accessor` into a `bufferView` (i.e., `accessor.byteOffset`) and the offset of an `accessor` into a `buffer` (i.e., `accessor.byteOffset + bufferView.byteOffset`) must be a multiple of the size of the accessor's component type.
+The offset of an `accessor` into a `bufferView` (i.e., `accessor.byteOffset`) and the offset of an `accessor` into a `buffer` (i.e., `accessor.byteOffset + bufferView.byteOffset`) **MUST** be a multiple of the size of the accessor's component type.
 
-When `byteStride` of referenced `bufferView` is not defined, it means that accessor elements are tightly packed, i.e., effective stride equals the size of the element. When `byteStride` is defined, it must be a multiple of the size of the accessor's component type. `byteStride` must be defined, when two or more accessors use the same `bufferView`.
+When `byteStride` of the referenced `bufferView` is not defined, it means that accessor elements are tightly packed, i.e., effective stride equals the size of the element. When `byteStride` is defined, it **MUST** be a multiple of the size of the accessor's component type.
 
-Each `accessor` must fit its `bufferView`, i.e., `accessor.byteOffset + STRIDE * (accessor.count - 1) + SIZE_OF_ELEMENT` must be less than or equal to `bufferView.length`.
+When two or more vertex attribute accessors use the same `bufferView`, its `byteStride` **MUST** be defined.
 
-For performance and compatibility reasons, each element of a vertex attribute must be aligned to 4-byte boundaries inside `bufferView` (i.e., `accessor.byteOffset` and `bufferView.byteStride` must be multiples of 4).
+Each accessor **MUST** fit its `bufferView`, i.e.,
 
-Accessors of matrix type have data stored in column-major order; start of each column must be aligned to 4-byte boundaries. To achieve this, three `type`/`componentType` combinations require special layout:
+[source]
+----
+accessor.byteOffset + EFFECTIVE_BYTE_STRIDE * (accessor.count - 1) + SIZE_OF_COMPONENT * NUMBER_OF_COMPONENTS
+----
+
+**MUST** be less than or equal to `bufferView.length`.
+
+For performance and compatibility reasons, each element of a vertex attribute **MUST** be aligned to 4-byte boundaries inside a `bufferView` (i.e., `accessor.byteOffset` and `bufferView.byteStride` **MUST** be multiples of 4).
+
+Accessors of matrix type have data stored in column-major order; start of each column **MUST** be aligned to 4-byte boundaries. To achieve this, three `type`/`componentType` combinations require special layout:
 
 *MAT2, 1-byte components*
 
@@ -819,12 +976,12 @@ Accessors of matrix type have data stored in column-major order; start of each c
 |m00|m00|m10|m10|m20|m20|---|---|m01|m01|m11|m11|m21|m21|---|---|m02|m02|m12|m12|m22|m22|---|---|
 ----
 
-Alignment requirements apply only to start of each column, so trailing bytes could be omitted if there's no further data.
+Alignment requirements apply only to start of each column, so trailing bytes **MAY** be omitted if there's no further data.
 
 [NOTE]
 .Implementation Note
 ====
-For JavaScript, this allows a runtime to efficiently create a single ArrayBuffer from a glTF `buffer` or an ArrayBuffer per `bufferView`, and then use an `accessor` to turn a typed array view (e.g., `Float32Array`) into an ArrayBuffer without copying it because the byte offset of the typed array view is a multiple of the size of the type (e.g., `4` for `Float32Array`).
+Alignment requirements allow client implementations to more efficiently process binary buffers because creating aligned data views usually does not require extra copying.
 ====
 
 Consider the following example:
@@ -836,8 +993,7 @@ Consider the following example:
         {
             "buffer": 0,
             "byteLength": 17136,
-            "byteOffset": 620,
-            "target": 34963
+            "byteOffset": 620
         }
     ],
     "accessors": [
@@ -845,31 +1001,52 @@ Consider the following example:
             "bufferView": 0,
             "byteOffset": 4608,
             "componentType": 5123,
-            "count": 5232,
+            "count": 42,
             "type": "VEC2"
         }
     ]
 }
 ----
 
-Accessing binary data defined by example above could be done like this:
+In this example, the accessor describes tightly-packed two-component unsigned short values.
 
-[source,js]
+The corresponding segment of the underlying buffer would start from byte 5228
+[source]
 ----
-const accessorTypeToNumComponentsMap = {
-                'SCALAR': 1,
-                'VEC2': 2,
-                'VEC3': 3,
-                'VEC4': 4,
-                'MAT2': 4,
-                'MAT3': 9,
-                'MAT4': 16
-};
-var typedView = new Uint16Array(buffer, accessor.byteOffset + accessor.bufferView.byteOffset, accessor.count * accessorTypeToNumComponentsMap[accessor.type]);
+start = accessor.byteOffset + accessor.bufferView.byteOffset
 ----
 
-The size of the accessor component type is two bytes (the `componentType` is unsigned short). The accessor's `byteOffset` is also divisible by two. Likewise, the accessor's offset into buffer `0` is `5228 ` (`620 + 4608`), which is divisible by two.
+and continue until byte 5396 exclusive
+[source]
+----
+end = 2 * 2 * accessor.count + start
+----
 
+The unsigned short view for the resulting buffer range could be created without copying: 84 scalar values starting from byte offset 5228.
+
+When accessor values are not tightly-packed (i.e. `bufferView.byteStride` is greater than element's byte length), iteration over the created data view would need to take interleaved values into account (e.g. skip them).
+
+
+[[accessors-bounds]]
+==== Accessors Bounds
+
+`accessor.min` and `accessor.max` properties are arrays that contain per-component minimum and maximum values, respectively. The length of these arrays **MUST** be equal to the number of accessor's components.
+
+Values stored in glTF JSON **MUST** match actual minimum and maximum binary values stored in buffers. The `accessor.normalized` flag has no effect on these properties.
+
+A sparse accessor `min` and `max` properties correspond, respectively, to the minimum and maximum component values once the sparse substitution is applied.
+
+When neither `sparse` nor `bufferView` is defined, `min` and `max` properties **MAY** have any values. This is intended for use cases when binary data is supplied by external means (e.g., via extensions).
+
+For floating-point components, JSON-stored minimum and maximum values represent single precision floats and **SHOULD** be rounded to single precision before usage to avoid any potential boundary mismatches.
+
+[NOTE]
+.ECMAScript Implementation Note
+====
+`Math.fround` function could be used to achieve that.
+====
+
+Animation input and vertex position attribute accessors **MUST** have `accessor.min` and `accessor.max` defined. For all other accessors, these properties are optional.
 
 
 [[geometry]]
@@ -878,7 +1055,7 @@ The size of the accessor component type is two bytes (the `componentType` is uns
 [[geometry-overview]]
 === Overview
 
-Any node can contain one mesh, defined in its `mesh` property. Mesh can be skinned using a information provided in referenced `skin` object. Mesh can have morph targets.
+Any node **MAY** contain one mesh, defined in its `mesh` property. Mesh **MAY** be skinned using an information provided in a referenced `skin` object. Mesh **MAY** have morph targets.
 
 
 [[meshes]]
@@ -887,17 +1064,17 @@ Any node can contain one mesh, defined in its `mesh` property. Mesh can be skinn
 [[meshes-overview]]
 ==== Overview
 
-In glTF, meshes are defined as arrays of *primitives*. Primitives correspond to the data required for GPU draw calls. Primitives specify one or more `attributes`, corresponding to the vertex attributes used in the draw calls. Indexed primitives also define an `indices` property. Attributes and indices are defined as references to accessors containing corresponding data. Each primitive also specifies a material and a primitive type that corresponds to the GPU primitive type (e.g., triangle set).
+Meshes are defined as arrays of _primitives_. Primitives correspond to the data required for GPU draw calls. Primitives specify one or more `attributes`, corresponding to the vertex attributes used in the draw calls. Indexed primitives also define an `indices` property. Attributes and indices are defined as references to accessors containing corresponding data. Each primitive **MAY** also specify a `material` and a `mode` that corresponds to the GPU topology type (e.g., triangle set).
 
 [NOTE]
 .Implementation Note
 ====
-Splitting one mesh into *primitives* could be useful to limit number of indices per draw call.
+Splitting one mesh into several *primitives* could be useful to limit number of indices per draw call or to assign different materials to different parts of the mesh.
 ====
 
-If `material` is not specified, then a <<default-material,default material>> is used.
+If `material` is undefined, then a <<default-material,default material>> **MUST** be used.
 
-The following example defines a mesh containing one triangle set primitive:
+The following example defines a mesh containing one indexed triangle set primitive:
 
 [source,json]
 ----
@@ -924,77 +1101,106 @@ The following example defines a mesh containing one triangle set primitive:
 
 Each attribute is defined as a property of the `attributes` object. The name of the property corresponds to an enumerated value identifying the vertex attribute, such as `POSITION`. The value of the property is the index of an accessor that contains the data.
 
-Valid attribute semantic property names include `POSITION`, `NORMAL`, `TANGENT`, `TEXCOORD_0`, `TEXCOORD_1`, `COLOR_0`, `JOINTS_0`, and `WEIGHTS_0`.  Application-specific semantics must start with an underscore, e.g., `_TEMPERATURE`.
+Valid attribute semantic property names include `POSITION`, `NORMAL`, `TANGENT`, `TEXCOORD_0`, `TEXCOORD_1`, `COLOR_0`, `JOINTS_0`, and `WEIGHTS_0`.
+
+Application-specific attribute semantics **MUST** start with an underscore, e.g., `_TEMPERATURE`. Application-specific attribute semantics **MUST NOT** use _unsigned int__ component type.
 
 Valid accessor type and component type for each attribute semantic property are defined below.
 
 [options="header",cols="15%,20%,35%,30%"]
 |====
 | Name        | Accessor Type(s)| Component Type(s)| Description
-| `POSITION`  | `"VEC3"`        | `5126` (FLOAT)                     | XYZ vertex positions
-| `NORMAL`    | `"VEC3"`        | `5126` (FLOAT)                     | Normalized XYZ vertex normals
-| `TANGENT`   | `"VEC4"`        | `5126` (FLOAT)                     | XYZW vertex tangents where the *w* component is a sign value (-1 or +1) indicating handedness of the tangent basis
-| `TEXCOORD_0`| `"VEC2"`        | `5126` (FLOAT) +
-                                  `5121` (UNSIGNED_BYTE) normalized +
-                                  `5123` (UNSIGNED_SHORT) normalized | UV texture coordinates for the first set
-| `TEXCOORD_1`| `"VEC2"`        | `5126` (FLOAT) +
-                                  `5121` (UNSIGNED_BYTE) normalized +
-                                  `5123` (UNSIGNED_SHORT) normalized | UV texture coordinates for the second set
+| `POSITION`  | `"VEC3"`        | _float_                     | XYZ vertex positions
+| `NORMAL`    | `"VEC3"`        | _float_                     | Normalized XYZ vertex normals
+| `TANGENT`   | `"VEC4"`        | _float_                     | XYZW vertex tangents where the W component is a sign value (-1 or +1) indicating handedness of the tangent basis
+| `TEXCOORD_0`| `"VEC2"`        | _float_ +
+                                  _unsigned byte_ normalized +
+                                  _unsigned short_ normalized | UV texture coordinates for the first set
+| `TEXCOORD_1`| `"VEC2"`        | _float_ +
+                                  _unsigned byte_ normalized +
+                                  _unsigned short_ normalized | UV texture coordinates for the second set
 | `COLOR_0`   | `"VEC3"` +
-                `"VEC4"`        | `5126` (FLOAT) +
-                                  `5121` (UNSIGNED_BYTE) normalized +
-                                  `5123` (UNSIGNED_SHORT) normalized | RGB or RGBA vertex color
-| `JOINTS_0`  | `"VEC4"`        | `5121` (UNSIGNED_BYTE)
-                                  `5123` (UNSIGNED_SHORT)            | See <<skinned-mesh-attributes,Skinned Mesh Attributes>>
-| `WEIGHTS_0` | `"VEC4"`        | `5126` (FLOAT) +
-                                  `5121` (UNSIGNED_BYTE) normalized +
-                                  `5123` (UNSIGNED_SHORT) normalized | See <<skinned-mesh-attributes,Skinned Mesh Attributes>>
+                `"VEC4"`        | _float_ +
+                                  _unsigned byte_ normalized +
+                                  _unsigned short_ normalized | RGB or RGBA vertex color linear multiplier
+| `JOINTS_0`  | `"VEC4"`        | _unsigned byte_
+                                  _unsigned short_            | See <<skinned-mesh-attributes,Skinned Mesh Attributes>>
+| `WEIGHTS_0` | `"VEC4"`        | _float_) +
+                                  _unsigned byte_ normalized +
+                                  _unsigned short_ normalized | See <<skinned-mesh-attributes,Skinned Mesh Attributes>>
 |====
 
-`POSITION` accessor *must* have `min` and `max` properties defined.
+`POSITION` accessor **MUST** have its `min` and `max` properties defined.
 
-`TEXCOORD`, `COLOR`, `JOINTS`, and `WEIGHTS` attribute semantic property names must be of the form `[semantic]_[set_index]`, e.g., `TEXCOORD_0`, `TEXCOORD_1`, `COLOR_0`. Client implementations must support at least two UV texture coordinate sets, one vertex color, and one joints/weights set. Extensions can add additional property names, accessor types, and/or accessor component types.
+`TEXCOORD`, `COLOR`, `JOINTS`, and `WEIGHTS` attribute semantic property names **MUST** be of the form `[semantic]_[set_index]`, e.g., `TEXCOORD_0`, `TEXCOORD_1`, `COLOR_0`. All indices for indexed attribute semantics **MUST** start with 0 and be continuous positive integers: `TEXCOORD_0`, `TEXCOORD_1`, etc. Indices **MUST NOT** use leading zeroes to pad the number of digits (e.g. `TEXCOORD_01`).
 
-All indices for indexed attribute semantics must start with 0 and be continuous positive integers: `TEXCOORD_0`, `TEXCOORD_1`, etc. Indices must not use leading zeroes to pad the number of digits, and clients are not required to support more indexed semantics than described above.
+Client implementations **SHOULD** support at least two UV texture coordinate sets, one vertex color, and one joints/weights set.
 
-All attribute accessors for a given primitive must have the same `count`. When `indices` property is not defined, it indicates the number of vertices to render; when `indices` property is defined, it indicates the upper (exclusive) bound on the index values in the `indices` accessor.
+All attribute accessors for a given primitive **MUST** have the same `count`. When `indices` property is not defined, accessors' `count` indicates the number of vertices to render; when `indices` property is defined, it indicates the upper (exclusive) bound on the index values in the `indices` accessor.
 
-[NOTE]
-.Implementation Note
-====
-Each primitive corresponds to one WebGL draw call (engines are, of course, free to batch draw calls). When a primitive's `indices` property is defined, it references the accessor to use for index data, and GL's `drawElements` function should be used. When the `indices` property is not defined, GL's `drawArrays` function should be used with a count equal to the count property of any of the accessors referenced by the `attributes` property (they are all equal for a given primitive).
-====
+`indices` accessor **MUST NOT** contain the maximum possible value for the component type used (i.e. 255 for unsigned bytes, 65535 for unsigned shorts, 4294967295 for unsigned ints).
 
-[NOTE]
-.Implementation Note
-====
-When positions are not specified, client implementations should skip primitive's rendering unless its positions are provided by other means (e.g., by extension). This applies to both indexed and non-indexed geometry.
-====
+When `indices` property is not defined, the number of vertex indices to render is defined by `count` of attribute accessors (with the implied values from range `[0..count)`); when `indices` property is defined, the number of vertex indices to render is defined by `count` of accessor referred to by `indices`. In either case, the number of vertex indices **MUST** be valid for the topology type used:
 
-[NOTE]
-.Implementation Note
-====
-When normals are not specified, client implementations should calculate flat normals.
-====
+* For _points_, it **MUST** be non-zero.
+* For _line loops_ and _line strips_, it **MUST** be 2 or greater.
+* For _triangle strips_ and _triangle fans_, it **MUST** be 3 or greater.
+* For _lines_, it **MUST** be divisible by 2 and non-zero.
+* For _triangles_, it **MUST** be divisible by 3 and non-zero
 
-[NOTE]
-.Implementation Note
-====
-When tangents are not specified, client implementations should calculate tangents using default MikkTSpace algorithms.  For best results, the mesh triangles should also be processed using default MikkTSpace algorithms.
-====
+The topology types are defined as follows.
 
-[NOTE]
-.Implementation Note
-====
-Vertices of the same triangle should have the same `tangent.w` value. When vertices of the same triangle have different `tangent.w` values, tangent space is considered undefined.
-====
+* **Points**
++
+Each vertex defines a single point primitive, according to the equation:
 
-[NOTE]
-.Implementation Note
-====
-When normals and tangents are specified, client implementations should compute the bitangent by taking the cross product of the normal and tangent xyz vectors and multiplying against the w component of the tangent: `bitangent = cross(normal, tangent.xyz) * tangent.w`
-====
+  {empty}:: [eq]#p~i~ = {v~i~}#
 
+* **Line Strips**
++
+One line primitive is defined by each vertex and the following vertex, according to the equation:
+
+  {empty}:: [eq]#p~i~ = {v~i~, v~i+1~}#
+
+* **Line Loops**
++
+Loops are the same as line strips except that a final segment is added from the final specified vertex to the first vertex.
+
+* **Lines**
++
+Each consecutive pair of vertices defines a single line primitive, according to the equation:
+
+  {empty}:: [eq]#p~i~ = {v~2i~, v~2i+1~}#
+
+* **Triangles**
++
+Each consecutive set of three vertices defines a single triangle primitive, according to the equation:
+
+  {empty}:: [eq]#p~i~ = {v~3i~, v~3i+1~, v~3i+2~}#
+
+* **Triangle Strips**
++
+One triangle primitive is defined by each vertex and the two vertices that follow it, according to the equation:
+
+  {empty}:: [eq]#p~i~ = {v~i~, v~i+(1+i%2)~, v~i+(2-i%2)~}#
+
+* **Triangle Fans**
++
+Triangle primitives are defined around a shared common vertex, according to the equation:
+
+  {empty}:: [eq]#p~i~ = {v~i+1~, v~i+2~, v~0~}#
+
+When positions are not specified, client implementations **SHOULD** skip primitive's rendering unless its positions are provided by other means (e.g., by an extension). This applies to both indexed and non-indexed geometry.
+
+When tangents are not specified, client implementations **SHOULD** calculate tangents using default <<mikktspace,MikkTSpace>> algorithms.
+
+When normals are not specified, client implementations **SHOULD** assume flat normals and the provided tangents (if present) **SHOULD** be ignored.
+
+Vertices of the same triangle **SHOULD** have the same `tangent.w` value. When vertices of the same triangle have different `tangent.w` values, its tangent space is considered undefined.
+
+The bitangent vectors **MUST** be computed by taking the cross product of the normal and tangent XYZ vectors and multiplying it against the W component of the tangent: `bitangent = cross(normal.xyz, tangent.xyz) * tangent.w`
+
+Extensions **MAY** add additional property names, accessor types and/or component types.
 
 [[morph-targets]]
 ==== Morph Targets
@@ -1013,23 +1219,27 @@ primitives[i].attributes.POSITION +
   weights[2] * primitives[i].targets[2].POSITION + ...
 ----
 
-Morph Targets are implemented via the `targets` property defined in the Mesh `primitives`. Each target in the `targets` array is a dictionary mapping a primitive attribute to an accessor containing Morph Target displacement data. Currently only three attributes -- `POSITION`, `NORMAL`, and `TANGENT` -- are commonly supported. If morph targets contain application-specific semantics, their names must be prefixed with an underscore (e.g. `_TEMPERATURE`) like the associated attribute semantic. All primitives are required to list the same number of `targets` in the same order.
+Morph Targets are specified via the `targets` property defined in the Mesh `primitives`. Each target in the `targets` array is a dictionary mapping a primitive attribute to an accessor containing Morph Target displacement data.
 
-Valid accessor type and component type for each attribute semantic property are defined below. Note that the *w* component for handedness is omitted when targeting `TANGENT` data since handedness cannot be displaced.
+Client implementations **SHOULD** support at least three attributes -- `POSITION`, `NORMAL`, and `TANGENT` -- for morphing. If morph targets contain application-specific semantics, their names **MUST** be prefixed with an underscore (e.g. `_TEMPERATURE`) like the associated attribute semantic.
+
+All primitives **MUST** have the same number of morph targets in the same order.
+
+Accessor type and component type for each morphed attribute semantic property **MUST** follow the table below. Note that the W component for handedness is omitted when targeting `TANGENT` data since handedness cannot be displaced.
 
 [options="header"]
 |====
-| Name       | Accessor Type(s) | Component Type(s) | Description
-| `POSITION` | `"VEC3"`         | `5126` (FLOAT)    | XYZ vertex position displacements
-| `NORMAL`   | `"VEC3"`         | `5126` (FLOAT)    | XYZ vertex normal displacements
-| `TANGENT`  | `"VEC3"`         | `5126` (FLOAT)    | XYZ vertex tangent displacements
+| Name       | Accessor Type | Component Type | Description
+| `POSITION` | `"VEC3"`      | _float_        | XYZ vertex position displacements
+| `NORMAL`   | `"VEC3"`      | _float_        | XYZ vertex normal displacements
+| `TANGENT`  | `"VEC3"`      | _float_        | XYZ vertex tangent displacements
 |====
 
-`POSITION` accessor *must* have `min` and `max` properties defined.
+`POSITION` accessor **MUST** have `min` and `max` properties defined.
 
-All Morph Target's accessors *must* have the same `count` as the accessors of the original primitive.
+All Morph Target's accessors **MUST** have the same `count` as the accessors of the original primitive.
 
-A Morph Target may also define an optional `mesh.weights` property that stores the default targets weights. In the absence of a `node.weights` property, the primitives attributes are resolved using these weights. When this property is missing, the default targets weights are assumed to be zero.
+A mesh with Morph Targets **MAY** also define an optional `mesh.weights` property that stores the default targets weights. In the absence of a `node.weights` property, the primitives attributes are resolved using these weights. When this property is missing, the default targets weights are zeros.
 
 The following example extends the Mesh defined in the previous example to a morphable one by adding two Morph Targets:
 
@@ -1064,13 +1274,9 @@ The following example extends the Mesh defined in the previous example to a morp
 }
 ----
 
-After applying morph targets to vertex positions and normals, tangent space may need to be recalculated. See <<appendix-a-tangent-space-recalculation,Appendix A>> for details.
+The number of morph targets is not limited. Client implementations **SHOULD** support at least eight morphed attributes. This means that they **SHOULD** support at least eight morph targets that contain a `POSITION` attribute, or four morph targets that contain a `POSITION` and a `NORMAL` attribute, or two morph targets that contain `POSITION`, `NORMAL` and `TANGENT` attributes.
 
-[NOTE]
-.Implementation Note
-====
-The number of morph targets is not limited in glTF. A conformant client implementation must support at least eight morphed attributes. This means that it has to support at least eight morph targets that contain a `POSITION` attribute, or four morph targets that contain a `POSITION` and a `NORMAL` attribute, or two morph targets that contain `POSITION`, `NORMAL` and `TANGENT` attributes. For assets that contain a higher number of morphed attributes, renderers may choose to either fully support them (for example, by performing the morph computations in software), or to only use the eight attributes of the morph targets with the highest weights.
-====
+For assets that contain a higher number of morphed attributes, client implementations **MAY** choose to only use the eight attributes of the morph targets with the highest weights.
 
 
 [NOTE]
@@ -1080,26 +1286,33 @@ A significant number of authoring and client implementations associate names wit
 ====
 
 
-
 [[skins]]
 === Skins
 
 [[skins-overview]]
 ==== Overview
 
-All skins are stored in the `skins` array of the asset. Each skin is defined by the `inverseBindMatrices` property (which points to an accessor with IBM data), used to bring coordinates being skinned into the same space as each joint; and a `joints` array property that lists the nodes indices used as joints to animate the skin. The order of joints is defined in the `skin.joints` array and it must match the order of `inverseBindMatrices` data. The `skeleton` property (if present) points to the node that is the common root of a joints hierarchy or to a direct or indirect parent node of the common root.
+Skins are stored in the `skins` array of the asset. Each skin is defined by an **OPTIONAL** `inverseBindMatrices` property (which points to an accessor with inverse bind matrices data), used to bring coordinates being skinned into the same space as each joint; and a **REQUIRED** `joints` array property that lists the node indices used as joints to animate the skin.
+
+The order of joints is defined in the `skin.joints` array and it **MUST** match the order of `inverseBindMatrices` accessor elements (when the latter is present). The `skeleton` property (if present) points to the node that is the common root of a joints hierarchy or to a direct or indirect parent node of the common root.
 
 [NOTE]
 .Implementation Note
 ====
-The matrix defining how to pose the skin's geometry for use with the joints ("Bind Shape Matrix") should be premultiplied to mesh data or to Inverse Bind Matrices.
+Although the `skeleton` property is not needed for computing skinning transforms, it may be used to provide a specific "pivot point" for the skinned geometry.
 ====
+
+An accessor referenced by `inverseBindMatrices` **MUST** have floating-point components of `"MAT4"` type. The number of elements of the accessor referenced by `inverseBindMatrices` **MUST** greater than or equal to the number of `joints` elements.
 
 [NOTE]
 .Implementation Note
 ====
-Client implementations should apply only the transform of the skeleton root node to the skinned mesh while ignoring the transform of the skinned mesh node. In the example below, the translation of `node_0` and the scale of `node_1` are applied while the translation of `node_3` and rotation of `node_4` are ignored.
+The matrix defining how to pose the skin's geometry for use with the joints (also known as "Bind Shape Matrix") should be premultiplied to mesh data or to Inverse Bind Matrices.
 ====
+
+Only the transform of the skeleton root node is applied to the skinned mesh while the transform of the skinned mesh node **MUST** be ignored.
+
+In the example below, the translation of `node_0` and the scale of `node_1` are applied while the translation of `node_3` and rotation of `node_4` are ignored.
 
 [source,json]
 ----
@@ -1144,7 +1357,7 @@ Client implementations should apply only the transform of the skeleton root node
 [[skinned-mesh-attributes]]
 ==== Skinned Mesh Attributes
 
-The mesh for a skin is defined with vertex attributes that are used in skinning calculations in the vertex shader. The `JOINTS_0` attribute data contains the indices of the joints from corresponding `joints` array that should affect the vertex. The `WEIGHTS_0` attribute data defines the weights indicating how strongly the joint should influence the vertex. The following mesh skin defines `JOINTS_0` and `WEIGHTS_0` vertex attributes for a triangle mesh primitive:
+The mesh for a skin is defined with vertex attributes that are used in skinning calculations in the vertex shader. The `JOINTS_0` attribute data contains the indices of the joints from the corresponding `skin.joints` array that affect the vertex. The `WEIGHTS_0` attribute data defines the weights indicating how strongly the joint influences the vertex. The following mesh skin defines `JOINTS_0` and `WEIGHTS_0` vertex attributes for a triangle mesh primitive:
 
 [source,json]
 ----
@@ -1171,14 +1384,18 @@ The mesh for a skin is defined with vertex attributes that are used in skinning 
 }
 ----
 
-The number of joints that influence one vertex is limited to 4 per set, so referenced accessors must have `VEC4` type and following component types:
+The number of joints that influence one vertex is limited to 4 per set, so referenced accessors **MUST** have `VEC4` type and following component types:
 
-* *`JOINTS_0`*: `UNSIGNED_BYTE` or `UNSIGNED_SHORT`
-* *`WEIGHTS_0`*: `FLOAT`, or normalized `UNSIGNED_BYTE`, or normalized `UNSIGNED_SHORT`
+* *`JOINTS_0`*: _unsigned byte_ or _unsigned short_
+* *`WEIGHTS_0`*: _float_, or _normalized unsigned byte_, or _normalized unsigned short_`
 
-The joint weights for each vertex must be non-negative. No joint may have more than one non-zero weight for a given vertex.
+The joint weights for each vertex **MUST** be non-negative.
 
-When the weights are stored using `FLOAT` component type, glTF exporters should produce weights with linear sum as close as reasonably possible to `1.0` for a given vertex. When the weights are stored using `UNSIGNED_BYTE` or `UNSIGNED_SHORT` component types, their linear sum before normalization must be `255` or `65535` respectively. Without these requirements, vertices would be deformed significantly because the weight error would get multiplied by the joint position. For example, an error of `1/255` in the weight sum would result in an unacceptably large difference in the joint position.
+Joints **MUST NOT** contain more than one non-zero weight for a given vertex.
+
+When the weights are stored using _float_ component type, their linear sum **SHOULD** be as close as reasonably possible to `1.0` for a given vertex.
+
+When the weights are stored using _normalized unsigned byte_, or _normalized unsigned short_` component types, their linear sum before normalization **MUST** be `255` or `65535` respectively. Without these requirements, vertices would be deformed significantly because the weight error would get multiplied by the joint position. For example, an error of `1/255` in the weight sum would result in an unacceptably large difference in the joint position.
 
 [NOTE]
 .Implementation Note
@@ -1189,32 +1406,32 @@ The threshold in the official validation tool is set to `2e-7` times the number 
 [NOTE]
 .Implementation Note
 ====
-Since the allowed threshold is much lower than minimum possible step for quantized component types, exporters should just renormalize weight sum after quantization.
+Since the allowed threshold is much lower than minimum possible step for quantized component types, weight sum should be renormalized after quantization.
 ====
 
-In the event that of any of the vertices are influenced by more than four joints, the additional joint and weight information will be found in subsequent sets. For example `JOINTS_1` and `WEIGHTS_1` if present will reference the accessor for up to 4 additional joints that influence the vertices. Note that client implementations are only required to support a single set of up to four weights and joints, however not supporting all weight and joint sets present in the file may have an impact on the model's animation.
+When any of the vertices are influenced by more than four joints, the additional joint and weight information are stored in subsequent sets. For example `JOINTS_1` and `WEIGHTS_1` if present will reference the accessor for up to 4 additional joints that influence the vertices. Client implementations **MAY** support only a single set of up to four weights and joints, however not supporting all weight and joint sets present in the file may have an impact on the asset's animation.
 
-All joint values must be within the range of joints in the skin. Unused joint values (i.e. joints with a weight of zero) should be set to zero.
+All joint values **MUST** be within the range of joints in the skin. Unused joint values (i.e. joints with a weight of zero) **SHOULD** be set to zero.
 
 
 [[joint-hierarchy]]
 ==== Joint Hierarchy
 
-The joint hierarchy used for controlling skinned mesh pose is simply the glTF node hierarchy, with each node designated as a joint. Each skin's joints must have a common root, which may or may not be a joint node itself. When a skin is referenced by a node within a scene, the common root must belong to the same scene.
+The joint hierarchy used for controlling skinned mesh pose is simply the node hierarchy, with each node designated as a joint. Each skin's joints **MUST** have a common root, which may or may not be a joint node itself. When a skin is referenced by a node within a scene, the common root **MUST** belong to the same scene.
 
+[NOTE]
+.Implementation Note
+====
 For more details of vertex skinning implementation, refer to https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/figures/gltfOverview-2.0.0b.png[glTF Overview].
-
-[NOTE]
-.Implementation Note
-====
-A node definition does not specify whether the node should be treated as a joint. Client implementations may wish to traverse the `skins` array first, marking each joint node.
 ====
 
 [NOTE]
 .Implementation Note
 ====
-A joint may have regular nodes attached to it, even a complete node sub graph with meshes. It's often used to have an entire geometry attached to a joint without having it being skinned by the joint. (ie. a sword attached to a hand joint). Note that the node transform is the local transform of the node relative to the joint, like any other node in the glTF node hierarchy as described in the <<transformations,Transformation>> section.
+A node definition does not specify whether the node is a joint. Client implementations may need to traverse the `skins` array first, marking each joint node.
 ====
+
+A joint **MAY** have regular nodes attached to it, even a complete node sub graph with meshes. It's often used to have an entire geometry attached to a joint without having it being skinned by the joint. (i.e. a sword attached to a hand joint). Note that the node transform is the local transform of the node relative to the joint, like any other node in the glTF node hierarchy as described in the <<transformations,Transformation>> section.
 
 
 [[instantiation]]
@@ -1242,12 +1459,17 @@ A mesh is instantiated by `node.mesh` property. The same mesh could be used by m
 
 ----
 
-A Morph Target is instanced within a node using:
+When a mesh primitive uses any triangle-based topology (i.e. _triangles_, _triangle strip_, or _triangle fan_), the determinant of the node's global transform defines the winding order of that primitive. If the determinant is a positive value, the winding order triangle faces is counter-clockwise; in the opposite case, the winding order is clockwise.
 
-- The Morph Target referenced in the `mesh` property.
-- The Morph Target `weights` overriding the `weights` of the Morph Target referenced in the `mesh` property.
+[NOTE]
+.Implementation Note
+====
+Switching the winding order to clockwise enables mirroring geometry via negative scale transformations.
+====
 
-The example below instatiates a Morph Target with non-default weights.
+When an instantiated mesh has morph targets, it **MUST** use morph weights specified with the `node.weights` property. When the latter is undefined, `mesh.weights` property **MUST** used instead. When both of these fields are undefined, the mesh is instantiated in a non-morphed state (i.e. with all morph weights set to zeros).
+
+The example below instantiates a Morph Target with non-default weights.
 
 [source,json]
 ----
@@ -1312,13 +1534,13 @@ A skin is instanced within a node using a combination of the node's `mesh` and `
 [[texture-data-overview]]
 === Overview
 
-glTF separates texture access into three distinct types of objects: Textures, Images, and Samplers.
+glTF 2.0 separates texture access into three distinct types of objects: Textures, Images, and Samplers.
 
 
 [[textures]]
 === Textures
 
-All textures are stored in the asset's `textures` array. A texture is defined by an image resource, denoted by the `source` property and a sampler index (`sampler`).
+Textures are stored in the asset's `textures` array. A texture is defined by an image index, denoted by the `source` property and a sampler index (`sampler`). glTF 2.0 supports only static 2D textures.
 
 [source,json]
 ----
@@ -1332,11 +1554,15 @@ All textures are stored in the asset's `textures` array. A texture is defined by
 }
 ----
 
+When `texture.source` is undefined, the image **SHOULD** be provided by an extension or application-specific means, otherwise the texture object is undefined.
+
 [NOTE]
 .Implementation Note
 ====
-glTF 2.0 supports only 2D textures.
+Client implementations may render such textures with a predefined placeholder image or being filled with some error color (usually magenta).
 ====
+
+When `texture.sampler` is undefined, a sampler with repeat wrapping (in both directions) and auto filtering **MUST** be used.
 
 
 [[images]]
@@ -1346,9 +1572,9 @@ Images referred to by textures are stored in the `images` array of the asset.
 
 Each image contains one of
 
-- a URI to an external file in one of the supported images formats, or
-- a URI with embedded base64-encoded data, or
-- a reference to a `bufferView`; in that case `mimeType` must be defined.
+- a URI (or IRI) to an external file in one of the supported image formats, or
+- a Data URI with embedded data, or
+- a reference to a `bufferView`; in that case `mimeType` **MUST** be defined.
 
 The following example shows an image pointing to an external PNG image file and another image referencing a `bufferView` with JPEG data.
 
@@ -1367,31 +1593,94 @@ The following example shows an image pointing to an external PNG image file and 
 }
 ----
 
-[NOTE]
-.Implementation Note
-====
-When image data is provided by `uri` and `mimeType` is defined, client implementations should prefer JSON-defined MIME Type over one provided by transport layer.
-====
+Client implementations **MAY** need to manually determine the media type of some images. In such a case, the following table **SHOULD** be used to check the values of the first few bytes.
 
-The origin of the UV coordinates (0, 0) corresponds to the upper left corner of a texture image.
-This is illustrated in the following figure, where the respective UV coordinates are shown for all four corners of a normalized UV space:
+[options="header"]
+|====
+| Media Type   | Pattern Length | Pattern Bytes
+| `image/png`  | 8              | `0x89 0x50 0x4E 0x47 0x0D 0x0A 0x1A 0x0A`
+| `image/jpeg` | 3              | `0xFF 0xD8 0xFF`
+|====
+
+The image data **MUST** match the `image.mimeType` property when the latter is defined.
+
+The origin of the UV coordinates (0, 0) corresponds to the upper left corner of a texture image. This is illustrated in the following figure, where the respective UV coordinates are shown for all four corners of a normalized UV space:
 
 image:figures/texcoords.jpg[pdfwidth=4in,align=left]
 
-Any colorspace information (such as ICC profiles, intents, etc) from PNG or JPEG containers must be ignored. Effective transfer function is defined by a glTF object that refers to the image.
+Any colorspace information (such as ICC profiles, intents, gamma values, etc) from PNG or JPEG images **MUST** be ignored. Effective transfer function (encoding) is defined by a glTF object that refers to the image (in most cases it's a texture that is used by a material).
 
 [NOTE]
-.Implementation Note
+.Web Implementation Note
 ====
-This increases portability of an asset, since not all image decoding libraries fully support custom color conversions. To achieve correct rendering, WebGL runtimes must disable such conversions by setting `UNPACK_COLORSPACE_CONVERSION_WEBGL` flag to `NONE`.
+To ignore embedded colorspace information when using WebGL API, set `UNPACK_COLORSPACE_CONVERSION_WEBGL` flag to `NONE`.
+
+To ignore embedded colorspace information when using ImageBitmap API, set `colorSpaceConversion` option to `none`.
 ====
 
 
 [[samplers]]
 === Samplers
 
-Samplers are stored in the `samplers` array of the asset. Each sampler specifies filter and wrapping options corresponding to the GL types. The following example defines a sampler with linear mag filtering, linear mipmap min filtering, and repeat wrapping in S (U) and T (V).
+==== Overview
+Samplers are stored in the `samplers` array of the asset. Each sampler specifies filtering and wrapping modes.
 
+Client implementations **SHOULD** follow specified filtering modes. When the latter are undefined, client implementations **MAY** set their own default texture filtering settings.
+
+Client implementations **MUST** follow specified wrapping modes.
+
+==== Filtering
+
+Filtering modes control texture's magnification and minification.
+
+Magnification modes include:
+
+* _Nearest_. For each requested texel coordinates, the sampler selects a texel with the nearest coordinates. This process is sometimes called "nearest neighbor".
+
+* _Linear_. For each requested texel coordinates, the sampler computes a weighted sum of several adjacent texels. This process is sometimes called "bilinear interpolation".
+
+Minification modes include:
+
+* _Nearest_. For each requested texel coordinates, the sampler selects a texel with the nearest (in Manhattan distance) coordinates from the original image. This process is sometimes called "nearest neighbor".
+
+* _Linear_. For each requested texel coordinates, the sampler computes a weighted sum of several adjacent texels from the original image. This process is sometimes called "bilinear interpolation".
+
+* _Nearest-mipmap-nearest_. For each requested texel coordinates, the sampler first selects one of pre-minified versions of the original image, and then selects a texel with the nearest (in Manhattan distance) coordinates from it.
+
+* _Linear-mipmap-nearest_. For each requested texel coordinates, the sampler first selects one of pre-minified versions of the original image, and then computes a weighted sum of several adjacent texels from it.
+
+* _Nearest-mipmap-linear_. For each requested texel coordinates, the sampler first selects two pre-minified versions of the original image, selects a texel with the nearest (in Manhattan distance) coordinates from each of them, and performs final linear interpolation between these two intermediate results.
+
+* _Linear-mipmap-linear_. For each requested texel coordinates, the sampler first selects two pre-minified versions of the original image, computes a weighted sum of several adjacent texels from each of them, and performs final linear interpolation between these two intermediate results. This process is sometimes called "trilinear interpolation".
+
+To support mipmap modes, client implementations **MUST** be able to generate mipmaps at runtime.
+
+
+==== Wrapping
+
+Wrapping defines how to handle out of range texture coordinates, independently for both directions. Supported modes include:
+
+* _Repeat_. Only the fractional part of texture coordinates is used.
++
+[NOTE]
+.Example
+====
+`2.2` maps to `0.2`; `-0.4` maps to `0.6`. 
+====
+
+* _Mirrored Repeat_. This mode works as _repeat_ but flips the direction when the integer part (truncated towards −∞) is odd.
++
+[NOTE]
+.Example
+====
+`2.2` maps to `0.2`; `-0.4` is treated as `0.4`. 
+====
+
+* _Clamp to edge_. Texture coordinates with values outside the image are clamped to the closest existing image texel at the edge.
+
+==== Example 
+
+The following example defines a sampler with _linear_ magnification filtering, _linear-mipmap-linear_ minification filtering, and _repeat_ wrapping in both directions.
 
 [source,json]
 ----
@@ -1407,32 +1696,26 @@ Samplers are stored in the `samplers` array of the asset. Each sampler specifies
 }
 ----
 
-[NOTE]
-.Default Filtering Implementation Note
-====
-When filtering options are defined, runtime must use them. Otherwise, it is free to adapt filtering to performance or quality goals.
-====
+
+==== Non-power-of-two Textures
+
+Client implementations **SHOULD** resize non power-of-two textures when running on certain platforms that have limited support for such texture dimensions.
 
 [NOTE]
-.Mipmapping Implementation Note
+.Implementation Note
 ====
-When a sampler's minification filter (`minFilter`) uses mipmapping (`NEAREST_MIPMAP_NEAREST`, `NEAREST_MIPMAP_LINEAR`, `LINEAR_MIPMAP_NEAREST`, or `LINEAR_MIPMAP_LINEAR`), any texture referencing the sampler needs to have mipmaps, e.g., by calling GL's `generateMipmap()` function.
-====
+Specifically if the `sampler` the texture references
 
-[NOTE]
-.Non-Power-Of-Two Texture Implementation Note
-====
-glTF does not guarantee that a texture's dimensions are a power-of-two.  At runtime, if a texture's width or height is not a power-of-two, the texture needs to be resized so its dimensions are powers-of-two if the `sampler` the texture references
+* Has a wrapping mode (either `wrapS` or `wrapT`) equal to _repeat_ or _mirrored repeat_, or
 
-* Has a wrapping mode (either `wrapS` or `wrapT`) equal to `REPEAT` or `MIRRORED_REPEAT`, or
-* Has a minification filter (`minFilter`) that uses mipmapping (`NEAREST_MIPMAP_NEAREST`, `NEAREST_MIPMAP_LINEAR`, `LINEAR_MIPMAP_NEAREST`, or `LINEAR_MIPMAP_LINEAR`).
+* Has a minification filter (`minFilter`) that uses mipmapping.
 ====
 
 
 [[materials]]
 == Materials
 
-[[materials-overvew]]
+[[materials-overview]]
 === Overview
 
 glTF defines materials using a common set of parameters that are based on widely used material representations from Physically-Based Rendering (PBR). Specifically, glTF uses the metallic-roughness material model. Using this declarative representation of materials enables a glTF file to be rendered consistently across platforms.
@@ -1443,7 +1726,7 @@ image:figures/materials.png[pdfwidth=4in,align=left]
 [[metallic-roughness-material]]
 === Metallic-Roughness Material
 
-All parameters related to the metallic-roughness material model are defined under the `pbrMetallicRoughness` property of `material` object. The following example shows how a material like gold can be defined using the metallic-roughness parameters:
+All parameters related to the metallic-roughness material model are defined under the `pbrMetallicRoughness` property of `material` object. The following example shows how to define a gold-like material using the metallic-roughness parameters:
 
 [source,json]
 ----
@@ -1463,37 +1746,81 @@ All parameters related to the metallic-roughness material model are defined unde
 
 The metallic-roughness material model is defined by the following properties:
 
-* `baseColor` - The base color of the material
-* `metallic` - The metalness of the material
-* `roughness` - The roughness of the material
+* _base color_ - The base color of the material.
+* _metalness_ - The metalness of the material; values range from `0.0` (non-metal) to `1.0` (metal).
+* _roughness_ - The roughness of the material; values range from `0.0` (smooth) to `1.0` (rough).
 
-The base color has two different interpretations depending on the value of metalness. When the material is a metal, the base color is the specific measured reflectance value at normal incidence (F0). For a non-metal the base color represents the reflected diffuse color of the material. In this model it is not possible to specify a F0 value for non-metals, and a linear value of 4% (0.04) is used.
+The _base color_ has two different interpretations depending on the value of _metalness_. When the material is a metal, the base color is the specific measured reflectance value at normal incidence (F0). For a non-metal the base color represents the reflected diffuse color of the material. In this model it is not possible to specify a F0 value for non-metals, and a linear value of 4% (0.04) is used.
 
-The value for each property (`baseColor`, `metallic`, `roughness`) can be defined using factors or textures. The `metallic` and `roughness` properties are packed together in a single texture called `metallicRoughnessTexture`. If a texture is not given, all respective texture components within this material model are assumed to have a value of `1.0`. If both factors and textures are present the factor value acts as a linear multiplier for the corresponding texture values. The `baseColorTexture` uses the sRGB transfer function and must be converted to linear space before it is used for any computations.
+The value for each property **MAY** be defined using factors and / or textures (e.g. `baseColorTexture` and `baseColorFactor`). If a texture is not given, all respective texture components within this material model **MUST** be assumed to have a value of `1.0`. If both factors and textures are present, the factor value acts as a linear multiplier for the corresponding texture values. A texture binding is defined by an `index` of a _texture_ object and an optional index of texture coordinates.
 
-For example, assume a value of `[0.9, 0.5, 0.3, 1.0]` in linear space is obtained from an RGBA `baseColorTexture`, and assume that `baseColorFactor` is given as `[0.2, 1.0, 0.7, 1.0]`.
-Then, the result would be
+[source,json]
+----
+{
+    "materials": [
+        {
+            "pbrMetallicRoughness": {
+                "baseColorTexture": {
+                    "index": 0,
+                    "texCoord": 1
+                },
+            }
+        }
+    ],
+    "textures": [
+        {
+            "source": 0
+        }
+    ],
+    "images": [
+        {
+            "uri": "base_color.png"
+        }
+    ]
+}
+----
+
+
+The _base color_ texture **MUST** contain 8-bit values encoded with the <<srgb, sRGB opto-electronic transfer function>> so RGB values **MUST** be decoded to real linear values before they are used for any computations. To achieve correct filtering, the transfer function **SHOULD** be decoded before performing linear interpolation.
+
+The textures for _metalness_ and _roughness_ properties are packed together in a single texture called `metallicRoughnessTexture`. Its _green_ channel contains roughness values and its _blue_ channel contains metalness values. This texture **MUST** be encoded with linear transfer function and **MAY** use more than 8 bits per channel.
+
+For example, assume an 8-bit RGBA value of `[64, 124, 231, 255]` is sampled from `baseColorTexture` and assume that `baseColorFactor` is given as `[0.2, 1.0, 0.7, 1.0]`. Then, the final _base color_ value would be (after decoding the transfer function and multiplying by the factor)
 
 [source,c]
 ----
-[0.9 * 0.2, 0.5 * 1.0, 0.3 * 0.7, 1.0 * 1.0] = [0.18, 0.5, 0.21, 1.0]
+[0.051 * 0.2, 0.202 * 1.0, 0.799 * 0.7, 1.0 * 1.0] = [0.0102, 0.202, 0.5593, 1.0]
 ----
 
-Implementations of the BRDF itself can vary based on device performance and resource constraints. See <<appendix-b-brdf-implementation,Appendix B>> for more details on the BRDF calculations.
+In addition to the material properties, if a primitive specifies a vertex color using the attribute semantic property `COLOR_0`, then this value acts as an additional linear multiplier to _base color_.
+
+Implementations of the BRDF itself **MAY** vary based on device performance and resource constraints. See <<appendix-b-brdf-implementation,Appendix B>> for more details on the BRDF calculations.
 
 
-[[additional-maps]]
-=== Additional Maps
+[[additional-textures]]
+=== Additional Textures
 
-The material definition also provides for additional maps that can also be used with the metallic-roughness material model as well as other material models which could be provided via glTF extensions.
+The material definition also provides for additional textures that **MAY** also be used with the metallic-roughness material model as well as other material models which could be provided via glTF extensions.
 
-Materials define the following additional maps:
+The following additional textures are supported:
 
-- *normal* : A tangent space normal map.
-- *occlusion* : The occlusion map indicates areas that receive less diffuse lighting from ambient sources. Direct lighting is not affected.
-- *emissive* : The emissive map controls the color and intensity of the light being emitted by the material.
+- *normal* : A tangent space normal texture. The texture encodes XYZ components of a normal vector in tangent space as RGB values stored with linear transfer function. Normal textures **SHOULD NOT** contain _alpha_ channel as it not used anyway. After dequantization, texel values **MUST** be mapped as follows: _red_ [0.0 .. 1.0] to X [-1 .. 1], _green_ [0.0 .. 1.0] to Y [-1 .. 1], _blue_ (0.5 .. 1.0] maps to Z (0 .. 1]. Normal textures **SHOULD NOT** contain blue values less than or equal to `0.5`.
++
+[NOTE]
+.Implementation Note
+====
+This mapping is usually implemented as `sampledValue * 2.0 - 1.0`.
+====
++
+The texture binding for normal textures **MAY** additionally contain a scalar `scale` value that linearly scales X and Y components of the normal vector. After scaling, the normal vector **MUST** be re-normalized.
 
-The following examples shows a material that is defined using `pbrMetallicRoughness` parameters as well as additional texture maps:
+- *occlusion* : The occlusion texture; it indicates areas that receive less diffuse lighting from ambient sources. Direct lighting is not affected. The _red_ channel of the texture encodes the occlusion value, where `0.0` means fully-occluded area (no indirect lighting) and `1.0` means not occluded area (full indirect lighting). Other texture channels (if present) do not affect occlusion.
++
+The texture binding for occlusion maps **MAY** optionally contain a scalar `strength` value that is used to reduce the occlusion effect. When present, it affects the occlusion value as `1.0 + strength * (occlusionTexture - 1.0)`.
+
+- *emissive* : The emissive texture and factor control the color and intensity of the light being emitted by the material. The texture **MUST** contain 8-bit values encoded with the <<srgb, sRGB opto-electronic transfer function>> so RGB values **MUST** be decoded to real linear values before they are used for any computations. To achieve correct filtering, the transfer function **SHOULD** be decoded before performing linear interpolation.
+
+The following example shows a material that is defined using `pbrMetallicRoughness` parameters as well as additional textures:
 
 [source,json]
 ----
@@ -1525,31 +1852,26 @@ The following examples shows a material that is defined using `pbrMetallicRoughn
 }
 ----
 
-[NOTE]
-.Implementation Note
-====
-If an implementation is resource-bound and cannot support all the maps defined it should support these additional maps in the following priority order.  Resource-bound implementations should drop maps from the bottom to the top.
+If a client implementation is resource-bound and cannot support all the textures defined it **SHOULD** support these additional textures in the following priority order.  Resource-bound implementations **SHOULD** drop textures from the bottom to the top.
 
 [options="header",cols="20%,80%"]
 |====
-| Map       | Rendering impact when map is not supported
+| Texture   | Rendering impact when feature is not supported
 | Normal    | Geometry will appear less detailed than authored.
-| Occlusion | Model will appear brighter in areas that should be darker.
+| Occlusion | Model will appear brighter in areas that are intended to be darker.
 | Emissive  | Model with lights will not be lit. For example, the headlights of a car model will be off instead of on.
 |====
-
-====
 
 
 [[alpha-coverage]]
 === Alpha Coverage
 
-The `alphaMode` property defines how the alpha value of the main factor and texture should be interpreted. The alpha value is defined in the `baseColor` for metallic-roughness material model.
+The `alphaMode` property defines how the alpha value is interpreted. The alpha value is taken from the fourth component of the _base color_ for metallic-roughness material model.
 
 `alphaMode` can be one of the following values:
 
 * `OPAQUE` - The rendered output is fully opaque and any alpha value is ignored.
-* `MASK` - The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value. This mode is used to simulate geometry such as tree leaves or wire fences.
+* `MASK` - The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified _alpha cutoff_ value. This mode is used to simulate geometry such as tree leaves or wire fences.
 * `BLEND` - The rendered output is combined with the background using the normal painting operation (i.e. the Porter and Duff over operator). This mode is used to simulate geometry such as guaze cloth or animal fur.
 
 When `alphaMode` is set to `MASK` the `alphaCutoff` property specifies the cutoff threshold. If the alpha value is greater than or equal to the `alphaCutoff` value then it is rendered as fully opaque, otherwise, it is rendered as fully transparent. `alphaCutoff` value is ignored for other modes.
@@ -1561,33 +1883,40 @@ Real-time rasterizers typically use depth buffers and mesh sorting to support al
 
 * `OPAQUE` - A depth value is written for every pixel and mesh sorting is not required for correct output.
 * `MASK` - A depth value is not written for a pixel that is discarded after the alpha test. A depth value is written for all other pixels. Mesh sorting is not required for correct output.
-* `BLEND` - Support for this mode varies. There is no perfect and fast solution that works for all cases. Implementations should try to achieve the correct blending output for as many situations as possible. Whether depth value is written or whether to sort is up to the implementation. For example, implementations can discard pixels which have zero or close to zero alpha value to avoid sorting issues.
+* `BLEND` - Support for this mode varies. There is no perfect and fast solution that works for all cases. Client implementations should try to achieve the correct blending output for as many situations as possible. Whether depth value is written or whether to sort is up to the implementation. For example, implementations may discard pixels which have zero or close to zero alpha value to avoid sorting issues.
 ====
 
 
 [[double-sided]]
 === Double Sided
 
-The `doubleSided` property specifies whether the material is double sided. When this value is false, back-face culling is enabled. When this value is true, back-face culling is disabled and double sided lighting is enabled. The back-face must have its normals reversed before the lighting equation is evaluated.
+The `doubleSided` property specifies whether the material is double sided.
+
+When this value is false, back-face culling is enabled, i.e. only front-facing triangles are rendered.
+
+When this value is true, back-face culling is disabled and double sided lighting is enabled. The back-face **MUST** have its normals reversed before the lighting equation is evaluated.
 
 
 [[default-material]]
 === Default Material
 
-The default material, used when a mesh does not specify a material, is defined to be a material with no properties specified. All the default values of <<reference-material,`material`>> apply. Note that this material does not emit light and will be black unless some lighting is present in the scene.
+The default material, used when a mesh does not specify a material, is defined to be a material with no properties specified. All the default values of <<reference-material,`material`>> apply.
 
+[NOTE]
+.Implementation Note
+====
+This material does not emit light and will be black unless some lighting is present in the scene.
+====
 
 [[point-and-line-materials]]
 === Point and Line Materials
 
-*This section is non-normative.*
+This specification does not define size and style of non-triangular primitives (such as _points_ or _lines_), and applications **MAY** use various techniques to render these primitives as appropriate. However, the following conventions are **RECOMMENDED** for consistency:
 
-This specification does not define size and style of non-triangular primitives (such as POINTS or LINES) at this time, and applications may use various techniques to render these primitives as appropriate. However, the following recommendations are provided for consistency:
-
-* POINTS and LINES should have widths of 1px in viewport space.
-* For LINES with `NORMAL` and `TANGENT` properties, render with standard lighting including normal maps.
-* For POINTS or LINES with no `TANGENT` property, render with standard lighting but ignore any normal maps on the material.
-* For POINTS or LINES with no `NORMAL` property, don't calculate lighting and instead output the `COLOR` value for each pixel drawn.
+* Points and Lines **SHOULD** have widths of 1px in viewport space.
+* Lines with `NORMAL` and `TANGENT` attributes **SHOULD** be rendered with standard lighting including normal maps.
+* Points or Lines with no `TANGENT` attribute **SHOULD** be rendered with standard lighting but ignoring any normal maps on the material.
+* Points or Lines with no `NORMAL` property **SHOULD** be rendered without lighting and instead use the `COLOR` value for each pixel drawn.
 
 
 [[cameras]]
@@ -1600,7 +1929,9 @@ A camera defines the projection matrix that transforms from view to clip coordin
 
 Cameras are stored in the asset's `cameras` array. Each camera defines a `type` property that designates the type of projection (perspective or orthographic), and either a `perspective` or `orthographic` property that defines the details.
 
-Depending on the presence of `zfar` property, perspective cameras could use finite or infinite projection.
+There are two subtypes of perspective projections: finite and infinite. When `zfar` property is undefined, infinite projection is used. Otherwise the camera defines a finite projection.
+
+For orthographic and finite perspective cameras, `zfar` **MUST** be greater than `znear`.
 
 The following example defines two perspective cameras with supplied values for Y field of view, aspect ratio, and clipping information.
 
@@ -1638,8 +1969,7 @@ The following example defines two perspective cameras with supplied values for Y
 [[projection-matrices-overview]]
 ==== Overview
 
-Runtimes are expected to use the following projection matrices.
-
+Client implementations **SHOULD** use the following projection matrices.
 
 [[infinite-perspective-projection]]
 ==== Infinite perspective projection
@@ -1707,18 +2037,19 @@ where
 == Animations
 
 glTF supports articulated and skinned animation via key frame animations of nodes' transforms. Key frame data is stored in buffers and referenced in animations using accessors.
-glTF 2.0 also supports animation of instantiated Morph Targets in a similar fashion.
+
+glTF 2.0 also supports animation of instantiated morph targets in a similar fashion.
 
 [NOTE]
 .Note
 ====
-glTF 2.0 only supports animating node transforms and Morph Targets weights. A future version of the specification may support animating arbitrary properties, such as material colors and texture transform matrices.
+glTF 2.0 only supports animating node transforms and morph target weights. Extensions or a future version of the specification may support animating arbitrary properties, such as material colors and texture transform matrices.
 ====
 
 [NOTE]
 .Note
 ====
-glTF 2.0 defines only animation storage, so this specification doesn't define any particular runtime behavior, such as: order of playing, auto-start, loops, mapping of timelines, etc...
+glTF 2.0 defines only storage of animation keyframes, so this specification doesn't define any particular runtime behavior, such as: order of playing, auto-start, loops, mapping of timelines, etc... When loading a glTF 2.0 asset, client implementations may select an animation entry and pause it on the first frame, play it automatically, or ignore all animations until further user requests. When a playing animation is stopped, client implementations may reset the scene to the initial state or to freeze it at the current frame.
 ====
 
 [NOTE]
@@ -1870,43 +2201,51 @@ The following examples show expected animations usage.
 }
 ----
 
-*Channels* connect the output values of the key frame animation to a specific node in the hierarchy. A channel's `sampler` property contains the index of one of the samplers present in the containing animation's `samplers` array. The `target` property is an object that identifies which node to animate using its `node` property, and which property of the node to animate using `path`. Non-animated properties must keep their values during animation.
+_Channels_ connect the output values of the key frame animation to a specific node in the hierarchy. A channel's `sampler` property contains the index of one of the samplers present in the containing animation's `samplers` array. The `target` property is an object that identifies which node to animate using its `node` property, and which property of the node to animate using `path`. Non-animated properties **MUST** keep their values during animation.
 
-When `node` isn't defined, channel should be ignored. Valid path names are `"translation"`, `"rotation"`, `"scale"`, and `"weights"`.
+When `node` isn't defined, channel **SHOULD** be ignored. Valid path names are `"translation"`, `"rotation"`, `"scale"`, and `"weights"`.
 
-Each of the animation's *samplers* defines the `input`/`output` pair: a set of floating point scalar values representing linear time in seconds; and a set of vectors or scalars representing animated property. All values are stored in a buffer and accessed via accessors; refer to the table below for output accessor types. Interpolation between keys is performed using the interpolation method specified in the `interpolation` property. Supported `interpolation` values include `LINEAR`, `STEP`, and `CUBICSPLINE`. See <<appendix-c-spline-interpolation,Appendix C>> for additional information about spline interpolation.
+Each of the animation's *samplers* defines the `input`/`output` pair: a set of floating point scalar values representing linear time in seconds; and a set of vectors or scalars representing the animated property. All values are stored in a buffer and accessed via accessors; refer to the table below for output accessor types. Interpolation between keys is performed using the interpolation method specified in the `interpolation` property. Supported `interpolation` values include `LINEAR`, `STEP`, and `CUBICSPLINE`. See <<appendix-c-spline-interpolation,Appendix C>> for additional information about spline interpolation.
 
-The inputs of each sampler are relative to `t=0`, defined as the beginning of the parent `animations` entry. Before and after the provided input range, output should be "clamped" to the nearest end of the input range. For example, if the earliest sampler input for an animation is `t=10`, a client implementation should begin playback of that animation at `t=0` with output clamped to the first output value. Samplers within a given animation are _not_ required to have the same inputs.
+The inputs of each sampler are relative to `t = 0`, defined as the beginning of the parent `animations` entry. Before and after the provided input range, output **MUST** be clamped to the nearest end of the input range.
+
+[NOTE]
+.Implementation Note
+====
+For example, if the earliest sampler input for an animation is `t = 10`, a client implementation must begin playback of that animation channel at `t = 0` with output clamped to the first available output value.
+====
+
+Samplers within a given animation are **MAY** have different inputs.
 
 [options="header",cols="15%,15%,35%,35%"]
 |====
-| `channel.path`  | Accessor Type | Component Type(s)                  | Description
-| `"translation"` | `"VEC3"`      | `5126` (FLOAT)                     | XYZ translation vector
-| `"rotation"`    | `"VEC4"`      | `5126` (FLOAT) +
-                                    `5120` (BYTE) normalized +
-                                    `5121` (UNSIGNED_BYTE) normalized +
-                                    `5122` (SHORT) normalized +
-                                    `5123` (UNSIGNED_SHORT) normalized | XYZW rotation quaternion
-| `"scale"`       | `"VEC3"`      | `5126` (FLOAT)|XYZ scale vector
-| `"weights"`     | `"SCALAR"`    | `5126` (FLOAT) +
-                                    `5120` (BYTE) normalized +
-                                    `5121` (UNSIGNED_BYTE) normalized +
-                                    `5122` (SHORT) normalized +
-                                    `5123` (UNSIGNED_SHORT) normalized | Weights of morph targets
+| `channel.path`  | Accessor Type | Component Type(s)           | Description
+| `"translation"` | `"VEC3"`      | _float_                     | XYZ translation vector
+| `"rotation"`    | `"VEC4"`      | _float_ +
+                                    _signed byte_ normalized +
+                                    _unsigned byte_ normalized +
+                                    _signed short_ normalized +
+                                    _unsigned short_ normalized | XYZW rotation quaternion
+| `"scale"`       | `"VEC3"`      | _float_ |XYZ scale vector
+| `"weights"`     | `"SCALAR"`    | _float_ +
+                                    _signed byte_ normalized +
+                                    _unsigned byte_ normalized +
+                                    _signed short_ normalized +
+                                    _unsigned short_ normalized | Weights of morph targets
 |====
 
-Implementations must use following equations to get corresponding floating-point value `f` from a normalized integer `c` and vise-versa:
+Implementations **MUST** use following equations to decode real floating-point value `f` from a normalized integer `c` and vise-versa:
 
 [options="header"]
 |====
 | `accessor.componentType` | int-to-float                 | float-to-int
-| `5120` (BYTE)            | `f = max(c / 127.0, -1.0)`   | `c = round(f * 127.0)`
-| `5121` (UNSIGNED_BYTE)   | `f = c / 255.0`              | `c = round(f * 255.0)`
-| `5122` (SHORT)           | `f = max(c / 32767.0, -1.0)` | `c = round(f * 32767.0)`
-| `5123` (UNSIGNED_SHORT)  | `f = c / 65535.0`            | `c = round(f * 65535.0)`
+| _signed byte_            | `f = max(c / 127.0, -1.0)`   | `c = round(f * 127.0)`
+| _unsigned byte_          | `f = c / 255.0`              | `c = round(f * 255.0)`
+| _signed short_           | `f = max(c / 32767.0, -1.0)` | `c = round(f * 32767.0)`
+| _unsigned short_         | `f = c / 65535.0`            | `c = round(f * 65535.0)`
 |====
 
-Animation Sampler's `input` accessor *must* have `min` and `max` properties defined.
+Animation sampler's `input` accessor **MUST** have its `min` and `max` properties defined.
 
 [NOTE]
 .Implementation Note
@@ -1914,21 +2253,21 @@ Animation Sampler's `input` accessor *must* have `min` and `max` properties defi
 Animations with non-linear time inputs, such as time warps in Autodesk 3ds Max or Maya, are not directly representable with glTF animations. glTF is a runtime format and non-linear time inputs are expensive to compute at runtime. Exporter implementations should sample a non-linear time animation into linear inputs and outputs for an accurate representation.
 ====
 
-A Morph Target animation frame is defined by a sequence of scalars of length equal to the number of targets in the animated Morph Target. These scalar sequences must lie end-to-end as a single stream in the output accessor, whose final size will equal the number of Morph Targets times the number of animation frames.
+A morph target animation frame is defined by a sequence of scalars of length equal to the number of targets in the animated morph target. These scalar sequences **MUST** lie end-to-end as a single stream in the output accessor, whose final size is equal to the number of morph targets times the number of animation frames.
 
-Morph Target animation is by nature sparse, consider using <<sparse-accessors,Sparse Accessors>> for storage of Morph Target animation. When used with `CUBICSPLINE` interpolation, tangents (a~k~, b~k~) and values (v~k~) are grouped within keyframes:
+Morph target animation is by nature sparse, consider using <<sparse-accessors,Sparse Accessors>> for storage of morph target animation. When used with `CUBICSPLINE` interpolation, tangents (a~k~, b~k~) and values (v~k~) are grouped within keyframes:
 
 a~1~,a~2~,...a~n~,v~1~,v~2~,...v~n~,b~1~,b~2~,...b~n~
 
 See <<appendix-c-spline-interpolation,Appendix C>> for additional information about spline interpolation.
 
-glTF animations can be used to drive articulated or skinned animations. Skinned animation is achieved by animating the joints in the skin's joint hierarchy.
+Skinned animation is achieved by animating the joints in the skin's joint hierarchy.
 
 
 [[specifying-extensions]]
 == Specifying Extensions
 
-glTF defines an extension mechanism that allows the base format to be extended with new capabilities. Any glTF object can have an optional `extensions` property, as in the following example:
+glTF defines an extension mechanism that allows the base format to be extended with new capabilities. Any glTF object **MAY** have an optional `extensions` property, as in the following example:
 
 [source,json]
 ----
@@ -1936,8 +2275,13 @@ glTF defines an extension mechanism that allows the base format to be extended w
     "material": [
         {
             "extensions": {
-                "KHR_materials_common": {
-                    "technique": "LAMBERT"
+                "KHR_materials_sheen": {
+                    "sheenColorFactor": [
+                        1.0,
+                        0.329,
+                        0.1
+                    ],
+                    "sheenRoughnessFactor": 0.8
                 }
             }
         }
@@ -1945,70 +2289,74 @@ glTF defines an extension mechanism that allows the base format to be extended w
 }
 ----
 
-All extensions used in a glTF asset must be listed in the top-level `extensionsUsed` array object, e.g.,
+All extensions used in a glTF asset **MUST** be listed in the top-level `extensionsUsed` array object, e.g.,
 
 [source,json]
 ----
 {
     "extensionsUsed": [
-        "KHR_materials_common",
+        "KHR_materials_sheen",
         "VENDOR_physics"
     ]
 }
 ----
 
-All glTF extensions required to load and/or render an asset must be listed in the top-level `extensionsRequired` array, e.g.,
+All glTF extensions required to load and/or render an asset **MUST** be listed in the top-level `extensionsRequired` array, e.g.,
 
 [source,json]
 ----
 {
     "extensionsRequired": [
-        "WEB3D_quantized_attributes"
+        "KHR_texture_transform"
+    ],
+    "extensionsUsed": [
+        "KHR_texture_transform"
     ]
 }
 ----
 
-`extensionsRequired` is a subset of `extensionsUsed`. All values in `extensionsRequired` must also exist in `extensionsUsed`.
+`extensionsRequired` is a subset of `extensionsUsed`. All values in `extensionsRequired` **MUST** also exist in `extensionsUsed`.
 
-For more information on glTF extensions, consult the https://github.com/KhronosGroup/glTF/blob/master/extensions/README.md[extensions registry specification].
+[NOTE]
+.Note
+====
+For more information on developing glTF extensions, consult the https://github.com/KhronosGroup/glTF/blob/master/extensions/README.md[extensions registry specification].
+====
 
 
 [[glb-file-format-specification]]
 = GLB File Format Specification
 
 [[glb-file-format-specification-general]]
-== General
+== General (Informative)
 
 glTF provides two delivery options that can also be used together:
 
 * glTF JSON points to external binary data (geometry, key frames, skins), and images.
 * glTF JSON embeds base64-encoded binary data, and images inline using data URIs.
 
-For these resources, glTF requires either separate requests or extra space due to base64-encoding. Base64-encoding requires extra processing to decode and increases the file size (by ~33% for encoded resources). While gzip mitigates the file size increase, decompression and decoding still add significant loading time.
+For these resources, loading glTF usually requires either separate requests or extra space due to base64-encoding. Base64-encoding requires extra processing to decode and increases the file size (by ~33% for encoded resources). While transport-layer gzip mitigates the file size increase, decompression and decoding still add significant loading time.
 
 To solve this, a container format, _Binary glTF_ is introduced. In Binary glTF, a glTF asset (JSON, .bin, and images) can be stored in a binary blob.
 
-This binary blob (which can be a file, for example) has the following structure:
-
-* A 12-byte preamble, entitled the `header`.
-* One or more `chunks` that contains JSON content and binary data.
-
-The `chunk` containing JSON can refer to external resources as usual, and can also reference resources stored within other `chunks`.
-
 For example, an application that wants to download textures on demand may embed everything except images in the Binary glTF. Embedded base64-encoded resources are also still supported, but it would be inefficient to use them.
 
+[[glb-file-format-specification-structure]]
+== Structure
 
-[[file-extension]]
-== File Extension
+This binary blob (which can be a file, for example) has the following structure:
+
+* A 12-byte preamble, entitled the _header_.
+* One or more _chunks_ that contain JSON content and binary data.
+
+The _chunk_ containing JSON **MAY** refer to external resources as usual, and **MAY** also reference resources stored within other _chunks_.
+
+[[glb-file-format-specification-file-extension]]
+== File Extension & Media Type
 
 The file extension to be used with Binary glTF is `.glb`.
 
-
-[[mime-type]]
-== MIME Type
-
-Use `model/gltf-binary`.
-
+The registered media type is `model/gltf-binary`.
 
 [[binary-gltf-layout]]
 == Binary glTF Layout
@@ -2037,15 +2385,11 @@ uint32 version
 uint32 length
 ----
 
-* `magic` equals `0x46546C67`. It is ASCII string `glTF`, and can be used to identify data as Binary glTF.
+* `magic` **MUST** be equal to equal `0x46546C67`. It is ASCII string `glTF`, and can be used to identify data as Binary glTF.
 * `version` indicates the version of the Binary glTF container format. This specification defines version 2.
-* `length` is the total length of the Binary glTF, including Header and all Chunks, in bytes.
-
-[NOTE]
-.Implementation Note
-====
-Client implementations that load GLB format should also check for the <<asset,asset version properties>> in the JSON chunk, as the version specified in the GLB header only refers to the GLB container version.
-====
++
+Client implementations that load GLB format **MUST** also check for the <<asset,asset version properties>> in the JSON chunk, as the version specified in the GLB header only refers to the GLB container version.
+* `length` is the total length of the Binary glTF, including _header_ and all _chunks_, in bytes.
 
 
 [[chunks]]
@@ -2067,7 +2411,7 @@ ubyte[] chunkData
 * `chunkType` indicates the type of chunk. See <<table-chunktypes>> for details.
 * `chunkData` is a binary payload of chunk.
 
-The start and the end of each chunk must be aligned to 4-byte boundary. See chunks definitions for padding schemes. Chunks must appear in exactly the order given in <<table-chunktypes>>.
+The start and the end of each chunk **MUST** be aligned to 4-byte boundary. See chunks definitions for padding schemes. Chunks **MUST** appear in exactly the order given in <<table-chunktypes>>.
 
 [[table-chunktypes]]
 .Chunk types
@@ -2078,34 +2422,35 @@ The start and the end of each chunk must be aligned to 4-byte boundary. See chun
 | 2. | 0x004E4942 | BIN   | Binary buffer           | 0 or 1
 |====
 
-Client implementations must ignore chunks with unknown types to enable glTF extensions to reference additional chunks with new types following the first two chunks.
+Client implementations **MUST** ignore chunks with unknown types to enable glTF extensions to reference additional chunks with new types following the first two chunks.
 
 
 [[structured-json-content]]
 ==== Structured JSON Content
 
-This chunk holds the structured glTF content description, as it would be provided within a .gltf file.
+This chunk holds the glTF JSON, as it would be provided within a .gltf file.
 
 [NOTE]
-.Implementation Note
+.ECMAScript Implementation Note
 ====
 In a JavaScript implementation, the `TextDecoder` API can be used to extract the glTF content from the ArrayBuffer, and then the JSON can be parsed with `JSON.parse` as usual.
 ====
 
-This chunk must be the very first chunk of Binary glTF asset. By reading this chunk first, an implementation is able to progressively retrieve resources from subsequent chunks. This way, it is also possible to read only a selected subset of resources from a Binary glTF asset (for instance, the coarsest LOD of a mesh).
+This chunk **MUST** be the very first chunk of Binary glTF asset. By reading this chunk first, an implementation is able to progressively retrieve resources from subsequent chunks. This way, it is also possible to read only a selected subset of resources from a Binary glTF asset.
 
-This chunk must be padded with trailing `Space` chars (`0x20`) to satisfy alignment requirements.
+This chunk **MUST** be padded with trailing `Space` chars (`0x20`) to satisfy alignment requirements.
 
 
 [[binary-buffer]]
 ==== Binary buffer
 
-This chunk contains the binary payload for geometry, animation key frames, skins, and images. See glTF specification for details on referencing this chunk from JSON.
+This chunk contains the binary payload for geometry, animation key frames, skins, and images. See <<glb-stored-buffer,GLB-stored Buffer>> for details on referencing this chunk from JSON.
 
-This chunk must be the second chunk of the Binary glTF asset.
+This chunk **MUST** be the second chunk of the Binary glTF asset.
 
-This chunk must be padded with trailing zeros (`0x00`) to satisfy alignment requirements.
+This chunk **MUST** be padded with trailing zeros (`0x00`) to satisfy alignment requirements.
 
+When the binary buffer is empty or when it is stored by other means, this chunk **SHOULD** be omitted.
 
 [[properties-reference]]
 = Properties Reference
@@ -2182,7 +2527,7 @@ include::JsonSchemaReference.adoc[]
 
 [appendix]
 [[appendix-b-brdf-implementation]]
-= BRDF Implementation
+= BRDF Implementation (Informative)
 
 [[appendix-b-brdf-implementation-general]]
 == General
@@ -2491,7 +2836,7 @@ More recently, <<Jakob2014,Jakob et al. (2014)>> developed a generic framework f
 [[appendix-c-spline-interpolation]]
 = Spline Interpolation
 
-Animations in glTF support spline interpolation with a cubic spline.
+glTF animations support cubic spline interpolation.
 
 The keyframes of a cubic spline in glTF have input and output values where each input value corresponds to three output values of the same type: in-tangent, data point, and out-tangent.
 
@@ -2531,17 +2876,14 @@ and where at input offset _t_~_current_~ with keyframe index _k_
 
 The scalar-point multiplications are per point component.
 
-When the sampler targets a node's rotation property, the resulting *p*(_t_) quaternion must be normalized before applying the result to the node's rotation.
+When the sampler targets a node's rotation property, the resulting *p*(_t_) quaternion **MUST** be normalized before applying the result to the node's rotation.
+
+When writing out rotation output values, exporters **SHOULD** take care to not write out values which can result in an invalid quaternion with all zero values.
 
 [NOTE]
 .Implementation Note
 ====
-When writing out rotation output values, exporters should take care to not write out values which can result in an invalid quaternion with all zero values. This can be achieved by ensuring the output values never have both -*q* and *q* in the same spline.
+This can be achieved by ensuring the output values never have both -*q* and *q* in the same spline.
 ====
 
-[NOTE]
-.Implementation Note
-====
-The first in-tangent *a*~1~ and last out-tangent *b*~*n*~ should be zeros as they are not used in the spline calculations.
-====
-
+The first in-tangent *a*~1~ and last out-tangent *b*~*n*~ **SHOULD** be zeros as they are not used in the spline calculations.

--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -4,10 +4,11 @@
 
 // :regtitle: is explained in
 // https://discuss.asciidoctor.org/How-to-add-markup-to-author-information-in-document-title-td6488.html
-= glTF{tmtitle} 2.0 Specification - PREVIEW DRAFT
+= glTF{tmtitle} 2.0 Specification
 :tmtitle: pass:q,r[^™^]
 :regtitle: pass:q,r[^®^]
 The Khronos{regtitle} 3D Formats Working Group
+Version 2.0.0
 :data-uri:
 :icons: font
 :toc2:
@@ -341,11 +342,18 @@ Major version updates may be incompatible with previous versions.
 ** `.bin`, `.glbin`, or `.glbuf` file extensions with <<gltf-buffer,`application/gltf-buffer`>> Media Type.
 
 * <<png,PNG>> images **SHOULD** use `.png` file extension with <<image-png,`image/png`>> Media Type;
-** PNG images **SHOULD NOT** contain animations, non-square pixel ratios, or embedded ICC profiles. Such features if present **MUST** be ignored by client implementations.
+** PNG images **SHOULD NOT** contain animations, non-square pixel ratios, or embedded ICC profiles. Such features, if present, **MUST** be ignored by client implementations.
 
 * <<jpeg,JPEG>> images **SHOULD** use `.jpeg` or `.jpg` file extensions with <<image-jpeg,`image/jpeg`>> Media Type
-** JPEG images **SHOULD** use <<jfif,JPEG File Interchange Format>>.
-** Client implementations **MAY** support JPEG images that use <<exif,Exchangeable image file format (Exif)>>.
+** JPEG images **MUST** be compatible with <<jfif,JPEG File Interchange Format>>.
+** JPEG images **SHOULD NOT** contain embedded ICC profiles. If present, embedded ICC profiles **MUST** be ignored by client implementations.
+** <<exif,Exchangeable image file format (Exif)>> chunks **MAY** be ignored by client implementations.
++
+[NOTE]
+.Implementation Note
+====
+Certain Exif chunks, e.g. "`Orientation`", may severely impact asset's portability.
+====
 
 [[json-encoding]]
 == JSON Encoding

--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -167,8 +167,6 @@ _Portable Network Graphics (PNG): Functional specification_
 A free version of this standard is available from W3C: https://www.w3.org/TR/PNG/
 ====
 
-
-
 * [[jpeg]]
 ISO/IEC 10918-1:1994
 _Digital compression and coding of continuous-tone still images: Requirements and guidelines_
@@ -347,7 +345,7 @@ Although glTF Specification does not define any subset of the <<json,JSON>> form
 
 1. glTF JSON data **SHOULD** be written with UTF-8 encoding without BOM. This requirement is not applied when a glTF implementation does not control string encoding. glTF implementations **SHOULD** adhere to <<json,RFC 8259>>, Section 8.1. with regards to treating BOM presence.
 
-2. ASCII characters stored in glTF JSON **SHOULD** be written unescaped.
+2. ASCII characters stored in glTF JSON **SHOULD** be written without JSON escaping.
 +
 [NOTE]
 .Example
@@ -429,7 +427,7 @@ glTF assets use <<uri,URIs>> or <<iri,IRIs>> to reference buffers and image reso
 Base64 encoding used in Data URI increases the payload's byte length by 33%.
 ====
 
-- **Relative paths** -- `path-noscheme` or `ipath-noscheme` as defined by <<uri,RFC 3986>>, Section 4.2 or <<iri,RFC 3987>>, Section 2.2 -- without scheme, authority, or parameters. Reserved characters **MUST** be percent-encoded, per <<uri,RFC 3986>>, Section 2.2.
+- **Relative paths** -- `path-noscheme` or `ipath-noscheme` as defined by <<uri,RFC 3986>>, Section 4.2 or <<iri,RFC 3987>>, Section 2.2 -- without scheme, authority, or parameters. Reserved characters (as defined by <<uri,RFC 3986>>, Section 2.2. and <<iri,RFC 3987>>, Section 2.2.) **MUST** be percent-encoded.
 
 Client implementations **MAY** optionally support additional URI components. For example `http://` or `file://` schemes, authorities, hostnames, absolute paths, and query or fragment parameters. Assets containing these additional URI components would be less portable.
 
@@ -529,12 +527,12 @@ All angles are in radians.
 
 Positive rotation is counterclockwise.
 
-RGB color values **MUST** use <<srgb,sRGB>> color primaries.
+Red, Green, and Blue primary colors use <<bt709,Recommendation ITU-R BT.709>> chromaticity coordinates.
 
 [NOTE]
 .Implementation Note
 ====
-Color primaries define the interpretation of each color channel of the color model, particularly with respect to the RGB color model. In the context of a typical display, color primaries describe the color of the red, green and blue phosphors or filters. The same primaries are also defined in <<bt709,Recommendation ITU-R BT.709>>. Since the overwhelming majority of currently used consumer displays are using the same primaries as default, client implementations usually do not need to convert color values. Future specification versions or extensions may allow other color primaries (such as P3).
+Chromaticity coordinates define the interpretation of each primary color channel of the color model. In the context of a typical display, color primaries describe the color of the red, green and blue phosphors or filters. Unless a wide color gamut output is explicitly used, client implementations usually do not need to convert colors. Future specification versions or extensions may allow other color primaries (such as P3).
 ====
 
 
@@ -734,13 +732,13 @@ The following example defines a buffer. The `byteLength` property specifies the 
 
 The byte length of the referenced resource **MUST** be greater than or equal to the `buffer.byteLength` property.
 
-Buffer data **MAY** alternatively be embedded in the glTF file via `data:` URI with base64 encoding. When `data:` URI is used for buffer storage, its `mediatype` field **MUST** be set to `application/octet-stream` or `application/gltf-buffer`. The byte length of the base64-encoded data **MUST** be equal to the `buffer.byteLength` property.
+Buffer data **MAY** alternatively be embedded in the glTF file via `data:` URI with base64 encoding. When `data:` URI is used for buffer storage, its `mediatype` field **MUST** be set to `application/octet-stream` or `application/gltf-buffer`.
 
 A _buffer view_ represents a contiguous segment of data in a buffer, defined by a byte offset into the buffer specified in the `byteOffset` property and a total byte length specified by the `byteLength` property of the buffer view.
 
 Buffer views used for images, vertex indices, vertex attributes, or inverse bind matrices **MUST** contain only one kind of data, i.e. the same buffer view **MUST NOT** be used both for vertex indices and vertex attributes.
 
-When a buffer view is used by vertex indices or attribute accessors it **SHOULD** specify `bufferView.target` with a value of `34963` or `34962` respectively.
+When a buffer view is used by vertex indices or attribute accessors it **SHOULD** specify `bufferView.target` with a value of _element array buffer_ or _array buffer_ respectively.
 
 [NOTE]
 .Implementation Note
@@ -986,7 +984,9 @@ accessor.byteOffset + EFFECTIVE_BYTE_STRIDE * (accessor.count - 1) + SIZE_OF_COM
 
 For performance and compatibility reasons, each element of a vertex attribute **MUST** be aligned to 4-byte boundaries inside a `bufferView` (i.e., `accessor.byteOffset` and `bufferView.byteStride` **MUST** be multiples of 4).
 
-Accessors of matrix type have data stored in column-major order; start of each column **MUST** be aligned to 4-byte boundaries. To achieve this, three `type`/`componentType` combinations require special layout:
+Accessors of matrix type have data stored in column-major order; start of each column **MUST** be aligned to 4-byte boundaries. Specifically, when `ROWS * SIZE_OF_COMPONENT` (where `ROWS` is the number of rows of the matrix) is not a multiple of 4, then `(ROWS * SIZE_OF_COMPONENT) % 4` padding bytes **MUST** be inserted at the end of each column.
+
+Only the following three accessor configurations require padding.
 
 *MAT2, 1-byte components*
 
@@ -1012,7 +1012,7 @@ Accessors of matrix type have data stored in column-major order; start of each c
 |m00|m00|m10|m10|m20|m20|---|---|m01|m01|m11|m11|m21|m21|---|---|m02|m02|m12|m12|m22|m22|---|---|
 ----
 
-Alignment requirements apply only to start of each column, so trailing bytes **MAY** be omitted if there's no further data.
+Alignment requirements apply only to the start of each column, so trailing bytes **MAY** be omitted if there's no further data.
 
 [NOTE]
 .Implementation Note
@@ -1137,7 +1137,7 @@ The following example defines a mesh containing one indexed triangle set primiti
 
 Each attribute is defined as a property of the `attributes` object. The name of the property corresponds to an enumerated value identifying the vertex attribute, such as `POSITION`. The value of the property is the index of an accessor that contains the data.
 
-Valid attribute semantic property names include `POSITION`, `NORMAL`, `TANGENT`, `TEXCOORD_0`, `TEXCOORD_1`, `COLOR_0`, `JOINTS_0`, and `WEIGHTS_0`.
+The specification defines the following attribute semantics: `POSITION`, `NORMAL`, `TANGENT`, `TEXCOORD_0`, `TEXCOORD_1`, `COLOR_0`, `JOINTS_0`, and `WEIGHTS_0`.
 
 Application-specific attribute semantics **MUST** start with an underscore, e.g., `_TEMPERATURE`. Application-specific attribute semantics **MUST NOT** use __unsigned int__ component type.
 

--- a/specification/2.0/schema/accessor.schema.json
+++ b/specification/2.0/schema/accessor.schema.json
@@ -2,26 +2,26 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Accessor",
     "type": "object",
-    "description": "A typed view into a bufferView.  A bufferView contains raw binary data.  An accessor provides a typed view into a bufferView or a subset of a bufferView similar to how WebGL's `vertexAttribPointer()` defines an attribute in a buffer.",
+    "description": "A typed view into a buffer view that contains raw binary data.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "bufferView": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of the bufferView.",
-            "gltf_detailedDescription": "The index of the bufferView. When not defined, accessor must be initialized with zeros; `sparse` property or extensions could override zeros with actual values."
+            "gltf_detailedDescription": "The index of the buffer view. When undefined, the accessor **MUST** be initialized with zeros; `sparse` property or extensions **MAY** override zeros with actual values."
         },
         "byteOffset": {
             "type": "integer",
-            "description": "The offset relative to the start of the bufferView in bytes.",
+            "description": "The offset relative to the start of the buffer view in bytes.",
             "minimum": 0,
             "default": 0,
-            "gltf_detailedDescription": "The offset relative to the start of the bufferView in bytes.  This must be a multiple of the size of the component datatype.",
+            "gltf_detailedDescription": "The offset relative to the start of the buffer view in bytes.  This **MUST** be a multiple of the size of the component datatype. This property **MUST NOT** be defined when `bufferView` is undefined.",
             "gltf_webgl": "`vertexAttribPointer()` offset parameter"
         },
         "componentType": {
-            "description": "The datatype of components in the attribute.",
-            "gltf_detailedDescription": "The datatype of components in the attribute.  All valid values correspond to WebGL enums.  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, `Uint32Array`, and `Float32Array`, respectively.  5125 (UNSIGNED_INT) is only allowed when the accessor contains indices, i.e., the accessor is only referenced by `primitive.indices`.",
-            "gltf_webgl": "`vertexAttribPointer()` type parameter",
+            "description": "The datatype of the accessor's components.",
+            "gltf_detailedDescription": "The datatype of the accessor's components.  UNSIGNED_INT type **MUST NOT** be used for any accessor that is not referenced by `mesh.primitive.indices`.",
+            "gltf_webgl": "`type` parameter of `vertexAttribPointer()`.  The corresponding typed arrays are `Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, `Uint32Array`, and `Float32Array`.",
             "anyOf": [
                 {
                     "enum": [ 5120 ],
@@ -60,19 +60,19 @@
         },
         "normalized": {
             "type": "boolean",
-            "description": "Specifies whether integer data values should be normalized.",
+            "description": "Specifies whether integer data values should be normalized before usage.",
             "default": false,
-            "gltf_detailedDescription": "Specifies whether integer data values should be normalized (`true`) to [0, 1] (for unsigned types) or [-1, 1] (for signed types), or converted directly (`false`) when they are accessed. This property is defined only for accessors that contain vertex attributes or animation output data.",
-            "gltf_webgl": "`vertexAttribPointer()` normalized parameter"
+            "gltf_detailedDescription": "Specifies whether integer data values should be normalized (`true`) to [0, 1] (for unsigned types) or to [-1, 1] (for signed types) when they are accessed. This property **MAY** be defined only for accessors that contain vertex attributes or animation output data. This property **MUST NOT** be defined for accessors with floating-point components.",
+            "gltf_webgl": "`normalized` parameter of `vertexAttribPointer()` "
         },
         "count": {
             "type": "integer",
-            "description": "The number of attributes referenced by this accessor.",
+            "description": "The number of elements referenced by this accessor.",
             "minimum": 1,
-            "gltf_detailedDescription": "The number of attributes referenced by this accessor, not to be confused with the number of bytes or number of components."
+            "gltf_detailedDescription": "The number of elements referenced by this accessor, not to be confused with the number of bytes or number of components."
         },
         "type": {
-            "description": "Specifies if the attribute is a scalar, vector, or matrix.",
+            "description": "Specifies if the accessor's elements are scalars, vectors, or matrices.",
             "anyOf": [
                 {
                     "enum": [ "SCALAR" ]
@@ -102,27 +102,27 @@
         },
         "max": {
             "type": "array",
-            "description": "Maximum value of each component in this attribute.",
+            "description": "Maximum value of each component in this accessor.",
             "items": {
                 "type": "number"
             },
             "minItems": 1,
             "maxItems": 16,
-            "gltf_detailedDescription": "Maximum value of each component in this attribute.  Array elements must be treated as having the same data type as accessor's `componentType`. Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be 1, 2, 3, 4, 9, or 16.\n\n`normalized` property has no effect on array values: they always correspond to the actual values stored in the buffer. When accessor is sparse, this property must contain max values of accessor data with sparse substitution applied."
+            "gltf_detailedDescription": "Maximum value of each component in this accessor.  Array elements **MUST** be treated as having the same data type as accessor's `componentType`. Both `min` and `max` arrays have the same length.  The length is determined by the value of the `type` property; it can be 1, 2, 3, 4, 9, or 16.\n\n`normalized` property has no effect on array values: they always correspond to the actual values stored in the buffer. When the accessor is sparse, this property must contain maximum values of accessor data with sparse substitution applied."
         },
         "min": {
             "type": "array",
-            "description": "Minimum value of each component in this attribute.",
+            "description": "Minimum value of each component in this accessor.",
             "items": {
                 "type": "number"
             },
             "minItems": 1,
             "maxItems": 16,
-            "gltf_detailedDescription": "Minimum value of each component in this attribute.  Array elements must be treated as having the same data type as accessor's `componentType`. Both min and max arrays have the same length.  The length is determined by the value of the type property; it can be 1, 2, 3, 4, 9, or 16.\n\n`normalized` property has no effect on array values: they always correspond to the actual values stored in the buffer. When accessor is sparse, this property must contain min values of accessor data with sparse substitution applied."
+            "gltf_detailedDescription": "Minimum value of each component in this accessor.  Array elements **MUST** be treated as having the same data type as accessor's `componentType`. Both `min` and `max` arrays have the same length.  The length is determined by the value of the `type` property; it can be 1, 2, 3, 4, 9, or 16.\n\n`normalized` property has no effect on array values: they always correspond to the actual values stored in the buffer. When the accessor is sparse, this property must contain minimum values of accessor data with sparse substitution applied."
         },
         "sparse": {
             "allOf": [ { "$ref": "accessor.sparse.schema.json" } ],
-            "description": "Sparse storage of attributes that deviate from their initialization value."
+            "description": "Sparse storage of elements that deviate from their initialization value."
         },
         "name": { },
         "extensions": { },

--- a/specification/2.0/schema/accessor.schema.json
+++ b/specification/2.0/schema/accessor.schema.json
@@ -60,9 +60,9 @@
         },
         "normalized": {
             "type": "boolean",
-            "description": "Specifies whether integer data values should be normalized before usage.",
+            "description": "Specifies whether integer data values are normalized before usage.",
             "default": false,
-            "gltf_detailedDescription": "Specifies whether integer data values should be normalized (`true`) to [0, 1] (for unsigned types) or to [-1, 1] (for signed types) when they are accessed. This property **MAY** be defined only for accessors that contain vertex attributes or animation output data. This property **MUST NOT** be defined for accessors with floating-point components.",
+            "gltf_detailedDescription": "Specifies whether integer data values are normalized (`true`) to [0, 1] (for unsigned types) or to [-1, 1] (for signed types) when they are accessed. This property **MAY** be defined only for accessors that contain vertex attributes or animation output data. This property **MUST NOT** be defined for accessors with floating-point components.",
             "gltf_webgl": "`normalized` parameter of `vertexAttribPointer()` "
         },
         "count": {
@@ -108,7 +108,7 @@
             },
             "minItems": 1,
             "maxItems": 16,
-            "gltf_detailedDescription": "Maximum value of each component in this accessor.  Array elements **MUST** be treated as having the same data type as accessor's `componentType`. Both `min` and `max` arrays have the same length.  The length is determined by the value of the `type` property; it can be 1, 2, 3, 4, 9, or 16.\n\n`normalized` property has no effect on array values: they always correspond to the actual values stored in the buffer. When the accessor is sparse, this property must contain maximum values of accessor data with sparse substitution applied."
+            "gltf_detailedDescription": "Maximum value of each component in this accessor.  Array elements **MUST** be treated as having the same data type as accessor's `componentType`. Both `min` and `max` arrays have the same length.  The length is determined by the value of the `type` property; it can be 1, 2, 3, 4, 9, or 16.\n\n`normalized` property has no effect on array values: they always correspond to the actual values stored in the buffer. When the accessor is sparse, this property **MUST** contain maximum values of accessor data with sparse substitution applied."
         },
         "min": {
             "type": "array",
@@ -118,7 +118,7 @@
             },
             "minItems": 1,
             "maxItems": 16,
-            "gltf_detailedDescription": "Minimum value of each component in this accessor.  Array elements **MUST** be treated as having the same data type as accessor's `componentType`. Both `min` and `max` arrays have the same length.  The length is determined by the value of the `type` property; it can be 1, 2, 3, 4, 9, or 16.\n\n`normalized` property has no effect on array values: they always correspond to the actual values stored in the buffer. When the accessor is sparse, this property must contain minimum values of accessor data with sparse substitution applied."
+            "gltf_detailedDescription": "Minimum value of each component in this accessor.  Array elements **MUST** be treated as having the same data type as accessor's `componentType`. Both `min` and `max` arrays have the same length.  The length is determined by the value of the `type` property; it can be 1, 2, 3, 4, 9, or 16.\n\n`normalized` property has no effect on array values: they always correspond to the actual values stored in the buffer. When the accessor is sparse, this property **MUST** contain minimum values of accessor data with sparse substitution applied."
         },
         "sparse": {
             "allOf": [ { "$ref": "accessor.sparse.schema.json" } ],

--- a/specification/2.0/schema/accessor.sparse.indices.schema.json
+++ b/specification/2.0/schema/accessor.sparse.indices.schema.json
@@ -2,22 +2,21 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Accessor Sparse Indices",
     "type": "object",
-    "description": "Indices of those attributes that deviate from their initialization value.",
+    "description": "An object pointing to a buffer view containing the indices of deviating accessor values. The number of indices is equal to `accessor.sparse.count`. Indices **MUST** strictly increase.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "bufferView": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the bufferView with sparse indices. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target."
+            "description": "The index of the buffer view with sparse indices. The referenced buffer view **MUST NOT** have its `target` or `byteStride` properties defined. The buffer view and the optional `byteOffset` **MUST** be aligned to the `componentType` byte length."
         },
         "byteOffset": {
             "type": "integer",
-            "description": "The offset relative to the start of the bufferView in bytes. Must be aligned.",
+            "description": "The offset relative to the start of the buffer view in bytes.",
             "minimum": 0,
             "default": 0
         },
         "componentType": {
             "description": "The indices data type.",
-            "gltf_detailedDescription": "The indices data type.  Valid values correspond to WebGL enums: `5121` (UNSIGNED_BYTE), `5123` (UNSIGNED_SHORT), `5125` (UNSIGNED_INT).",
             "anyOf": [
                 {
                     "enum": [ 5121 ],

--- a/specification/2.0/schema/accessor.sparse.schema.json
+++ b/specification/2.0/schema/accessor.sparse.schema.json
@@ -2,22 +2,21 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Accessor Sparse",
     "type": "object",
-    "description": "Sparse storage of attributes that deviate from their initialization value.",
+    "description": "Sparse storage of accessor values that deviate from their initialization value.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "count": {
             "type": "integer",
-            "description": "Number of entries stored in the sparse array.",
-            "minimum": 1,
-            "gltf_detailedDescription": "The number of attributes encoded in this sparse accessor."
+            "description": "Number of deviating accessor values stored in the sparse array.",
+            "minimum": 1
         },
         "indices": {
             "allOf": [ { "$ref": "accessor.sparse.indices.schema.json" } ],
-            "description": "Index array of size `count` that points to those accessor attributes that deviate from their initialization value. Indices must strictly increase."
+            "description": "An object pointing to a buffer view containing the indices of deviating accessor values. The number of indices is equal to `count`. Indices **MUST** strictly increase."
         },
         "values": {
             "allOf": [ { "$ref": "accessor.sparse.values.schema.json" } ],
-            "description": "Array of size `count` times number of components, storing the displaced accessor attributes pointed by `indices`. Substituted values must have the same `componentType` and number of components as the base accessor."
+            "description": "An object pointing to a buffer view containing the deviating accessor values."
         },
         "extensions": { },
         "extras": { }

--- a/specification/2.0/schema/accessor.sparse.values.schema.json
+++ b/specification/2.0/schema/accessor.sparse.values.schema.json
@@ -2,16 +2,16 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Accessor Sparse Values",
     "type": "object",
-    "description": "Array of size `accessor.sparse.count` times number of components storing the displaced accessor attributes pointed by `accessor.sparse.indices`.",
+    "description": "An object pointing to a buffer view containing the deviating accessor values. The number of elements is equal to `accessor.sparse.count` times number of components. The elements have the same component type as the base accessor. The elements are tightly packed. Data **MUST** be aligned following the same rules as the base accessor.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "bufferView": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the bufferView with sparse values. Referenced bufferView can't have ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER target."
+            "description": "The index of the bufferView with sparse values. The referenced buffer view **MUST NOT** have its `target` or `byteStride` properties defined."
         },
         "byteOffset": {
             "type": "integer",
-            "description": "The offset relative to the start of the bufferView in bytes. Must be aligned.",
+            "description": "The offset relative to the start of the bufferView in bytes.",
             "minimum": 0,
             "default": 0
         },

--- a/specification/2.0/schema/animation.sampler.schema.json
+++ b/specification/2.0/schema/animation.sampler.schema.json
@@ -17,15 +17,15 @@
             "anyOf": [
                 {
                     "enum": [ "LINEAR" ],
-                    "description": "The animated values are linearly interpolated between keyframes. When targeting a rotation, spherical linear interpolation (slerp) **SHOULD** be used to interpolate quaternions. The number of output elements must equal the number of input elements."
+                    "description": "The animated values are linearly interpolated between keyframes. When targeting a rotation, spherical linear interpolation (slerp) **SHOULD** be used to interpolate quaternions. The number of output elements **MUST** equal the number of input elements."
                 },
                 {
                     "enum": [ "STEP" ],
-                    "description": "The animated values remain constant to the output of the first keyframe, until the next keyframe. The number of output elements must equal the number of input elements."
+                    "description": "The animated values remain constant to the output of the first keyframe, until the next keyframe. The number of output elements **MUST** equal the number of input elements."
                 },
                 {
                     "enum": [ "CUBICSPLINE" ],
-                    "description": "The animation's interpolation is computed using a cubic spline with specified tangents. The number of output elements must equal three times the number of input elements. For each input element, the output stores three elements, an in-tangent, a spline vertex, and an out-tangent. There **MUST** be at least two keyframes when using this interpolation."
+                    "description": "The animation's interpolation is computed using a cubic spline with specified tangents. The number of output elements **MUST** equal three times the number of input elements. For each input element, the output stores three elements, an in-tangent, a spline vertex, and an out-tangent. There **MUST** be at least two keyframes when using this interpolation."
                 },
                 {
                     "type": "string"

--- a/specification/2.0/schema/animation.sampler.schema.json
+++ b/specification/2.0/schema/animation.sampler.schema.json
@@ -8,7 +8,7 @@
         "input": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of an accessor containing keyframe input values, e.g., time.",
-            "gltf_detailedDescription": "The index of an accessor containing keyframe input values, e.g., time. That accessor must have componentType `FLOAT`. The values represent time in seconds with `time[0] >= 0.0`, and strictly increasing values, i.e., `time[n + 1] > time[n]`."
+            "gltf_detailedDescription": "The index of an accessor containing keyframe input values, e.g., time. That accessor **MUST** have floating-point components. The values represent time in seconds with `time[0] >= 0.0`, and strictly increasing values, i.e., `time[n + 1] > time[n]`."
         },
         "interpolation": {
             "description": "Interpolation algorithm.",
@@ -17,7 +17,7 @@
             "anyOf": [
                 {
                     "enum": [ "LINEAR" ],
-                    "description": "The animated values are linearly interpolated between keyframes. When targeting a rotation, spherical linear interpolation (slerp) should be used to interpolate quaternions. The number output of elements must equal the number of input elements."
+                    "description": "The animated values are linearly interpolated between keyframes. When targeting a rotation, spherical linear interpolation (slerp) **SHOULD** be used to interpolate quaternions. The number of output elements must equal the number of input elements."
                 },
                 {
                     "enum": [ "STEP" ],
@@ -25,7 +25,7 @@
                 },
                 {
                     "enum": [ "CUBICSPLINE" ],
-                    "description": "The animation's interpolation is computed using a cubic spline with specified tangents. The number of output elements must equal three times the number of input elements. For each input element, the output stores three elements, an in-tangent, a spline vertex, and an out-tangent. There must be at least two keyframes when using this interpolation."
+                    "description": "The animation's interpolation is computed using a cubic spline with specified tangents. The number of output elements must equal three times the number of input elements. For each input element, the output stores three elements, an in-tangent, a spline vertex, and an out-tangent. There **MUST** be at least two keyframes when using this interpolation."
                 },
                 {
                     "type": "string"
@@ -34,8 +34,7 @@
         },
         "output": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of an accessor, containing keyframe output values.",
-            "gltf_detailedDescription": "The index of an accessor containing keyframe output values. When targeting translation or scale paths, the `accessor.componentType` of the output values must be `FLOAT`. When targeting rotation or morph weights, the `accessor.componentType` of the output values must be `FLOAT` or normalized integer. For weights, each output element stores `SCALAR` values with a count equal to the number of morph targets."
+            "description": "The index of an accessor, containing keyframe output values."
         },
         "extensions": { },
         "extras": { }

--- a/specification/2.0/schema/animation.schema.json
+++ b/specification/2.0/schema/animation.schema.json
@@ -7,7 +7,7 @@
     "properties": {
         "channels": {
             "type": "array",
-            "description": "An array of channels, each of which targets an animation's sampler at a node's property. Different channels of the same animation can't have equal targets.",
+            "description": "An array of animation channels, each of which targets an animation's sampler at a node's property. Different channels of the same animation **MUST NOT** have the same targets.",
             "items": {
                 "$ref": "animation.channel.schema.json"
             },
@@ -15,7 +15,7 @@
         },
         "samplers": {
             "type": "array",
-            "description": "An array of samplers that combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).",
+            "description": "An array of animation samplers that combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).",
             "items": {
                 "$ref": "animation.sampler.schema.json"
             },

--- a/specification/2.0/schema/asset.schema.json
+++ b/specification/2.0/schema/asset.schema.json
@@ -15,12 +15,12 @@
         },
         "version": {
             "type": "string",
-            "description": "The glTF version that this asset targets.",
+            "description": "The glTF version in the form of `<major>.<minor>` that this asset targets.",
             "pattern": "^[0-9]+\\.[0-9]+$"
         },
         "minVersion": {
             "type": "string",
-            "description": "The minimum glTF version that this asset targets.",
+            "description": "The minimum glTF version in the form of `<major>.<minor>` that this asset targets.",
             "pattern": "^[0-9]+\\.[0-9]+$"
         },
         "extensions": { },

--- a/specification/2.0/schema/buffer.schema.json
+++ b/specification/2.0/schema/buffer.schema.json
@@ -7,9 +7,9 @@
     "properties": {
         "uri": {
             "type": "string",
-            "description": "The uri of the buffer.",
+            "description": "The URI (or IRI) of the buffer.",
             "format": "uriref",
-            "gltf_detailedDescription": "The uri of the buffer.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.",
+            "gltf_detailedDescription": "The URI (or IRI) of the buffer.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI.",
             "gltf_uriType": "application"
         },
         "byteLength": {

--- a/specification/2.0/schema/bufferView.schema.json
+++ b/specification/2.0/schema/bufferView.schema.json
@@ -26,11 +26,11 @@
             "minimum": 4,
             "maximum": 252,
             "multipleOf": 4,
-            "gltf_detailedDescription": "The stride, in bytes, between vertex attributes.  When this is not defined, data is tightly packed. When two or more accessors use the same bufferView, this field must be defined.",
+            "gltf_detailedDescription": "The stride, in bytes, between vertex attributes.  When this is not defined, data is tightly packed. When two or more accessors use the same buffer view, this field **MUST** be defined.",
             "gltf_webgl": "`vertexAttribPointer()` stride parameter"
         },
         "target": {
-            "description": "The target that the GPU buffer should be bound to.",
+            "description": "The hint representing the intended GPU buffer type to use with this buffer view.",
             "gltf_webgl": "`bindBuffer()`",
             "anyOf": [
                 {

--- a/specification/2.0/schema/camera.orthographic.schema.json
+++ b/specification/2.0/schema/camera.orthographic.schema.json
@@ -7,15 +7,15 @@
     "properties": {
         "xmag": {
             "type": "number",
-            "description": "The floating-point horizontal magnification of the view. Must not be zero."
+            "description": "The floating-point horizontal magnification of the view. This value **MUST NOT** be equal to zero."
         },
         "ymag": {
             "type": "number",
-            "description": "The floating-point vertical magnification of the view. Must not be zero."
+            "description": "The floating-point vertical magnification of the view. This value **MUST NOT** be equal to zero."
         },
         "zfar": {
             "type": "number",
-            "description": "The floating-point distance to the far clipping plane. `zfar` must be greater than `znear`.",
+            "description": "The floating-point distance to the far clipping plane. This value **MUST NOT** be equal to zero. `zfar` **MUST** be greater than `znear`.",
             "minimum": 0.0,
             "exclusiveMinimum": true
         },

--- a/specification/2.0/schema/camera.orthographic.schema.json
+++ b/specification/2.0/schema/camera.orthographic.schema.json
@@ -7,11 +7,11 @@
     "properties": {
         "xmag": {
             "type": "number",
-            "description": "The floating-point horizontal magnification of the view. This value **MUST NOT** be equal to zero."
+            "description": "The floating-point horizontal magnification of the view. This value **MUST NOT** be equal to zero. This value **SHOULD NOT** be negative."
         },
         "ymag": {
             "type": "number",
-            "description": "The floating-point vertical magnification of the view. This value **MUST NOT** be equal to zero."
+            "description": "The floating-point vertical magnification of the view. This value **MUST NOT** be equal to zero. This value **SHOULD NOT** be negative."
         },
         "zfar": {
             "type": "number",

--- a/specification/2.0/schema/camera.perspective.schema.json
+++ b/specification/2.0/schema/camera.perspective.schema.json
@@ -23,7 +23,7 @@
             "description": "The floating-point distance to the far clipping plane.",
             "minimum": 0.0,
             "exclusiveMinimum": true,
-            "gltf_detailedDescription": "The floating-point distance to the far clipping plane. When defined, `zfar` must be greater than `znear`. If `zfar` is undefined, client implementations **SHOULD** use infinite projection matrix."
+            "gltf_detailedDescription": "The floating-point distance to the far clipping plane. When defined, `zfar` **MUST** be greater than `znear`. If `zfar` is undefined, client implementations **SHOULD** use infinite projection matrix."
         },
         "znear": {
             "type": "number",

--- a/specification/2.0/schema/camera.perspective.schema.json
+++ b/specification/2.0/schema/camera.perspective.schema.json
@@ -10,7 +10,7 @@
             "description": "The floating-point aspect ratio of the field of view.",
             "minimum": 0.0,
             "exclusiveMinimum": true,
-            "gltf_detailedDescription": "The floating-point aspect ratio of the field of view. When this is undefined, the aspect ratio of the canvas is used."
+            "gltf_detailedDescription": "The floating-point aspect ratio of the field of view. When undefined, the aspect ratio of the rendering viewport **MUST** be used."
         },
         "yfov": {
             "type": "number",
@@ -23,7 +23,7 @@
             "description": "The floating-point distance to the far clipping plane.",
             "minimum": 0.0,
             "exclusiveMinimum": true,
-            "gltf_detailedDescription": "The floating-point distance to the far clipping plane. When defined, `zfar` must be greater than `znear`. If `zfar` is undefined, runtime must use infinite projection matrix."
+            "gltf_detailedDescription": "The floating-point distance to the far clipping plane. When defined, `zfar` must be greater than `znear`. If `zfar` is undefined, client implementations **SHOULD** use infinite projection matrix."
         },
         "znear": {
             "type": "number",

--- a/specification/2.0/schema/camera.schema.json
+++ b/specification/2.0/schema/camera.schema.json
@@ -2,20 +2,20 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Camera",
     "type": "object",
-    "description": "A camera's projection.  A node can reference a camera to apply a transform to place the camera in the scene.",
+    "description": "A camera's projection.  A node **MAY** reference a camera to apply a transform to place the camera in the scene.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "orthographic": {
             "allOf": [ { "$ref": "camera.orthographic.schema.json" } ],
-            "description": "An orthographic camera containing properties to create an orthographic projection matrix."
+            "description": "An orthographic camera containing properties to create an orthographic projection matrix. This property **MUST NOT** be defined when `perspective` is defined."
         },
         "perspective": {
             "allOf": [ { "$ref": "camera.perspective.schema.json" } ],
-            "description": "A perspective camera containing properties to create a perspective projection matrix."
+            "description": "A perspective camera containing properties to create a perspective projection matrix. This property **MUST NOT** be defined when `orthographic` is defined."
         },
         "type": {
             "description": "Specifies if the camera uses a perspective or orthographic projection.",
-            "gltf_detailedDescription": "Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's `perspective` or `orthographic` property will be defined.",
+            "gltf_detailedDescription": "Specifies if the camera uses a perspective or orthographic projection.  Based on this, either the camera's `perspective` or `orthographic` property **MUST** be defined.",
             "anyOf": [
                 {
                     "enum": [ "perspective" ]

--- a/specification/2.0/schema/extension.schema.json
+++ b/specification/2.0/schema/extension.schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Extension",
     "type": "object",
-    "description": "Dictionary object with extension-specific objects.",
+    "description": "JSON object with extension-specific objects.",
     "properties": {
     },
     "additionalProperties": {

--- a/specification/2.0/schema/extras.schema.json
+++ b/specification/2.0/schema/extras.schema.json
@@ -2,5 +2,5 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Extras",
     "description": "Application-specific data.",
-    "gltf_sectionDescription": "**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability."
+    "gltf_sectionDescription": "Although `extras` **MAY** have any type, it is common for applications to store and access custom data as key/value pairs. Therefore, `extras` **SHOULD** be a JSON object rather than a primitive value for best portability."
 }

--- a/specification/2.0/schema/glTF.schema.json
+++ b/specification/2.0/schema/glTF.schema.json
@@ -7,7 +7,7 @@
     "properties": {
         "extensionsUsed": {
             "type": "array",
-            "description": "Names of glTF extensions used somewhere in this asset.",
+            "description": "Names of glTF extensions used in this asset.",
             "items": {
                 "type": "string"
             },
@@ -117,7 +117,8 @@
         },
         "scene": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the default scene."
+            "description": "The index of the default scene.",
+            "gltf_detailedDescription": "The index of the default scene.  This property **MUST NOT** be defined, when `scenes` is undefined."
         },
         "scenes": {
             "type": "array",

--- a/specification/2.0/schema/image.schema.json
+++ b/specification/2.0/schema/image.schema.json
@@ -2,14 +2,14 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Image",
     "type": "object",
-    "description": "Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.",
+    "description": "Image data used to create a texture. Image **MAY** be referenced by an URI (or IRI) or a buffer view index.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "uri": {
             "type": "string",
-            "description": "The uri of the image.",
+            "description": "The URI (or IRI) of the image.",
             "format": "uriref",
-            "gltf_detailedDescription": "The uri of the image.  Relative paths are relative to the .gltf file.  Instead of referencing an external file, the uri can also be a data-uri.  The image format must be jpg or png.",
+            "gltf_detailedDescription": "The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.",
             "gltf_uriType": "image"
         },
         "mimeType": {
@@ -24,11 +24,11 @@
                     "type": "string"
                 }
             ],
-            "description": "The image's MIME type. Required if `bufferView` is defined."
+            "description": "The image's media type. This field **MUST** be defined when `bufferView` is defined."
         },
         "bufferView": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the bufferView that contains the image. Use this instead of the image's uri property."
+            "description": "The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined."
         },
         "name": { },
         "extensions": { },

--- a/specification/2.0/schema/material.normalTextureInfo.schema.json
+++ b/specification/2.0/schema/material.normalTextureInfo.schema.json
@@ -8,9 +8,9 @@
         "texCoord": { },
         "scale": {
             "type": "number",
-            "description": "The scalar multiplier applied to each normal vector of the normal texture.",
+            "description": "The scalar parameter applied to each normal vector of the normal texture.",
             "default": 1.0,
-            "gltf_detailedDescription": "The scalar multiplier applied to each normal vector of the texture. This value scales the normal vector using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`. This value is ignored if normalTexture is not specified. This value is linear."
+            "gltf_detailedDescription": "The scalar parameter applied to each normal vector of the texture. This value scales the normal vector in X and Y directions using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`."
         },
         "extensions": { },
         "extras": { }

--- a/specification/2.0/schema/material.occlusionTextureInfo.schema.json
+++ b/specification/2.0/schema/material.occlusionTextureInfo.schema.json
@@ -12,7 +12,7 @@
             "default": 1.0,
             "minimum": 0.0,
             "maximum": 1.0,
-            "gltf_detailedDescription": "A scalar multiplier controlling the amount of occlusion applied. A value of 0.0 means no occlusion. A value of 1.0 means full occlusion. This value affects the resulting color using the formula: `occludedColor = lerp(color, color * <sampled occlusion texture value>, <occlusion strength>)`. This value is ignored if the corresponding texture is not specified. This value is linear."
+            "gltf_detailedDescription": "A scalar parameter controlling the amount of occlusion applied. A value of `0.0` means no occlusion. A value of `1.0` means full occlusion. This value affects the final occlusion value as: `1.0 + strength * (<sampled occlusion texture value> - 1.0)`."
         },
         "extensions": { },
         "extras": { }

--- a/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
+++ b/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
@@ -12,37 +12,37 @@
                 "minimum": 0.0,
                 "maximum": 1.0
             },
-            "description": "The material's base color factor.",
+            "description": "The factors for the base color of the material.",
             "default": [ 1.0, 1.0, 1.0, 1.0 ],
             "minItems": 4,
             "maxItems": 4,
-            "gltf_detailedDescription": "The RGBA components of the base color of the material. The fourth component (A) is the alpha coverage of the material. The `alphaMode` property specifies how alpha is interpreted. These values are linear. If a baseColorTexture is specified, this value is multiplied with the texel values."
+            "gltf_detailedDescription": "The factors for the base color of the material. This value defines linear multipliers for the sampled texels of the base color texture."
         },
         "baseColorTexture": {
             "allOf": [ { "$ref": "textureInfo.schema.json" } ],
             "description": "The base color texture.",
-            "gltf_detailedDescription": "The base color texture. The first three components (RGB) are encoded with the sRGB transfer function. They specify the base color of the material. If the fourth component (A) is present, it represents the linear alpha coverage of the material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property specifies how alpha is interpreted. The stored texels must not be premultiplied."
+            "gltf_detailedDescription": "The base color texture. The first three components (RGB) **MUST** be encoded with the sRGB transfer function. They specify the base color of the material. If the fourth component (A) is present, it represents the linear alpha coverage of the material. Otherwise, the alpha coverage is equal to `1.0`. The `material.alphaMode` property specifies how alpha is interpreted. The stored texels **MUST NOT** be premultiplied. When undefined, the texture **MUST** be sampled as having `1.0` in all components."
         },
         "metallicFactor": {
             "type": "number",
-            "description": "The metalness of the material.",
+            "description": "The factor for the metalness of the material.",
             "default": 1.0,
             "minimum": 0.0,
             "maximum": 1.0,
-            "gltf_detailedDescription": "The metalness of the material. A value of 1.0 means the material is a metal. A value of 0.0 means the material is a dielectric. Values in between are for blending between metals and dielectrics such as dirty metallic surfaces. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the metallic texel values."
+            "gltf_detailedDescription": "The factor for the metalness of the material. This value defines a linear multiplier for the sampled metalness values of the metallic-roughness texture."
         },
         "roughnessFactor": {
             "type": "number",
-            "description": "The roughness of the material.",
+            "description": "The factor for the roughness of the material.",
             "default": 1.0,
             "minimum": 0.0,
             "maximum": 1.0,
-            "gltf_detailedDescription": "The roughness of the material. A value of 1.0 means the material is completely rough. A value of 0.0 means the material is completely smooth. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the roughness texel values."
+            "gltf_detailedDescription": "The factor for the roughness of the material. This value defines a linear multiplier for the sampled roughness values of the metallic-roughness texture."
         },
         "metallicRoughnessTexture": {
             "allOf": [ { "$ref": "textureInfo.schema.json" } ],
             "description": "The metallic-roughness texture.",
-            "gltf_detailedDescription": "The metallic-roughness texture. The metalness values are sampled from the B channel. The roughness values are sampled from the G channel. These values are linear. If other channels are present (R or A), they are ignored for metallic-roughness calculations."
+            "gltf_detailedDescription": "The metallic-roughness texture. The metalness values are sampled from the B channel. The roughness values are sampled from the G channel. These values **MUST** be encoded with a linear transfer function. If other channels are present (R or A), they **MUST** be ignored for metallic-roughness calculations. When undefined, the texture **MUST** be sampled as having `1.0` in G and B components."
         },
         "extensions": { },
         "extras": { }

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -20,7 +20,7 @@
         "occlusionTexture": {
             "allOf": [ { "$ref": "material.occlusionTextureInfo.schema.json" } ],
             "description": "The occlusion texture.",
-            "gltf_detailedDescription": "The occlusion texture. The occlusion values are linearly sampled from the R channel. Higher values indicate areas that should receive full indirect lighting and lower values indicate no indirect lighting. If other channels are present (GBA), they **MUST** be ignored for occlusion calculations. When undefined, the material does not have an occlusion texture."
+            "gltf_detailedDescription": "The occlusion texture. The occlusion values are linearly sampled from the R channel. Higher values indicate areas that receive full indirect lighting and lower values indicate no indirect lighting. If other channels are present (GBA), they **MUST** be ignored for occlusion calculations. When undefined, the material does not have an occlusion texture."
         },
         "emissiveTexture": {
             "allOf": [ { "$ref": "textureInfo.schema.json" } ],
@@ -73,7 +73,7 @@
             "type": "boolean",
             "default": false,
             "description": "Specifies whether the material is double sided.",
-            "gltf_detailedDescription": "Specifies whether the material is double sided. When this value is false, back-face culling is enabled. When this value is true, back-face culling is disabled and double sided lighting is enabled. The back-face must have its normals reversed before the lighting equation is evaluated."
+            "gltf_detailedDescription": "Specifies whether the material is double sided. When this value is false, back-face culling is enabled. When this value is true, back-face culling is disabled and double sided lighting is enabled. The back-face **MUST** have its normals reversed before the lighting equation is evaluated."
         }
     },
      "dependencies" : {

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -10,22 +10,22 @@
         "extras": { },
         "pbrMetallicRoughness": {
             "allOf": [ { "$ref": "material.pbrMetallicRoughness.schema.json" } ],
-            "description": "A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply."
+            "description": "A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When undefined, all the default values of `pbrMetallicRoughness` **MUST* apply."
         },
         "normalTexture": {
             "allOf": [ { "$ref": "material.normalTextureInfo.schema.json" } ],
-            "description": "The normal map texture.",
-            "gltf_detailedDescription": "A tangent space normal map. The texture contains RGB components in linear space. Each texel represents the XYZ components of a normal vector in tangent space. Red [0 to 255] maps to X [-1 to 1]. Green [0 to 255] maps to Y [-1 to 1]. Blue [128 to 255] maps to Z [1/255 to 1]. The normal vectors use the convention +X is right and +Y is up. +Z points toward the viewer. In GLSL, this vector would be unpacked like so: `vec3 normalVector = tex2D(<sampled normal map texture value>, texCoord) * 2 - 1`. Client implementations should normalize the normal vectors before using them in lighting equations."
+            "description": "The tangent space normal texture.",
+            "gltf_detailedDescription": "The tangent space normal texture. The texture encodes RGB components with linear transfer function. Each texel represents the XYZ components of a normal vector in tangent space. The normal vectors use the convention +X is right and +Y is up. +Z points toward the viewer. If a fourth component (A) is present, it **MUST** be ignored. When undefined, the material does not have a tangent space normal texture."
         },
         "occlusionTexture": {
             "allOf": [ { "$ref": "material.occlusionTextureInfo.schema.json" } ],
-            "description": "The occlusion map texture.",
-            "gltf_detailedDescription": "The occlusion map texture. The occlusion values are sampled from the R channel. Higher values indicate areas that should receive full indirect lighting and lower values indicate no indirect lighting. These values are linear. If other channels are present (GBA), they are ignored for occlusion calculations."
+            "description": "The occlusion texture.",
+            "gltf_detailedDescription": "The occlusion texture. The occlusion values are linearly sampled from the R channel. Higher values indicate areas that should receive full indirect lighting and lower values indicate no indirect lighting. If other channels are present (GBA), they **MUST** be ignored for occlusion calculations. When undefined, the material does not have an occlusion texture."
         },
         "emissiveTexture": {
             "allOf": [ { "$ref": "textureInfo.schema.json" } ],
-            "description": "The emissive map texture.",
-            "gltf_detailedDescription": "The emissive map controls the color and intensity of the light being emitted by the material. This texture contains RGB components encoded with the sRGB transfer function. If a fourth component (A) is present, it is ignored."
+            "description": "The emissive texture.",
+            "gltf_detailedDescription": "The emissive texture. It controls the color and intensity of the light being emitted by the material. This texture contains RGB components encoded with the sRGB transfer function. If a fourth component (A) is present, it **MUST** be ignored. When undefined, the texture **MUST** be sampled as having `1.0` in RGB components."
         },
         "emissiveFactor": {
             "type": "array",
@@ -37,13 +37,13 @@
             "minItems": 3,
             "maxItems": 3,
             "default": [ 0.0, 0.0, 0.0 ],
-            "description": "The emissive color of the material.",
-            "gltf_detailedDescription": "The RGB components of the emissive color of the material. These values are linear. If an emissiveTexture is specified, this value is multiplied with the texel values."
+            "description": "The factors for the emissive color of the material.",
+            "gltf_detailedDescription": "The factors for the emissive color of the material. This value defines linear multipliers for the sampled texels of the emissive texture."
         },
         "alphaMode": {
             "default": "OPAQUE",
             "description": "The alpha rendering mode of the material.",
-            "gltf_detailedDescription": "The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.",
+            "gltf_detailedDescription": "The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the base color.",
             "anyOf": [
                 {
                     "enum": [ "OPAQUE" ],
@@ -51,7 +51,7 @@
                 },
                 {
                     "enum": [ "MASK" ],
-                    "description": "The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value."
+                    "description": "The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified `alphaCutoff` value."
                 },
                 {
                     "enum": [ "BLEND" ],
@@ -67,7 +67,7 @@
             "minimum": 0.0,
             "default": 0.5,
             "description": "The alpha cutoff value of the material.",
-            "gltf_detailedDescription": "Specifies the cutoff threshold when in `MASK` mode. If the alpha value is greater than or equal to this value then it is rendered as fully opaque, otherwise, it is rendered as fully transparent. A value greater than 1.0 will render the entire material as fully transparent. This value is ignored for other modes."
+            "gltf_detailedDescription": "Specifies the cutoff threshold when in `MASK` alpha mode. If the alpha value is greater than or equal to this value then it is rendered as fully opaque, otherwise, it is rendered as fully transparent. A value greater than `1.0` will render the entire material as fully transparent. This value **MUST** be ignored for other alpha modes. When `alphaMode` is not defined, this value **MUST NOT** be defined."
         },
         "doubleSided": {
             "type": "boolean",

--- a/specification/2.0/schema/mesh.primitive.schema.json
+++ b/specification/2.0/schema/mesh.primitive.schema.json
@@ -7,7 +7,7 @@
     "properties": {
         "attributes": {
             "type": "object",
-            "description": "A dictionary object, where each key corresponds to mesh attribute semantic and each value is the index of the accessor containing attribute's data.",
+            "description": "A plain JSON object, where each key corresponds to a mesh attribute semantic and each value is the index of the accessor containing attribute's data.",
             "minProperties": 1,
             "additionalProperties": {
                 "$ref": "glTFid.schema.json"
@@ -15,17 +15,17 @@
         },
         "indices": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the accessor that contains the indices.",
-            "gltf_detailedDescription": "The index of the accessor that contains mesh indices.  When this is not defined, the primitives should be rendered without indices using `drawArrays()`.  When defined, the accessor must contain indices: the `bufferView` referenced by the accessor should have a `target` equal to 34963 (ELEMENT_ARRAY_BUFFER); `componentType` must be 5121 (UNSIGNED_BYTE), 5123 (UNSIGNED_SHORT) or 5125 (UNSIGNED_INT), the latter may require enabling additional hardware support; `type` must be `\"SCALAR\"`. For triangle primitives, the front face has a counter-clockwise (CCW) winding order. Values of the index accessor must not include the maximum value for the given component type, which triggers primitive restart in several graphics APIs and would require client implementations to rebuild the index buffer. Primitive restart values are disallowed and all index values must refer to actual vertices. As a result, the index accessor's values must not exceed the following maxima: BYTE `< 255`, UNSIGNED_SHORT `< 65535`, UNSIGNED_INT `< 4294967295`."
+            "description": "The index of the accessor that contains the vertex indices.",
+            "gltf_detailedDescription": "The index of the accessor that contains the vertex indices.  When this is undefined, the primitive defines non-indexed geometry.  When defined, the accessor **MUST** have `SCALAR` type and an unsigned integer component type.",
+            "gltf_webgl": "`drawElements()` when defined and `drawArrays()` otherwise."
         },
         "material": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of the material to apply to this primitive when rendering."
         },
         "mode": {
-            "description": "The type of primitives to render.",
+            "description": "The topology type of primitives to render.",
             "default": 4,
-            "gltf_detailedDescription": "The type of primitives to render. All valid values correspond to WebGL enums.",
             "anyOf": [
                 {
                     "enum": [ 0 ],
@@ -69,14 +69,14 @@
         },
         "targets": {
             "type": "array",
-            "description": "An array of Morph Targets, each  Morph Target is a dictionary mapping attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their deviations in the Morph Target.",
+            "description": "An array of morph targets.",
             "items": {
                 "type": "object",
                 "minProperties": 1,
                 "additionalProperties": {
                     "$ref": "glTFid.schema.json"
                 },
-                "description": "A dictionary object specifying attributes displacements in a Morph Target, where each key corresponds to one of the three supported attribute semantic (`POSITION`, `NORMAL`, or `TANGENT`) and each value is the index of the accessor containing the attribute displacements' data."
+                "description": "A plain JSON object specifying attributes displacements in a morph target, where each key corresponds to one of the three supported attribute semantic (`POSITION`, `NORMAL`, or `TANGENT`) and each value is the index of the accessor containing the attribute displacements' data."
             },
             "minItems": 1
         },

--- a/specification/2.0/schema/mesh.schema.json
+++ b/specification/2.0/schema/mesh.schema.json
@@ -2,12 +2,12 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Mesh",
     "type": "object",
-    "description": "A set of primitives to be rendered.  A node can contain one mesh.  A node's transform places the mesh in the scene.",
+    "description": "A set of primitives to be rendered.  Its global transform is defined by a node that references it.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "primitives": {
             "type": "array",
-            "description": "An array of primitives, each defining geometry to be rendered with a material.",
+            "description": "An array of primitives, each defining geometry to be rendered.",
             "items": {
                 "$ref": "mesh.primitive.schema.json"
             },

--- a/specification/2.0/schema/node.schema.json
+++ b/specification/2.0/schema/node.schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Node",
     "type": "object",
-    "description": "A node in the node hierarchy.  When the node contains `skin`, all `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node can have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties may be present; `matrix` will not be present.",
+    "description": "A node in the node hierarchy.  When the node contains `skin`, all `mesh.primitives` **MUST** contain `JOINTS_0` and `WEIGHTS_0` attributes.  A node **MAY** have either a `matrix` or any combination of `translation`/`rotation`/`scale` (TRS) properties. TRS properties are converted to matrices and postmultiplied in the `T * R * S` order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation. If none are provided, the transform is the identity. When a node is targeted for animation (referenced by an animation.channel.target), `matrix` **MUST NOT** be present.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "camera": {
@@ -21,7 +21,7 @@
         "skin": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of the skin referenced by this node.",
-            "gltf_detailedDescription": "The index of the skin referenced by this node. When a skin is referenced by a node within a scene, all joints used by the skin must belong to the same scene."
+            "gltf_detailedDescription": "The index of the skin referenced by this node. When a skin is referenced by a node within a scene, all joints used by the skin **MUST** belong to the same scene. When defined, `mesh` **MUST** also be defined."
         },
         "matrix": {
             "type": "array",
@@ -32,7 +32,6 @@
             "minItems": 16,
             "maxItems": 16,
             "default": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ],
-            "gltf_detailedDescription": "A floating-point 4x4 transformation matrix stored in column-major order.",
             "gltf_webgl": "`uniformMatrix4fv()` with the transpose parameter equal to false"
         },
         "mesh": {
@@ -73,7 +72,7 @@
         },
         "weights": {
             "type": "array",
-            "description": "The weights of the instantiated Morph Target. Number of elements must match number of Morph Targets of used mesh.",
+            "description": "The weights of the instantiated morph target. Number of elements **MUST** match the number of Morph Targets of used mesh. When defined, `mesh` **MUST** also be defined.",
             "minItems": 1,
             "items": {
                 "type": "number"

--- a/specification/2.0/schema/sampler.schema.json
+++ b/specification/2.0/schema/sampler.schema.json
@@ -7,8 +7,7 @@
     "properties": {
         "magFilter": {
             "description": "Magnification filter.",
-            "gltf_detailedDescription": "Magnification filter.  Valid values correspond to WebGL enums: `9728` (NEAREST) and `9729` (LINEAR).",
-            "gltf_webgl": "`texParameterf()` with pname equal to TEXTURE_MAG_FILTER",
+            "gltf_webgl": "`samplerParameteri()` with pname equal to TEXTURE_MAG_FILTER",
             "anyOf": [
                 {
                     "enum": [ 9728 ],
@@ -27,8 +26,7 @@
         },
         "minFilter": {
             "description": "Minification filter.",
-            "gltf_detailedDescription": "Minification filter.  All valid values correspond to WebGL enums.",
-            "gltf_webgl": "`texParameterf()` with pname equal to TEXTURE_MIN_FILTER",
+            "gltf_webgl": "`samplerParameteri()` with pname equal to TEXTURE_MIN_FILTER",
             "anyOf": [
                 {
                     "enum": [ 9728 ],
@@ -66,10 +64,10 @@
             ]
         },
         "wrapS": {
-            "description": "s wrapping mode.",
+            "description": "S (U) wrapping mode.",
             "default": 10497,
             "gltf_detailedDescription": "S (U) wrapping mode.  All valid values correspond to WebGL enums.",
-            "gltf_webgl": "`texParameterf()` with pname equal to TEXTURE_WRAP_S",
+            "gltf_webgl": "`samplerParameteri()` with pname equal to TEXTURE_WRAP_S",
             "anyOf": [
                 {
                     "enum": [ 33071 ],
@@ -92,10 +90,9 @@
             ]
         },
         "wrapT": {
-            "description": "t wrapping mode.",
+            "description": "T (V) wrapping mode.",
             "default": 10497,
-            "gltf_detailedDescription": "T (V) wrapping mode.  All valid values correspond to WebGL enums.",
-            "gltf_webgl": "`texParameterf()` with pname equal to TEXTURE_WRAP_T",
+            "gltf_webgl": "`samplerParameteri()` with pname equal to TEXTURE_WRAP_T",
             "anyOf": [
                 {
                     "enum": [ 33071 ],
@@ -120,6 +117,5 @@
         "name": { },
         "extensions": { },
         "extras": { }
-    },
-    "gltf_webgl": "`texParameterf()`"
+    }
 }

--- a/specification/2.0/schema/skin.schema.json
+++ b/specification/2.0/schema/skin.schema.json
@@ -7,12 +7,13 @@
     "properties": {
         "inverseBindMatrices": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the accessor containing the floating-point 4x4 inverse-bind matrices.  The default is that each matrix is a 4x4 identity matrix, which implies that inverse-bind matrices were pre-applied."
+            "description": "The index of the accessor containing the floating-point 4x4 inverse-bind matrices.",
+            "gltf_detailedDescription": "The index of the accessor containing the floating-point 4x4 inverse-bind matrices. Its `accessor.count` property **MUST** be greater than or equal to the number of elements of the `joints` array. When undefined, each matrix is a 4x4 identity matrix."
         },
         "skeleton": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of the node used as a skeleton root.",
-            "gltf_detailedDescription": "The index of the node used as a skeleton root. The node must be the closest common root of the joints hierarchy or a direct or indirect parent node of the closest common root."
+            "gltf_detailedDescription": "The index of the node used as a skeleton root. The node **MUST** be the closest common root of the joints hierarchy or a direct or indirect parent node of the closest common root."
         },
         "joints": {
             "type": "array",
@@ -22,7 +23,7 @@
             },
             "uniqueItems": true,
             "minItems": 1,
-            "gltf_detailedDescription": "Indices of skeleton nodes, used as joints in this skin.  The array length must be the same as the `count` property of the `inverseBindMatrices` accessor (when defined)."
+            "gltf_detailedDescription": "Indices of skeleton nodes, used as joints in this skin."
         },
         "name": { },
         "extensions": { },

--- a/specification/2.0/schema/texture.schema.json
+++ b/specification/2.0/schema/texture.schema.json
@@ -7,11 +7,11 @@
     "properties": {
         "sampler": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering should be used."
+            "description": "The index of the sampler used by this texture. When undefined, a sampler with repeat wrapping and auto filtering **SHOULD** be used."
         },
         "source": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the image used by this texture. When undefined, it is expected that an extension or other mechanism will supply an alternate texture source, otherwise behavior is undefined."
+            "description": "The index of the image used by this texture. When undefined, an extension or other mechanism **SHOULD** supply an alternate texture source, otherwise behavior is undefined."
         },
         "name": { },
         "extensions": { },

--- a/specification/2.0/schema/textureInfo.schema.json
+++ b/specification/2.0/schema/textureInfo.schema.json
@@ -14,7 +14,7 @@
             "description": "The set index of texture's TEXCOORD attribute used for texture coordinate mapping.",
             "default": 0,
             "minimum": 0,
-            "gltf_detailedDescription": "This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in mesh.primitives.attributes (e.g. A value of `0` corresponds to `TEXCOORD_0`). Mesh must have corresponding texture coordinate attributes for the material to be applicable to it."
+            "gltf_detailedDescription": "This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in `mesh.primitives.attributes` (e.g. a value of `0` corresponds to `TEXCOORD_0`). A mesh primitive **MUST** have the corresponding texture coordinate attributes for the material to be applicable to it."
         },
         "extensions": { },
         "extras": { }


### PR DESCRIPTION
### General updates
* Use BCP 14 normative language.
* Properly list all external references.
* Expand the Samplers section.
* Expand material texture descriptions.
* Reduce emphasis on OpenGL.
* Minor language edits.

### Specific updates
* Restrict certain PNG and JPEG variations.
* Full rewrite of JSON encoding section, relaxing some of previously-unenforced restrictions.
* Explicitly allow IRIs.
* Explicitly disallow `bufferView.byteStride` for buffer views that do not contain vertex attributes.
* Elaborate on image media types handling.
* Restore accidentally removed vertex color usage.
* Discourage use of zero-length GLB BIN chunks.