### PR TITLE
Added hint about preview of AsciiDoc file

### DIFF
--- a/specification/2.0/README.md
+++ b/specification/2.0/README.md
@@ -8,3 +8,8 @@ to AsciiDoc markup. Published versions of the Specification are now located
 in the [glTF Registry](https://www.khronos.org/registry/glTF). The
 underlying AsciiDoc markup is in the `main` branch of the [glTF
 Specification Repository](https://www.github.com/KhronosGroup/glTF).
+
+A preview of the rendered output of the specification can be seen by
+opening the [`Specification.adoc`](Specification.adoc) file, but note that
+this preview does not include the properties reference and JSON schema
+reference, and will not render embedded mathematical equations correctly.


### PR DESCRIPTION
Addressing https://github.com/KhronosGroup/glTF/issues/2036 . For a preview of the updated readme, see https://github.com/KhronosGroup/glTF/blob/b4484b3b01272ddfb170dbadb64976c9c784db1b/specification/2.0/README.md 

