### PR TITLE
Add PlayCanvas to KHR_texture_basisu and KHR_texture_transform

### DIFF
--- a/extensions/2.0/Khronos/KHR_texture_basisu/README.md
+++ b/extensions/2.0/Khronos/KHR_texture_basisu/README.md
@@ -213,6 +213,7 @@ Authoring:
 Viewing:
 
 - [Babylon](https://www.babylonjs.com/)
+- [PlayCanvas](https://playcanvas.com/)
 - [three.js](https://threejs.org/)
 
 ## Resources

--- a/extensions/2.0/Khronos/KHR_texture_transform/README.md
+++ b/extensions/2.0/Khronos/KHR_texture_transform/README.md
@@ -105,6 +105,7 @@ This example inverts the T axis, effectively defining a bottom-left origin.
 
 * [UnityGLTF](https://github.com/KhronosGroup/UnityGLTF)
 * [Babylon.js](https://www.babylonjs.com/)
+* [PlayCanvas](https://playcanvas.com/)
 * [Three.js](https://threejs.org/)
 * [Blender](https://docs.blender.org/manual/en/2.81/addons/import_export/io_scene_gltf2.html#uv-mapping)
 * [Gestaltor](https://gestaltor.io/)


### PR DESCRIPTION
[PlayCanvas v1.46.0](https://github.com/playcanvas/engine/releases/tag/v1.46.0) adds support for both `KHR_texture_basisu` and `KHR_texture_transform` glTF 2.0 extensions. This PR adds the engine to both extensions' lists of implementations.