### PR TITLE
Add note about zero-scale meshes.

### DIFF
--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -674,7 +674,7 @@ Non-invertible transforms (e.g., scaling one axis to zero) could lead to lightin
 [NOTE]
 .Implementation Note
 ====
-When the scale is zero on all three axes (by node transform or by animated scale), implementations are free to optimize away rendering of the node's un-skinned mesh, and all of the node's children's un-skinned meshes.
+When the scale is zero on all three axes (by node transform or by animated scale), implementations are free to optimize away rendering of the node's mesh, and all of the node's children's meshes. This provides a mechanism to animate visibility. For skinned meshes, this optimization would only be applicable if all joints in the skin were scaled to zero simultaneously.
 ====
 
 The global transformation matrix of a node is the product of the global transformation matrix of its parent node and its own local transformation matrix. When the node has no parent node, its global transformation matrix is identical to its local transformation matrix.

--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -674,7 +674,7 @@ Non-invertible transforms (e.g., scaling one axis to zero) could lead to lightin
 [NOTE]
 .Implementation Note
 ====
-When the scale is zero on all three axes (by node transform or by animated scale), implementations are free to optimize away rendering of the node's mesh, and all of the node's children's meshes.
+When the scale is zero on all three axes (by node transform or by animated scale), implementations are free to optimize away rendering of the node's un-skinned mesh, and all of the node's children's un-skinned meshes.
 ====
 
 The global transformation matrix of a node is the product of the global transformation matrix of its parent node and its own local transformation matrix. When the node has no parent node, its global transformation matrix is identical to its local transformation matrix.

--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -671,6 +671,12 @@ To compose the local transformation matrix, TRS properties **MUST** be converted
 Non-invertible transforms (e.g., scaling one axis to zero) could lead to lighting and/or visibility artifacts.
 ====
 
+[NOTE]
+.Implementation Note
+====
+When the scale is zero on all three axes (by node transform or by animated scale), implementations are free to optimize away rendering of the node's mesh, and all of the node's children's meshes.
+====
+
 The global transformation matrix of a node is the product of the global transformation matrix of its parent node and its own local transformation matrix. When the node has no parent node, its global transformation matrix is identical to its local transformation matrix.
 
 In the example below, node named `Box` defines non-default rotation and translation.

--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -674,7 +674,7 @@ Non-invertible transforms (e.g., scaling one axis to zero) could lead to lightin
 [NOTE]
 .Implementation Note
 ====
-When the scale is zero on all three axes (by node transform or by animated scale), implementations are free to optimize away rendering of the node's mesh, and all of the node's children's meshes. This provides a mechanism to animate visibility. For skinned meshes, this optimization would only be applicable if all joints in the skin were scaled to zero simultaneously.
+When the scale is zero on all three axes (by node transform or by animated scale), implementations are free to optimize away rendering of the node's mesh, and all of the node's children's meshes. This provides a mechanism to animate visibility. Skinned meshes must not use this optimization unless all of the joints in the skin are scaled to zero simultaneously.
 ====
 
 The global transformation matrix of a node is the product of the global transformation matrix of its parent node and its own local transformation matrix. When the node has no parent node, its global transformation matrix is identical to its local transformation matrix.


### PR DESCRIPTION
Following conversation from https://github.com/KhronosGroup/glTF/issues/1314#issuecomment-754820704 and subsequent comments, I'd like to add an implementation note encouraging optimizations for zero-scale meshes.

Zero-scale meshes can be used to animate visibility of a mesh, and can enable use-cases such as fluid simulation where the computed mesh changes shape and changes number of vertices over a set of known timesteps.

/cc @donmccurdy @javagl