### PR TITLE
Update EXT_meshopt_compression specification to fix and clarify bitstream format

### DIFF
--- a/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+++ b/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
@@ -3,6 +3,7 @@
 ## Contributors
 
 * Arseny Kapoulkine, [@zeuxcg](https://twitter.com/zeuxcg)
+* Jasper St. Pierre, [@JasperRLZ] (https://twitter.com/JasperRLZ)
 
 ## Status
 
@@ -78,6 +79,7 @@ For the extension object to be valid, the following must hold:
 - When `mode` is `"TRIANGLES"` or `"INDICES"`, `filter` must be equal to `"NONE"` or omitted
 - When `filter` is `"OCTAHEDRAL"`, `byteStride` must be equal to 4 or 8
 - When `filter` is `"QUATERNION"`, `byteStride` must be equal to 8
+- When `filter` is `"EXPONENTIAL"`, `byteStride` must be divisible by 4
 
 The type of compressed data must match the bitstream specification (note that each `mode` specifies a different bitstream format).
 
@@ -191,31 +193,52 @@ The encoded stream structure is as follows:
 - One or more attribute blocks, detailed below
 - Tail block, which consists of a baseline element stored verbatim, padded to 32 bytes
 
-Each attribute block stores a sequence of deltas, with the first element in the first block using the deltas from the baseline element stored in the tail block, and each subsequent element using the deltas from the previous element. The attribute block always stores an integer number of elements, with that number computed as follows:
+Note that there is no easy way to directly calculate the length of a stream; instead, it is expected that the user passes a correctly sized stream so that the tail block element can be found.
+
+Each attribute block stores a sequence of deltas, with the first element in the first block using the deltas from the baseline element stored in the tail block, and each subsequent element using the deltas from the previous element. The attribute block always stores up to an integer number of elements, with that number computed as follows:
 
 ```
-blockSize = min((8192 / byteStride) & ~15, 256)
+attrBlockMaxElementCount = min((8192 / byteStride) & ~15, 256)
 ```
 
-The attribute block structure consists of `byteStride` blocks (one for each byte of the element) with the following structure:
-
-- Header bits, 2 bits for each group of 16 elements (`blockSize`/16 2-bit values), padded to a byte
-- Delta blocks, with variable number of bytes stored for each group of 16 elements
-
-Each group always contains 16 elements; when the number of elements that needs to be encoded isn't divisible by 16, it gets rounded up and the remaining elements are ignored after decoding.
-
-Header bits are stored from least significant to most significant bit - header bits for 4 consecutive groups of 16 elements are packed in a byte together as follows:
+Each attribute block consists of `byteStride` "data blocks" (one for each byte of the element), and each "data block" contains deltas stored for groups of elements. Each group always contains 16 elements; when the number of elements that needs to be encoded isn't divisible by 16, it gets rounded up and the remaining elements are ignored after decoding. In other terms:
 
 ```
-bits0 | (bits1 << 2) | (bits2 << 4) | (bits3 << 6)
+groupCount = ceil(attrBlockElementCount / 16)
+```
+
+The structure of each "data block" breaks down as follows:
+- Header bits, with 2 bits for each group
+- Delta blocks, with variable number of bytes stored for each group
+
+Header bits are stored from least significant to most significant bit - header bits for 4 consecutive groups are packed in a byte together as follows:
+
+```
+(headerBitsForGroup0 << 0) | (headerBitsForGroup1 << 2) | (headerBitsForGroup2 << 4) | (headerBitsForGroup3 << 6)
 ```
 
 The header bits establish the delta encoding mode (0-3) for each group of 16 elements that follows:
 
 - bits 0: All 16 byte deltas are 0; the size of the encoded block is 0 bytes
-- bits 1: Deltas are using 2-bit sentinel encoding; the size of the encoded block is [4..20] bytes
-- bits 2: Deltas are using 4-bit sentinel encoding; the size of the encoded block is [8..24] bytes
-- bits 3: All 16 byte deltas are stored verbatim; the size of the encoded block is 16 bytes
+- bits 1: Deltas are stored in 2-bit sentinel encoding; the size of the encoded block is [4..20] bytes
+- bits 2: Deltas are stored in 4-bit sentinel encoding; the size of the encoded block is [8..24] bytes
+- bits 3: All 16 byte delta are stored as bytes; the size of the encoded block is 16 bytes
+
+When using the sentinel encoding, each delta is stored as a 2-bit or 4-bit value in a single 4-byte or 8-byte block, with deltas stored from most significant to least significant bit inside the byte. That is, the 2-bit encoding is packed as:
+
+```
+(delta3 << 0) | (delta2 << 2) | (delta1 << 4) | (delta0 << 6)
+```
+
+And the 4-bit encoding is packed as:
+
+```
+(delta1 << 0) | (delta1 << 4)
+```
+
+Note that this is not the same order as the packing of the header bits found above.
+
+A that has all bits set to 1 (corresponds to `3` for 2-bit encoding and `15` for 4-bit encoding) indicates that the real delta value is outside of the 2-bit or 4-bit range, and is stored as a full byte after the bit deltas for this group.
 
 Byte deltas are stored as zigzag-encoded differences between the byte values of the element and the byte values of the previous element in the same position; the zigzag encoding scheme works as follows:
 
@@ -224,19 +247,19 @@ encode(uint8_t v) = ((v & 0x80) != 0) ? ~(v << 1) : (v << 1)
 decode(uint8_t v) = ((v & 1) != 0) ? ~(v >> 1) : (v >> 1)
 ```
 
-When using the sentinel encoding, each delta is stored as a 2-bit or 4-bit value in a single 4-byte or 8-byte block, with deltas stored from most significant to least significant bit inside the byte (e.g. two 4-bit deltas are stored as `0xXY` where X is the zigzag encoding of the first delta, and Y is the zigzag encoding of the second delta). The encoded value of the delta that has all bits set to 1 (corresponds to `3` for 2-bit deltas and `15` for 4-bit deltas, which, when decoded, represents `-2` and `-8` respectively) indicates that the real delta value is outside of the 2-bit or 4-bit range and is stored as a full byte after the bit deltas for this group. For example, for 4-bit deltas, the following byte sequence:
+For a complete example, assuming 4-bit sentinel coding, the following byte sequence:
 
 ```
 0x17 0x5f 0xf0 0xbc 0x77 0xa9 0x21 0x00 0x34 0xb5
 ```
 
-Encodes 16 deltas, where the first 8 bytes of the sequence specifies the 4-bit deltas, and the last 2 bytes of the sequence specify the explicit delta values encoded for elements 3 and 4 in the sequence, so the decoded deltas (after zigzag decoding) look like
+Encodes 16 deltas, where the first 8 bytes of the sequence specifies the 4-bit delta, and the last 2 bytes of the sequence specify the explicit delta code values encoded for elements 3 and 4 in the sequence. After de-zigzagging, the decoded deltas look like:
 
 ```
 -1 -4 -3 26 -91 0 -6 6 -4 -4 5 -5 1 -1 0 0
 ```
 
-Finally, note that the deltas are computed in 8-bit integer space with wrap-around two-complement arithmetic; for example, if the values of the first byte of two consecutive elements are `0x00` and `0xff`, the byte delta that is stored is `-1` (`1` after zigzag encoding).
+Finally, note that the deltas are computed in 8-bit integer space with wrap-around arithmetic; for example, if the values of the first byte of two consecutive elements are `0x00` and `0xFF`, the byte delta that is stored is `-1` (`1` after zigzag encoding).
 
 ## Mode 1: triangles
 
@@ -289,7 +312,8 @@ The encoding for `code` is split into various cases, some of which are self-suff
 The edge (a, b) is read from the edge FIFO at index X (where 0 is the most recently added edge).
 The third index, `c`, is equal to `next` (which is then incremented).
 
-Edges (c, b) and (a, c) are pushed to edge FIFO (in this order).
+Edge (c, b) is pushed to the edge FIFO.
+Edge (a, c) is pushed to the edge FIFO.
 Vertex c is pushed to vertex FIFO.
 
 - `0xXY`, where `X < 0xf` and `0 < Y < 0xd`: Encodes a recently encountered edge and a recently encountered vertex.
@@ -297,7 +321,8 @@ Vertex c is pushed to vertex FIFO.
 The edge (a, b) is read from the edge FIFO at index X (where 0 is the most recently added edge).
 The third index, `c`, is read from the vertex FIFO at index Y (where 0 is the most recently added vertex; note that 0 is never actually read here, since `Y > 0`).
 
-Edges (c, b) and (a, c) are pushed to edge FIFO (in this order).
+Edge (c, b) is pushed to the edge FIFO.
+Edge (a, c) is pushed to the edge FIFO.
 
 - `0xXd` or `0xXe`, where `X < 0xf`: Encodes a recently encountered edge and a vertex that's adjacent to `last`.
 
@@ -327,14 +352,16 @@ The third index, `c`, is equal to `next` if `W == 0` (`next` is then incremented
 
 Note that in the process `next` is incremented from 1 to 3 times depending on values of Z/W.
 
-Edges (b, a), (c, b) and (a, c) are pushed to edge FIFO (in this order).
+Edge (b, a) is pushed to the edge FIFO.
+Edge (c, b) is pushed to the edge FIFO.
+Edge (a, c) is pushed to the edge FIFO.
 Vertex a is pushed to vertex FIFO.
 Vertex b is pushed to vertex FIFO if `Z == 0`.
 Vertex c is pushed to vertex FIFO if `W == 0`.
 
 - `0xfe` or `0xff`: Encodes three indices explicitly.
 
-This requires an extra triangle code that is read from `data`; let's assume that results in `0xZW`.
+This requires an extra byte that is read from `data`; let's assume that results in `0xZW`. Note that this is *not* an LEB128 value, just a single byte.
 
 If `0xZW` == `0x00`, then `next` is reset to 0. This is a special mechanism used to restart the `next` sequence which is useful for concatenating independent triangle streams. This must be done before further processing.
 
@@ -342,7 +369,9 @@ The first index, `a`, is equal to `next` for `0xfe` encoding (`next` is then inc
 The second index, `b`, is equal to `next` if `Z == 0` (`next` is then incremented), is read from vertex FIFO at index `Z-1` (where 0 is the most recently added vertex) if `Z < 0xf`, or is read using `decodeIndex` by reading extra bytes from `data` (and also updates `last`) if `Z == 0xf`.
 The third index, `c`, is equal to `next` if `W == 0` (`next` is then incremented), is read from vertex FIFO at index `W-1` (where 0 is the most recently added vertex) if `W < 0xf`, or is read using `decodeIndex` by reading extra bytes from `data` (and also updates `last`) if `W == 0xf`.
 
-Edges (b, a), (c, b) and (a, c) are pushed to edge FIFO (in this order).
+Edge (b, a) is pushed to the edge FIFO.
+Edge (c, b) is pushed to the edge FIFO.
+Edge (a, c) is pushed to the edge FIFO.
 Vertex a is pushed to vertex FIFO.
 Vertex b is pushed to vertex FIFO if `Z == 0` or `Z == 0xf`.
 Vertex c is pushed to vertex FIFO if `W == 0` or `W == 0xf`.
@@ -395,7 +424,9 @@ For performance reasons the results of the decoding process are specified to one
 
 Octahedral filter allows to encode unit length 3D vectors (normals/tangents) using octahedral encoding, which results in a more optimal quality vs precision tradeoff compared to storing raw components.
 
-The input to the filter is four 8-bit or 16-bit components, where the first two specify the X and Y components in octahedral encoding encoded as signed normalized K-bit integers (4 <= K <= 16, integers are stored in two's complement format), the third component explicitly encodes 1.0 as a signed normalized K-bit integer, and the last component may contain arbitrary data (which is useful for tangents).
+This filter is only valid `byteStride` is 4 or 8. When `byteStride` is 4, then the input and output of this filter are four 8-bit components, and when `byteStride` is 8, the input and output of this filter are four 16-bit signed components.
+
+The input to the filter is four 8-bit or 16-bit components, where the first two specify the X and Y components in octahedral encoding encoded as signed normalized K-bit integers (4 <= K <= 16, integers are stored in two's complement format), the third component explicitly encodes 1.0 as a signed normalized K-bit integer. The last component may contain arbitrary data which is passed through unfiltered (this can be useful for tangents).
 
 The encoding of the third component allows to compute K for each vector independently from the bit representation, and must encode 1.0 precisely which is equivalent to `(1 << (K - 1)) - 1` as an integer; values of the third component that aren't equal to `(1 << (K - 1)) - 1` for a valid `K` are invalid and the result of decoding such vectors is unspecified.
 
@@ -406,7 +437,7 @@ The output of the filter is three decoded unit vector components, stored as 8-bi
 ```
 void decode(intN_t input[4], intN_t output[4]) {
 	// input[2] encodes a K-bit representation of 1.0
-	float32_t one = input[3];
+	float32_t one = input[2];
 
 	float32_t x = input[0] / one;
 	float32_t y = input[1] / one;
@@ -415,8 +446,8 @@ void decode(intN_t input[4], intN_t output[4]) {
 	// octahedral fixup for negative hemisphere
 	float32_t t = min(z, 0.0);
 
-	x += copysign(t, x);
-	y += copysign(t, y);
+	x -= copysign(t, x);
+	y -= copysign(t, y);
 
 	// renormalize (x, y, z)
 	float32_t len = sqrt(x * x + y * y + z * z);
@@ -439,6 +470,8 @@ void decode(intN_t input[4], intN_t output[4]) {
 ## Filter 2: quaternion
 
 Quaternion filter allows to encode unit length quaternions using normalized 16-bit integers for all components, but allows control over the precision used for the components and provides better quality compared to naively encoding each component one by one.
+
+This filter is only valid `byteStride` is 8.
 
 The input to the filter is three quaternion components, excluding the component with the largest magnitude, encoded as signed normalized K-bit integers (4 <= K <= 16, integers are stored in two's complement format), and an index of the largest component that is omitted in the encoding. The largest component is assumed to always be positive (which is possible due to quaternion double-cover). To allow per-element control over K, the last input element must explicitly encode 1.0 as a signed normalized K-bit integer, except for the least significant 2 bits that store the index of the maximum component.
 
@@ -474,6 +507,8 @@ void decode(int16_t input[4], int16_t output[4]) {
 ## Filter 3: exponential
 
 Exponential filter allows to encode floating point values with a range close to the full range of a 32-bit floating point value, but allows more control over the exponent/mantissa to trade quality for precision, and has a bit structure that is more optimally aligned to the byte boundary to facilitate better compression.
+
+This filter is only valid `byteStride` is a multiple of 4.
 
 The input to the filter is a sequence of 32-bit little endian integers, with the most significant 8 bits specifying a (signed) exponent value, and the remaining 24 bits specifying a (signed) mantissa value. The integers are stored in two-complement format.
 

--- a/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+++ b/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
@@ -195,17 +195,22 @@ The encoded stream structure is as follows:
 
 Note that there is no way to calculate the length of a stream; instead, it is expected that the input stream is correctly sized (using `byteLength`) so that the tail block element can be found.
 
-Each attribute block stores a sequence of deltas, with the first element in the first block using the deltas from the baseline element stored in the tail block, and each subsequent element using the deltas from the previous element. The attribute block always stores up to an integer number of elements, with that number computed as follows:
+Each attribute block stores a sequence of deltas, with the first element in the first block using the deltas from the baseline element stored in the tail block, and each subsequent element using the deltas from the previous element. The attribute block always stores an integer number of elements, with that number computed as follows:
 
 ```
 maxBlockElements = min((8192 / byteStride) & ~15, 256)
+blockElements = min(remainingElements, maxBlockElements)
 ```
+
+Where `remainingElements` is the number of elements that have yet to be decoded.
 
 Each attribute block consists of `byteStride` "data blocks" (one for each byte of the element), and each "data block" contains deltas stored for groups of elements. Each group always contains 16 elements; when the number of elements that needs to be encoded isn't divisible by 16, it gets rounded up and the remaining elements are ignored after decoding. In other terms:
 
 ```
 groupCount = ceil(blockElements / 16)
 ```
+
+For example, a stream with a `byteStride` of 64 containing 200 elements would be broken up into two attribute blocks: one containing 128 elements, and the other containing 72 elements. And these blocks would have 8 and 5 groups, respectively.
 
 The structure of each "data block" breaks down as follows:
 - Header bits, with 2 bits for each group, aligned to the byte boundary if groupCount is not divisible by 4

--- a/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+++ b/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
@@ -208,7 +208,7 @@ groupCount = ceil(blockElements / 16)
 ```
 
 The structure of each "data block" breaks down as follows:
-- Header bits, with 2 bits for each group
+- Header bits, with 2 bits for each group, aligned to the byte boundary if groupCount is not divisible by 4
 - Delta blocks, with variable number of bytes stored for each group
 
 Header bits are stored from least significant to most significant bit - header bits for 4 consecutive groups are packed in a byte together as follows:

--- a/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+++ b/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
@@ -193,7 +193,7 @@ The encoded stream structure is as follows:
 - One or more attribute blocks, detailed below
 - Tail block, which consists of a baseline element stored verbatim, padded to 32 bytes
 
-Note that there is no easy way to directly calculate the length of a stream; instead, it is expected that the user passes a correctly sized stream so that the tail block element can be found.
+Note that there is no way to calculate the length of a stream; instead, it is expected that the input stream is correctly sized (using `byteLength`) so that the tail block element can be found.
 
 Each attribute block stores a sequence of deltas, with the first element in the first block using the deltas from the baseline element stored in the tail block, and each subsequent element using the deltas from the previous element. The attribute block always stores up to an integer number of elements, with that number computed as follows:
 
@@ -272,7 +272,7 @@ The encoded stream structure is as follows:
 - Extra data which is necessary to decode triangles that don't fit into a single byte, referred to as `data` below
 - Tail block, which consists of a 16-byte lookup table, referred to as `codeaux` below
 
-Note that there is no easy way to directly calculate the length of a stream; instead, it is expected that the user passes a correctly sized stream so that the tail block element can be found.
+Note that there is no way to calculate the length of a stream; instead, it is expected that the input stream is correctly sized (using `byteLength`) so that the tail block element can be found.
 
 There are two limitations on the structure of the 16-byte lookup table:
 

--- a/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+++ b/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
@@ -253,13 +253,13 @@ For a complete example, assuming 4-bit sentinel coding, the following byte seque
 0x17 0x5f 0xf0 0xbc 0x77 0xa9 0x21 0x00 0x34 0xb5
 ```
 
-Encodes 16 deltas, where the first 8 bytes of the sequence specifies the 4-bit delta, and the last 2 bytes of the sequence specify the explicit delta code values encoded for elements 3 and 4 in the sequence. After de-zigzagging, the decoded deltas look like:
+Encodes 16 deltas, where the first 8 bytes of the sequence specifies 16 4-bit deltas, and the last 2 bytes of the sequence specify the explicit delta code values encoded for elements 3 and 4 in the sequence. After de-zigzagging, the decoded deltas look like:
 
 ```
 -1 -4 -3 26 -91 0 -6 6 -4 -4 5 -5 1 -1 0 0
 ```
 
-Finally, note that the deltas are computed in 8-bit integer space with wrap-around two-complement arithmetic; for example, if the values of the first byte of two consecutive elements are `0x00` and `0xFF`, the byte delta that is stored is `-1` (`1` after zigzag encoding).
+Finally, note that the deltas are computed in 8-bit integer space with wrap-around two-complement arithmetic; for example, if the values of the first byte of two consecutive elements are `0x00` and `0xff`, the byte delta that is stored is `-1` (`1` after zigzag encoding).
 
 ## Mode 1: triangles
 

--- a/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+++ b/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
@@ -222,7 +222,7 @@ The header bits establish the delta encoding mode (0-3) for each group of 16 ele
 - bits 0: All 16 byte deltas are 0; the size of the encoded block is 0 bytes
 - bits 1: Deltas are stored in 2-bit sentinel encoding; the size of the encoded block is [4..20] bytes
 - bits 2: Deltas are stored in 4-bit sentinel encoding; the size of the encoded block is [8..24] bytes
-- bits 3: All 16 byte delta are stored as bytes; the size of the encoded block is 16 bytes
+- bits 3: All 16 byte deltas are stored as bytes; the size of the encoded block is 16 bytes
 
 When using the sentinel encoding, each delta is stored as a 2-bit or 4-bit value in a single 4-byte or 8-byte block, with deltas stored from most significant to least significant bit inside the byte. That is, the 2-bit encoding is packed as follows with 4 deltas per byte:
 
@@ -333,7 +333,8 @@ The third index, `c`, is equal to `last-1` for `0xXd` and `last+1` for `0xXe`.
 
 `last` is set to `c` (effectively decrementing or incrementing it accordingly).
 
-Edges (c, b) and (a, c) are pushed to edge FIFO (in this order).
+Edge (c, b) is pushed to the edge FIFO.
+Edge (a, c) is pushed to the edge FIFO.
 Vertex c is pushed to the vertex FIFO.
 
 - `0xXf`, where `X < 0xf`: Encodes a recently encountered edge and a free-standing vertex encoded explicitly.
@@ -341,7 +342,8 @@ Vertex c is pushed to the vertex FIFO.
 The edge (a, b) is read from the edge FIFO at index X (where 0 is the most recently added edge).
 The third index, `c`, is decoded using `decodeIndex` by reading extra bytes from `data` (and also updates `last`).
 
-Edges (c, b) and (a, c) are pushed to edge FIFO (in this order).
+Edge (c, b) is pushed to edge FIFO.
+Edge (a, c) is pushed to edge FIFO.
 Vertex c is pushed to the vertex FIFO.
 
 - `0xfY`, where `Y < 0xe`: Encodes three indices using `codeaux` table lookup and vertex FIFO.

--- a/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+++ b/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
@@ -3,7 +3,7 @@
 ## Contributors
 
 * Arseny Kapoulkine, [@zeuxcg](https://twitter.com/zeuxcg)
-* Jasper St. Pierre, [@JasperRLZ] (https://twitter.com/JasperRLZ)
+* Jasper St. Pierre, [@JasperRLZ](https://twitter.com/JasperRLZ)
 
 ## Status
 
@@ -198,13 +198,13 @@ Note that there is no easy way to directly calculate the length of a stream; ins
 Each attribute block stores a sequence of deltas, with the first element in the first block using the deltas from the baseline element stored in the tail block, and each subsequent element using the deltas from the previous element. The attribute block always stores up to an integer number of elements, with that number computed as follows:
 
 ```
-attrBlockMaxElementCount = min((8192 / byteStride) & ~15, 256)
+maxBlockElements = min((8192 / byteStride) & ~15, 256)
 ```
 
 Each attribute block consists of `byteStride` "data blocks" (one for each byte of the element), and each "data block" contains deltas stored for groups of elements. Each group always contains 16 elements; when the number of elements that needs to be encoded isn't divisible by 16, it gets rounded up and the remaining elements are ignored after decoding. In other terms:
 
 ```
-groupCount = ceil(attrBlockElementCount / 16)
+groupCount = ceil(blockElements / 16)
 ```
 
 The structure of each "data block" breaks down as follows:
@@ -238,7 +238,7 @@ And the 4-bit encoding is packed as:
 
 Note that this is not the same order as the packing of the header bits found above.
 
-A that has all bits set to 1 (corresponds to `3` for 2-bit encoding and `15` for 4-bit encoding) indicates that the real delta value is outside of the 2-bit or 4-bit range, and is stored as a full byte after the bit deltas for this group.
+A delta that has all bits set to 1 (corresponds to `3` for 2-bit encoding and `15` for 4-bit encoding) indicates that the real delta value is outside of the 2-bit or 4-bit range, and is stored as a full byte after the bit deltas for this group.
 
 Byte deltas are stored as zigzag-encoded differences between the byte values of the element and the byte values of the previous element in the same position; the zigzag encoding scheme works as follows:
 
@@ -271,6 +271,8 @@ The encoded stream structure is as follows:
 - Triangle codes, referred to as `code` below, with a single byte for each triangle
 - Extra data which is necessary to decode triangles that don't fit into a single byte, referred to as `data` below
 - Tail block, which consists of a 16-byte lookup table, referred to as `codeaux` below
+
+Note that there is no easy way to directly calculate the length of a stream; instead, it is expected that the user passes a correctly sized stream so that the tail block element can be found.
 
 There are two limitations on the structure of the 16-byte lookup table:
 


### PR DESCRIPTION
To make sure that the spec for EXT_meshopt_compression is actually implementable, I've worked with @magcius to create a reference JS decoder by following the spec, and validate it using decoding tests from the original implementation.

While not a perfect clean-room implementation (the original implementation had to be consulted a couple of times because the spec was difficult to understand), this seems sufficiently comprehensive to make sure that the spec actually describes the intended bitstream correctly.

During this process, two bugs in the spec were found, both of them in the octahedral filter:

- fixed point encoding of 1.0 was stored in the .Z element ([2]); the comment correctly pointed that out, but pseudo-code used index 3
- the octahedral transform used the wrong sign (+= copysign instead of -= copysign).

These two bugs have been corrected to match the actual implementation. Other than that, no bugs were found so the spec seems correct, but this change contains many clarifications and wording tweaks made during the implementation process to hopefully make the spec more precise and easier to understand at the same time.

The reference decoder still needs a little bit of cleanup and it will be part of meshoptimizer repository, whereas this change contains the spec updates.