### PR TITLE
removed duplicate (1 - f0) in implementation notes

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -4071,7 +4071,6 @@ material = mix(dielectric_brdf, metal_brdf, metallic)
 Taking advantage of the fact that `roughness` is shared between metal and dielectric and that the Schlick Fresnel is used, we can simplify the mix and arrive at the final BRDF for the material:
 
 ```
-const dielectricSpecular = 0.04
 const black = 0
 
 c_diff = lerp(baseColor.rgb, black, metallic)

--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -4074,7 +4074,7 @@ Taking advantage of the fact that `roughness` is shared between metal and dielec
 const dielectricSpecular = 0.04
 const black = 0
 
-c_diff = lerp(baseColor.rgb * (1 - dielectricSpecular), black, metallic)
+c_diff = lerp(baseColor.rgb, black, metallic)
 f0 = lerp(0.04, baseColor.rgb, metallic)
 α = roughness^2
 


### PR DESCRIPTION
@WestLangley noticed that for our suggested implementation, if you plug in a pure dielectric material at normal incidence, our equations reduce to `f_diffuse = (1 / pi) * (1 - f0)^2 * baseColor`, which seems to be an error, as the energy-conservation term `(1 - f0)` is double-counted. I believe this is the right fix, but would appreciate more eyes on it. 