### PR TITLE
Add preview-mode-only warnings around auto-generated sections.

### DIFF
--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -2135,6 +2135,15 @@ Client implementations **SHOULD** use the following projection matrices.
 [[infinite-perspective-projection]]
 ==== Infinite perspective projection
 
+ifndef::revdate[]
+[NOTE]
+.Note
+====
+This section contains formulas that may not display correctly in all preview tools.
+View the full https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#infinite-perspective-projection[infinite perspective projection].
+====
+endif::[]
+
 [latexmath]
 ++++
 \begin{bmatrix}
@@ -2154,6 +2163,15 @@ where
 
 [[finite-perspective-projection]]
 ==== Finite perspective projection
+
+ifndef::revdate[]
+[NOTE]
+.Note
+====
+This section contains formulas that may not display correctly in all preview tools.
+View the full https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#finite-perspective-projection[finite perspective projection].
+====
+endif::[]
 
 [latexmath]
 ++++
@@ -2175,6 +2193,15 @@ where
 
 [[orthographic-projection]]
 ==== Orthographic projection
+
+ifndef::revdate[]
+[NOTE]
+.Note
+====
+This section contains formulas that may not display correctly in all preview tools.
+View the full https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#orthographic-projection[orthographic projection].
+====
+endif::[]
 
 [latexmath]
 ++++
@@ -2872,6 +2899,15 @@ We use the following notation:
 [[specular-brdf]]
 === Specular BRDF
 
+ifndef::revdate[]
+[NOTE]
+.Note
+====
+This section contains formulas that may not display correctly in all preview tools.
+View the full https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#specular-brdf[Specular BRDF Section].
+====
+endif::[]
+
 The specular reflection `specular_brdf(α)` is a microfacet BRDF
 
 [latexmath]
@@ -2929,6 +2965,15 @@ function specular_brdf(α) {
 [[diffuse-brdf]]
 === Diffuse BRDF
 
+ifndef::revdate[]
+[NOTE]
+.Note
+====
+This section contains formulas that may not display correctly in all preview tools.
+View the full https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#diffuse-brdf[Diffuse BRDF Section].
+====
+endif::[]
+
 The diffuse reflection `diffuse_brdf(color)` is a Lambertian BRDF
 
 [latexmath]
@@ -2948,6 +2993,15 @@ function diffuse_brdf(color) {
 
 [[fresnel]]
 === Fresnel
+
+ifndef::revdate[]
+[NOTE]
+.Note
+====
+This section contains formulas that may not display correctly in all preview tools.
+View the full https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#fresnel[Fresnel Section].
+====
+endif::[]
 
 An inexpensive approximation for the Fresnel term that can be used for conductors and dielectrics was developed by <<Schlick1994,Schlick (1994)>>:
 

--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -18,7 +18,15 @@ The Khronos{regtitle} 3D Formats Working Group
 :source-highlighter: coderay
 :title-logo-image: image:../figures/gltf.png[Logo,pdfwidth=4in,align=right]
 :stem:
-ifdef::env-github[]
+
+// This causes cross references to chapters, sections, and tables to be
+// rendered as "Section A.B" (for example) rather than rendering the reference
+// as the text of the section title.  It also enables cross references to
+// [source] blocks as "Listing N", but only if the [source] block has a title.
+:xrefstyle: short
+:listing-caption: Listing
+
+ifndef::revdate[]
 :toc-placement!:
 
 [NOTE]
@@ -29,13 +37,6 @@ feedback and remixing under CC-BY 4.0. Published versions of the Specification
 are located in the https://www.khronos.org/registry/glTF[glTF Registry].
 ====
 endif::[]
-
-// This causes cross references to chapters, sections, and tables to be
-// rendered as "Section A.B" (for example) rather than rendering the reference
-// as the text of the section title.  It also enables cross references to
-// [source] blocks as "Listing N", but only if the [source] block has a title.
-:xrefstyle: short
-:listing-caption: Listing
 
 // Table of contents is inserted here
 toc::[]
@@ -2618,6 +2619,15 @@ When the binary buffer is empty or when it is stored by other means, this chunk 
 
 [[properties-reference]]
 = Properties Reference
+ifndef::revdate[]
+[NOTE]
+.Note
+====
+This section is auto-generated, and will be a broken link when previewing.
+View the full https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#properties-reference[Properties Reference Section].
+To suggest changes, open a Pull Request to edit the https://github.com/KhronosGroup/glTF/tree/main/specification/2.0/schema[JSON Schema Files].
+====
+endif::[]
 
 // Generated with wetzel
 include::PropertiesReference.adoc[]
@@ -2686,6 +2696,15 @@ include::PropertiesReference.adoc[]
 [appendix]
 [[appendix-a-json-schema-reference]]
 = JSON Schema Reference (Informative)
+ifndef::revdate[]
+[NOTE]
+.Note
+====
+This section is auto-generated, and will be a broken link when previewing.
+View the full https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-a-json-schema-reference[JSON Schema Reference].
+To suggest changes, open a Pull Request to edit the https://github.com/KhronosGroup/glTF/tree/main/specification/2.0/schema[JSON Schema Files].
+====
+endif::[]
 
 // Generated with wetzel
 include::JsonSchemaReference.adoc[]


### PR DESCRIPTION
This adds preview-only warning notes to the two auto-generated sections, providing links to the fully-rendered versions, and an instruction about how to suggest changes.

Also the conditional was changed from `ifdef::env-github[]`, which is GitHub-specific, to `ifndef::revdate[]` which is specific to the glTF doc build process.  This means the notes will be visible to many more previewers in addition to GitHub, such as VSCode's adoc preview window.

There should be no change to the final rendered output from this PR.  (I diffed the outputs to check).