### PR TITLE
Update many spec links

### DIFF
--- a/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness/README.md
+++ b/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness/README.md
@@ -89,10 +89,10 @@ The following table lists the allowed types and ranges for the specular-glossine
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**diffuseFactor** | `number[4]` | The reflected diffuse factor of the material.|No, default:`[1.0,1.0,1.0,1.0]`|
-|**diffuseTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)  | The diffuse texture.|No|
+|**diffuseTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo)  | The diffuse texture.|No|
 |**specularFactor** | `number[3]` | The specular RGB color of the material. |No, default:`[1.0,1.0,1.0]`|
 |**glossinessFactor** | `number` | The glossiness or smoothness of the material. |No, default:`1.0`|
-|**specularGlossinessTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo) | The specular-glossiness texture.|No|
+|**specularGlossinessTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo) | The specular-glossiness texture.|No|
 
 Additional properties are allowed.
 
@@ -110,7 +110,7 @@ The RGBA components of the reflected diffuse color of the material. Metals have 
 
 The diffuse texture. This texture contains RGB components of the reflected diffuse color of the material encoded with the sRGB transfer function. If the fourth component (A) is present, it represents the linear alpha coverage of the material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property specifies how alpha is interpreted. The stored texels must not be premultiplied.
 
-* **Type**: [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)  
+* **Type**: [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo)  
 * **Required**: No
 
 ### specularFactor
@@ -134,7 +134,7 @@ The glossiness or smoothness of the material. A value of 1.0 means the material 
 
 The specular-glossiness texture is an RGBA texture, containing the specular color (RGB) encoded with the sRGB transfer function and the linear glossiness value (A).
 
-* **Type**: [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo) 
+* **Type**: [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo) 
 * **Required**: No
 
 

--- a/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness/README.md
+++ b/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness/README.md
@@ -138,9 +138,9 @@ The specular-glossiness texture is an RGBA texture, containing the specular colo
 * **Required**: No
 
 
-#### Additional Maps
+#### Additional Textures
 
-The [additional maps](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#additional-maps) defined in glTF materials node can also be used with the PBR specular-glossiness material model parameters defined in this extension.
+The [additional textures](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#additional-textures) defined in glTF materials node can also be used with the PBR specular-glossiness material model parameters defined in this extension.
 
 ```json
 {

--- a/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness/README.md
+++ b/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness/README.md
@@ -82,17 +82,17 @@ The following equations show how to calculate bidirectional reflectance distribu
 <br>
 *&alpha;* = `(1 - glossiness) ^ 2`
 
-All implementations should use the same calculations for the BRDF inputs. Implementations of the BRDF itself can vary based on device performance and resource constraints. See [appendix](/specification/2.0/README.md#appendix-b-brdf-implementation) for more details on the BRDF calculations.
+All implementations should use the same calculations for the BRDF inputs. Implementations of the BRDF itself can vary based on device performance and resource constraints. See [appendix](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation) for more details on the BRDF calculations.
 
 The following table lists the allowed types and ranges for the specular-glossiness model:
 
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**diffuseFactor** | `number[4]` | The reflected diffuse factor of the material.|No, default:`[1.0,1.0,1.0,1.0]`|
-|**diffuseTexture** | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo)  | The diffuse texture.|No|
+|**diffuseTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)  | The diffuse texture.|No|
 |**specularFactor** | `number[3]` | The specular RGB color of the material. |No, default:`[1.0,1.0,1.0]`|
 |**glossinessFactor** | `number` | The glossiness or smoothness of the material. |No, default:`1.0`|
-|**specularGlossinessTexture** | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo) | The specular-glossiness texture.|No|
+|**specularGlossinessTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo) | The specular-glossiness texture.|No|
 
 Additional properties are allowed.
 
@@ -110,7 +110,7 @@ The RGBA components of the reflected diffuse color of the material. Metals have 
 
 The diffuse texture. This texture contains RGB components of the reflected diffuse color of the material encoded with the sRGB transfer function. If the fourth component (A) is present, it represents the linear alpha coverage of the material. Otherwise, an alpha of 1.0 is assumed. The `alphaMode` property specifies how alpha is interpreted. The stored texels must not be premultiplied.
 
-* **Type**: [`textureInfo`](/specification/2.0/README.md#reference-textureInfo)  
+* **Type**: [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)  
 * **Required**: No
 
 ### specularFactor
@@ -134,13 +134,13 @@ The glossiness or smoothness of the material. A value of 1.0 means the material 
 
 The specular-glossiness texture is an RGBA texture, containing the specular color (RGB) encoded with the sRGB transfer function and the linear glossiness value (A).
 
-* **Type**: [`textureInfo`](/specification/2.0/README.md#reference-textureInfo) 
+* **Type**: [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo) 
 * **Required**: No
 
 
 #### Additional Maps
 
-The [additional maps](/specification/2.0/README.md#additional-maps) defined in glTF materials node can also be used with the PBR specular-glossiness material model parameters defined in this extension.
+The [additional maps](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#additional-maps) defined in glTF materials node can also be used with the PBR specular-glossiness material model parameters defined in this extension.
 
 ```json
 {

--- a/extensions/2.0/Archived/KHR_techniques_webgl/README.md
+++ b/extensions/2.0/Archived/KHR_techniques_webgl/README.md
@@ -156,7 +156,7 @@ One or more shader source files are listed in the asset's `KHR_techniques_webgl.
 
 ##### Shader Requirements
 
-Supplied shaders must respect values of material [`doubleSided`](../../../../specification/2.0/README.md#double-sided), [`alphaMode`](../../../../specification/2.0/README.md#alpha-coverage), and [`alphaCutoff`](../../../../specification/2.0/README.md#alpha-coverage) properties.
+Supplied shaders must respect values of material [`doubleSided`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#double-sided), [`alphaMode`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#alpha-coverage), and [`alphaCutoff`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#alpha-coverage) properties.
 
 > **Implementation Note**: TODO: Reference shader implementation notes on `doubleSided` once included in the main spec, including how to account for normal and tangent-space calculations.
 
@@ -246,7 +246,7 @@ Attributes and uniforms passed to the program instance's shader code are defined
 
 #### Attributes
 
-The `attributes` dictionary property specifies the vertex attributes of the data that will be passed to the shader. Each attribute's key is a string that corresponds to the attribute name in the GLSL source code. Each attribute's value is an [attribute](#reference-attribute) object, where the semantic of the attribute is defined. The semantic corresponds with the mesh attribute semantic specified in the [primitive](../../../../specification/2.0#reference-primitive), the value of which is the index of the accessor containing attribute's data. It's invalid to specify a semantic that does not exist in the mesh data.
+The `attributes` dictionary property specifies the vertex attributes of the data that will be passed to the shader. Each attribute's key is a string that corresponds to the attribute name in the GLSL source code. Each attribute's value is an [attribute](#reference-attribute) object, where the semantic of the attribute is defined. The semantic corresponds with the mesh attribute semantic specified in the [primitive](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-primitive), the value of which is the index of the accessor containing attribute's data. It's invalid to specify a semantic that does not exist in the mesh data.
 
 #### Uniforms
 
@@ -254,7 +254,7 @@ The `uniforms` dictionary property specifies the uniform variables that will be 
 
 When a material instances a technique, the name of each supplied value in its `KHR_techniques_webgl.values` property must correspond to one of the uniforms defined in the technique.
 
-Uniforms which specify the `SAMPLER_2D` type use a [`textureInfo`](../../../../specification/2.0#reference-textureinfo) object as a value to reference a texture, (see [conformance](#conformance) for objects with extended with `KHR_texture_transform`).
+Uniforms which specify the `SAMPLER_2D` type use a [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo) object as a value to reference a texture, (see [conformance](#conformance) for objects with extended with `KHR_texture_transform`).
 
 The above example illustrates several uniforms. The property `u_ambient` is defined as a `FLOAT_VEC4` type; and `u_light0Color` is defined as a `FLOAT_VEC3` with a default color value of white.
 
@@ -302,15 +302,15 @@ Table 1. Uniform Semantics
 | `MODELVIEWINVERSETRANSPOSE`  | `FLOAT_MAT3` | The inverse-transpose of `MODELVIEW` without the translation.  This transforms normals in model coordinates to eye coordinates. |
 | `VIEWPORT`                   | `FLOAT_VEC4` | The viewport's x, y, width, and height properties stored in the `x`, `y`, `z`, and `w` components, respectively.  For example, this is used to scale window coordinates to [0, 1]: `vec2 v = gl_FragCoord.xy / viewport.zw;` |
 | `JOINTMATRIX`                | `FLOAT_MAT4[]` | Array parameter; its length (`uniform.count`) must be greater than or equal to the length of `jointNames` array of a skin being used. Each element transforms mesh coordinates for a particular joint for skinning and animation. |
-| `ALPHACUTOFF`                | `FLOAT` | The value of the material's [`alphaCutoff`](../../../../specification/2.0/README.md#alpha-coverage) property. |
+| `ALPHACUTOFF`                | `FLOAT` | The value of the material's [`alphaCutoff`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#alpha-coverage) property. |
 
 For forward-compatibility, application-specific semantics must start with an underscore, e.g., `_SIMULATION_TIME`.
 
 ## Conformance
 
-Implementations should continue to respect material [`doubleSided`](../../../../specification/2.0/README.md#double-sided), [`alphaMode`](../../../../specification/2.0/README.md#alpha-coverage), and [`alphaCutoff`](../../../../specification/2.0/README.md#alpha-coverage) properties by modifying the render state. The default state of the WebGL context should not be assumed.
+Implementations should continue to respect material [`doubleSided`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#double-sided), [`alphaMode`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#alpha-coverage), and [`alphaCutoff`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#alpha-coverage) properties by modifying the render state. The default state of the WebGL context should not be assumed.
 
-[`textureInfo`](../../../../specification/2.0/README.md#reference-textureinfo) objects referenced by the `KHR_techniques_webgl` extension may not use the `KHR_texture_transform` extension. The `offset`, `rotation`, and `scale` transforms applied to the texture by using `KHR_texture_transform` can be applied with this extension by providing uniforms for these values and performing the necessary transformations in the supplied GLSL shader code.
+[`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo) objects referenced by the `KHR_techniques_webgl` extension may not use the `KHR_texture_transform` extension. The `offset`, `rotation`, and `scale` transforms applied to the texture by using `KHR_texture_transform` can be applied with this extension by providing uniforms for these values and performing the necessary transformations in the supplied GLSL shader code.
 
 ## Properties Reference
 

--- a/extensions/2.0/Archived/KHR_techniques_webgl/README.md
+++ b/extensions/2.0/Archived/KHR_techniques_webgl/README.md
@@ -246,7 +246,7 @@ Attributes and uniforms passed to the program instance's shader code are defined
 
 #### Attributes
 
-The `attributes` dictionary property specifies the vertex attributes of the data that will be passed to the shader. Each attribute's key is a string that corresponds to the attribute name in the GLSL source code. Each attribute's value is an [attribute](#reference-attribute) object, where the semantic of the attribute is defined. The semantic corresponds with the mesh attribute semantic specified in the [primitive](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-primitive), the value of which is the index of the accessor containing attribute's data. It's invalid to specify a semantic that does not exist in the mesh data.
+The `attributes` dictionary property specifies the vertex attributes of the data that will be passed to the shader. Each attribute's key is a string that corresponds to the attribute name in the GLSL source code. Each attribute's value is an [attribute](#reference-attribute) object, where the semantic of the attribute is defined. The semantic corresponds with the mesh attribute semantic specified in the [mesh primitive](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-mesh-primitive), the value of which is the index of the accessor containing attribute's data. It's invalid to specify a semantic that does not exist in the mesh data.
 
 #### Uniforms
 

--- a/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md
@@ -61,10 +61,10 @@ The following parameters are contributed by the `KHR_materials_clearcoat` extens
 |                                  | Type                                                                            | Description                            | Required             |
 |----------------------------------|---------------------------------------------------------------------------------|----------------------------------------|----------------------|
 |**clearcoatFactor**               | `number`                                                                        | The clearcoat layer intensity.         | No, default: `0.0`   |
-|**clearcoatTexture**              | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo)             | The clearcoat layer intensity texture. | No                   |
+|**clearcoatTexture**              | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)             | The clearcoat layer intensity texture. | No                   |
 |**clearcoatRoughnessFactor**      | `number`                                                                        | The clearcoat layer roughness.         | No, default: `0.0`   |
-|**clearcoatRoughnessTexture**     | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo)             | The clearcoat layer roughness texture. | No                   |
-|**clearcoatNormalTexture**        | [`normalTextureInfo`](/specification/2.0/README.md#reference-normaltextureinfo) | The clearcoat normal map texture.      | No                   |
+|**clearcoatRoughnessTexture**     | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)             | The clearcoat layer roughness texture. | No                   |
+|**clearcoatNormalTexture**        | [`normalTextureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-normaltextureinfo) | The clearcoat normal map texture.      | No                   |
 
 If `clearcoatFactor` (in the extension) is zero, the whole clearcoat layer is disabled.
 
@@ -108,11 +108,11 @@ Implementations of the BRDF or the layering operator can vary based on device pe
 
 #### Clearcoat BRDF
 
-The specular BRDF for the clearcoat layer `clearcoat_brdf` is computed using the specular term from the glTF 2.0 Metallic-Roughness material, defined in [Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation). Roughness and normal are taken from `clearcoatNormal` and `clearcoatRoughness`.
+The specular BRDF for the clearcoat layer `clearcoat_brdf` is computed using the specular term from the glTF 2.0 Metallic-Roughness material, defined in [Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation). Roughness and normal are taken from `clearcoatNormal` and `clearcoatRoughness`.
 
 #### Layering
 
-The `fresnel_coat` function is computed using the Schlick Fresnel term from the glTF 2.0 Metallic-Roughness material, defined in [Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation).
+The `fresnel_coat` function is computed using the Schlick Fresnel term from the glTF 2.0 Metallic-Roughness material, defined in [Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation).
 
 ```
 function fresnel_coat(normal, ior, weight, base, layer) {
@@ -128,7 +128,7 @@ Applying the functions we arrive at the coated material
 coated_material = mix(material, clearcoat_brdf(clearcoatRughness^2), clearcoat * (0.04 + (1 - 0.04) * (1 - NdotV)^5))
 ```
 
-and finally, substituting and simplifying, using some symbols from [Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation) and `Nc` for the clearcoat normal:
+and finally, substituting and simplifying, using some symbols from [Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation) and `Nc` for the clearcoat normal:
 
 ```
 clearcoatFresnel = 0.04 + (1 - 0.04) * (1 - abs(VdotNc))^5
@@ -158,7 +158,7 @@ The simple layering function ignores many effects that occur between clearcoat a
 * There is no scattering between layers.
 * There is no diffraction.
 
-More sophisticated layering techniques that improve the accuracy of the renderings are described in [Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation).
+More sophisticated layering techniques that improve the accuracy of the renderings are described in [Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation).
 
 ## Schema
 

--- a/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md
@@ -64,7 +64,7 @@ The following parameters are contributed by the `KHR_materials_clearcoat` extens
 |**clearcoatTexture**              | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo)             | The clearcoat layer intensity texture. | No                   |
 |**clearcoatRoughnessFactor**      | `number`                                                                        | The clearcoat layer roughness.         | No, default: `0.0`   |
 |**clearcoatRoughnessTexture**     | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo)             | The clearcoat layer roughness texture. | No                   |
-|**clearcoatNormalTexture**        | [`normalTextureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-normaltextureinfo) | The clearcoat normal map texture.      | No                   |
+|**clearcoatNormalTexture**        | [`normalTextureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-material-normaltextureinfo) | The clearcoat normal map texture.      | No                   |
 
 If `clearcoatFactor` (in the extension) is zero, the whole clearcoat layer is disabled.
 

--- a/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md
@@ -61,9 +61,9 @@ The following parameters are contributed by the `KHR_materials_clearcoat` extens
 |                                  | Type                                                                            | Description                            | Required             |
 |----------------------------------|---------------------------------------------------------------------------------|----------------------------------------|----------------------|
 |**clearcoatFactor**               | `number`                                                                        | The clearcoat layer intensity.         | No, default: `0.0`   |
-|**clearcoatTexture**              | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)             | The clearcoat layer intensity texture. | No                   |
+|**clearcoatTexture**              | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo)             | The clearcoat layer intensity texture. | No                   |
 |**clearcoatRoughnessFactor**      | `number`                                                                        | The clearcoat layer roughness.         | No, default: `0.0`   |
-|**clearcoatRoughnessTexture**     | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)             | The clearcoat layer roughness texture. | No                   |
+|**clearcoatRoughnessTexture**     | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo)             | The clearcoat layer roughness texture. | No                   |
 |**clearcoatNormalTexture**        | [`normalTextureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-normaltextureinfo) | The clearcoat normal map texture.      | No                   |
 
 If `clearcoatFactor` (in the extension) is zero, the whole clearcoat layer is disabled.

--- a/extensions/2.0/Khronos/KHR_materials_ior/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_ior/README.md
@@ -100,7 +100,7 @@ Valid values for `ior` are numbers greater than or equal to 1. In addition, a va
 
 *This section is non-normative*
 
-The extension changes the computation of the Fresnel term defined in [Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation) to the following:
+The extension changes the computation of the Fresnel term defined in [Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation) to the following:
 
 ```
 const dielectricSpecular = ((ior - 1)/(ior + 1))^2

--- a/extensions/2.0/Khronos/KHR_materials_sheen/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_sheen/README.md
@@ -64,9 +64,9 @@ The following parameters are contributed by the `KHR_materials_sheen` extension:
 |                                  | Type                                                                            | Description                            | Required                       |
 |----------------------------------|---------------------------------------------------------------------------------|----------------------------------------|--------------------------------|
 |**sheenColorFactor**                   | `array`                                                                         | The sheen color in linear space        | No, default: `[0.0, 0.0, 0.0]` |
-|**sheenColorTexture**         | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)             | The sheen color (RGB).<br> The sheen color is in sRGB transfer function | No               |
+|**sheenColorTexture**         | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo)             | The sheen color (RGB).<br> The sheen color is in sRGB transfer function | No               |
 |**sheenRoughnessFactor**               | `number`                                                                        | The sheen roughness.                   | No, default: `0.0`             |
-|**sheenRoughnessTexture**         | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)             | The sheen roughness (Alpha) texture. | No               |
+|**sheenRoughnessTexture**         | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo)             | The sheen roughness (Alpha) texture. | No               |
 
 The sheen BRDF is layered on top of the glTF 2.0 Metallic-Roughness material. If clearcoat (`KHR_materials_clearcoat`) is active at the same time, clearcoat is layered on top of sheen. The `sheenColorFactor` determines the view-independent intensity of the sheen BRDF. If `sheenColorFactor` is zero, the whole sheen layer is disabled. Implementations of the BRDF itself can vary based on device performance and resource constraints.
 

--- a/extensions/2.0/Khronos/KHR_materials_sheen/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_sheen/README.md
@@ -64,9 +64,9 @@ The following parameters are contributed by the `KHR_materials_sheen` extension:
 |                                  | Type                                                                            | Description                            | Required                       |
 |----------------------------------|---------------------------------------------------------------------------------|----------------------------------------|--------------------------------|
 |**sheenColorFactor**                   | `array`                                                                         | The sheen color in linear space        | No, default: `[0.0, 0.0, 0.0]` |
-|**sheenColorTexture**         | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo)             | The sheen color (RGB).<br> The sheen color is in sRGB transfer function | No               |
+|**sheenColorTexture**         | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)             | The sheen color (RGB).<br> The sheen color is in sRGB transfer function | No               |
 |**sheenRoughnessFactor**               | `number`                                                                        | The sheen roughness.                   | No, default: `0.0`             |
-|**sheenRoughnessTexture**         | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo)             | The sheen roughness (Alpha) texture. | No               |
+|**sheenRoughnessTexture**         | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)             | The sheen roughness (Alpha) texture. | No               |
 
 The sheen BRDF is layered on top of the glTF 2.0 Metallic-Roughness material. If clearcoat (`KHR_materials_clearcoat`) is active at the same time, clearcoat is layered on top of sheen. The `sheenColorFactor` determines the view-independent intensity of the sheen BRDF. If `sheenColorFactor` is zero, the whole sheen layer is disabled. Implementations of the BRDF itself can vary based on device performance and resource constraints.
 
@@ -89,7 +89,7 @@ Not all incoming light is reflected at a micro-fiber. Some of the light may hit 
 
 *This section is non-normative.*
 
-All implementations should use the same calculations for the BRDF inputs. See [Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation) for more details on the BRDF calculations.
+All implementations should use the same calculations for the BRDF inputs. See [Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation) for more details on the BRDF calculations.
 
 The sheen formula `f_sheen` follows the common microfacet form:
 
@@ -144,7 +144,7 @@ The Fresnel term may be omitted, i.e., *F* = 1.
 
 #### Albedo-scaling technique
 
-The sheen layer can be combined with the base layer with an albedo-scaling technique described in [Conty and Kulla (2017)](#ContyKulla2017). The base layer *f*<sub>*diffuse*</sub> + *f*<sub>*specular*</sub> from [Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation) is scaled with *sheenAlbedoScaling* to avoid energy gain.
+The sheen layer can be combined with the base layer with an albedo-scaling technique described in [Conty and Kulla (2017)](#ContyKulla2017). The base layer *f*<sub>*diffuse*</sub> + *f*<sub>*specular*</sub> from [Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation) is scaled with *sheenAlbedoScaling* to avoid energy gain.
 
 *f* = *f*<sub>*sheen*</sub> + (*f*<sub>*diffuse*</sub> + *f*<sub>*specular*</sub>) * *sheenAlbedoScaling* 
 

--- a/extensions/2.0/Khronos/KHR_materials_specular/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_specular/README.md
@@ -80,9 +80,9 @@ Factor and texture are combined by multiplication to describe a single value.
 | |Type|Description|Required|
 |-|----|-----------|--------|
 | **specularFactor** | `number` | The strength of the specular reflection. | No, default: `1.0`|
-| **specularTexture** | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo) | A texture that defines the strength of the specular reflection, stored in the alpha (`A`) channel. This will be multiplied by specularFactor. | No |
+| **specularTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo) | A texture that defines the strength of the specular reflection, stored in the alpha (`A`) channel. This will be multiplied by specularFactor. | No |
 | **specularColorFactor** | `number[3]` | The F0 color of the specular reflection (linear RGB). | No, default: `[1.0, 1.0, 1.0]`|
-| **specularColorTexture** | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo) | A texture that defines the F0 color of the specular reflection, stored in the `RGB` channels and encoded in sRGB. This texture will be multiplied by specularColorFactor. | No |
+| **specularColorTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo) | A texture that defines the F0 color of the specular reflection, stored in the `RGB` channels and encoded in sRGB. This texture will be multiplied by specularColorFactor. | No |
 
 The `specular` and `specularColor` parameters affect the `dielectric_brdf` of the glTF 2.0 metallic-roughness material.
 
@@ -115,7 +115,7 @@ The specular color factor is allowed to be set to values greater than [1, 1, 1].
 
 *This section is non-normative.*
 
-[Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation) defines the function `fresnel_mix`. In this extension, we add two additional arguments called `weight` and `f0_color`. It scales `f0` computed inside the function:
+[Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation) defines the function `fresnel_mix`. In this extension, we add two additional arguments called `weight` and `f0_color`. It scales `f0` computed inside the function:
 
 ```
 function fresnel_mix(f0_color, ior, weight, base, layer) {

--- a/extensions/2.0/Khronos/KHR_materials_specular/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_specular/README.md
@@ -80,9 +80,9 @@ Factor and texture are combined by multiplication to describe a single value.
 | |Type|Description|Required|
 |-|----|-----------|--------|
 | **specularFactor** | `number` | The strength of the specular reflection. | No, default: `1.0`|
-| **specularTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo) | A texture that defines the strength of the specular reflection, stored in the alpha (`A`) channel. This will be multiplied by specularFactor. | No |
+| **specularTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo) | A texture that defines the strength of the specular reflection, stored in the alpha (`A`) channel. This will be multiplied by specularFactor. | No |
 | **specularColorFactor** | `number[3]` | The F0 color of the specular reflection (linear RGB). | No, default: `[1.0, 1.0, 1.0]`|
-| **specularColorTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo) | A texture that defines the F0 color of the specular reflection, stored in the `RGB` channels and encoded in sRGB. This texture will be multiplied by specularColorFactor. | No |
+| **specularColorTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo) | A texture that defines the F0 color of the specular reflection, stored in the `RGB` channels and encoded in sRGB. This texture will be multiplied by specularColorFactor. | No |
 
 The `specular` and `specularColor` parameters affect the `dielectric_brdf` of the glTF 2.0 metallic-roughness material.
 

--- a/extensions/2.0/Khronos/KHR_materials_transmission/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_transmission/README.md
@@ -94,7 +94,7 @@ Only two properties are introduced with this extension and combine to describe a
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**transmissionFactor** | `number` | The base percentage of light that is transmitted through the surface.| No, Default: `0.0 ` |
-|**transmissionTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo) | A texture that defines the transmission percentage of the surface, stored in the `R` channel. This will be multiplied by `transmissionFactor`. | No |
+|**transmissionTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo) | A texture that defines the transmission percentage of the surface, stored in the `R` channel. This will be multiplied by `transmissionFactor`. | No |
 
 ### transmissionFactor 
 The amount of light that is transmitted by the surface rather than diffusely re-emitted. This is a percentage of all the light that penetrates a surface (i.e. isn’t specularly reflected) rather than a percentage of the total light that hits a surface. A value of 1.0 means that 100% of the light that penetrates the surface is transmitted through.

--- a/extensions/2.0/Khronos/KHR_materials_transmission/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_transmission/README.md
@@ -94,7 +94,7 @@ Only two properties are introduced with this extension and combine to describe a
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**transmissionFactor** | `number` | The base percentage of light that is transmitted through the surface.| No, Default: `0.0 ` |
-|**transmissionTexture** | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo) | A texture that defines the transmission percentage of the surface, stored in the `R` channel. This will be multiplied by `transmissionFactor`. | No |
+|**transmissionTexture** | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo) | A texture that defines the transmission percentage of the surface, stored in the `R` channel. This will be multiplied by `transmissionFactor`. | No |
 
 ### transmissionFactor 
 The amount of light that is transmitted by the surface rather than diffusely re-emitted. This is a percentage of all the light that penetrates a surface (i.e. isn’t specularly reflected) rather than a percentage of the total light that hits a surface. A value of 1.0 means that 100% of the light that penetrates the surface is transmitted through.
@@ -113,7 +113,7 @@ The `R` channel of this texture defines the amount of light that is transmitted 
 </figure>
 
 ## Tinting
-The `baseColor` of the material, as defined in the [Metallic-Roughness Material](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#metallic-roughness-material) section of the glTF specification, controls the amount of light at each frequency that is reflected (not absorbed) by the material. Similarily, we also use it to define the light that is transmitted (not absorbed) by a transparent surface. Absorption is usually defined as an amount of light at each frequency that is absorbed over a given distance through a medium (usually described by Beer’s Law). However, since this extension deals exclusively with infinitely thin surfaces, this absorption is constant and equal to `1.0 - baseColor`. The color tinting effects in the above images are defined by the material's `baseColor`. Tinting is very useful for real-world materials like stained glass and tinted plastics.
+The `baseColor` of the material, as defined in the [Metallic-Roughness Material](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#metallic-roughness-material) section of the glTF specification, controls the amount of light at each frequency that is reflected (not absorbed) by the material. Similarily, we also use it to define the light that is transmitted (not absorbed) by a transparent surface. Absorption is usually defined as an amount of light at each frequency that is absorbed over a given distance through a medium (usually described by Beer’s Law). However, since this extension deals exclusively with infinitely thin surfaces, this absorption is constant and equal to `1.0 - baseColor`. The color tinting effects in the above images are defined by the material's `baseColor`. Tinting is very useful for real-world materials like stained glass and tinted plastics.
 <figure>
   <img src="./figures/ConstantTransmission.png"/>
 <figcaption><em>The baseColor of the material (yellow, in this example) is used to tint the light being transmitted.</em></figcaption>
@@ -140,7 +140,7 @@ The metallic parameter of a glTF material effectively scales the `baseColor` of 
 
 ## Transmission BTDF ##
 
-From the core [glTF BRDF](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#appendix-b-brdf-implementation), we have:
+From the core [glTF BRDF](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation), we have:
 
 ```
 dielectric_brdf =

--- a/extensions/2.0/Khronos/KHR_materials_unlit/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_unlit/README.md
@@ -78,7 +78,7 @@ coverage and doubleSided still apply to unlit materials.
 
 The Unlit material model describes a constantly shaded surface that is
 independent of lighting. The material is defined only by properties already
-present in the [glTF 2.0 material specification](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#material).
+present in the [glTF 2.0 material specification](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#material).
 No new properties are added by this extension — it is effectively a boolean
 flag indicating use of an unlit shading model. Additional properties on the
 extension object are allowed, but may lead to undefined behaviour in conforming
@@ -90,7 +90,7 @@ Color is calculated as:
 color = <baseColorTerm>
 ```
 
-`<baseColorTerm>` is the product of `baseColorFactor`, `baseColorTexture`, and vertex color (if any), as defined by the [core glTF material specification](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#metallic-roughness-material).
+`<baseColorTerm>` is the product of `baseColorFactor`, `baseColorTexture`, and vertex color (if any), as defined by the [core glTF material specification](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#metallic-roughness-material).
 
 ### Example
 

--- a/extensions/2.0/Khronos/KHR_materials_unlit/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_unlit/README.md
@@ -78,10 +78,10 @@ coverage and doubleSided still apply to unlit materials.
 
 The Unlit material model describes a constantly shaded surface that is
 independent of lighting. The material is defined only by properties already
-present in the [glTF 2.0 material specification](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#material).
-No new properties are added by this extension — it is effectively a boolean
+present in the [glTF 2.0 material specification](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#materials).
+No new properties are added by this extension — it is effectively a Boolean
 flag indicating use of an unlit shading model. Additional properties on the
-extension object are allowed, but may lead to undefined behaviour in conforming
+extension object are allowed, but may lead to undefined behavior in conforming
 viewers.
 
 Color is calculated as:

--- a/extensions/2.0/Vendor/ADOBE_materials_clearcoat_specular/README.md
+++ b/extensions/2.0/Vendor/ADOBE_materials_clearcoat_specular/README.md
@@ -54,7 +54,7 @@ As with the core glTF 2.0 spec, all colored textures are assumed to be sRGB and 
 |----------------------------------|---------------------------------------------------------------------------------|----------------------------------------|----------------------|
 |**clearcoatIor**               | `number`                                                                        | The clearcoat IOR.         | No, default: `1.5`   |
 |**clearcoatSpecularFactor**               | `number`                                                                        | The clearcoat specular factor.         | No, default: `1.0`   |
-|**clearcoatSpecularTexture**              | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)             | The clearcoat layer's specular amount, stored in the `B` channel of a texture. | No                   |
+|**clearcoatSpecularTexture**              | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureinfo)             | The clearcoat layer's specular amount, stored in the `B` channel of a texture. | No                   |
 
 The clearcoat Fresnel contribution is usually calculated just as described for the base layer in [Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation).
 This extension modifies the Fresnel contribution of clearcoat as follows:

--- a/extensions/2.0/Vendor/ADOBE_materials_clearcoat_specular/README.md
+++ b/extensions/2.0/Vendor/ADOBE_materials_clearcoat_specular/README.md
@@ -46,17 +46,17 @@ Adding reflectivity information to the clearcoat can be done by adding the `ADOB
 
 ### Clearcoat Reflectivity
 
-All implementations should use the same calculations for the BRDF inputs. Implementations of the BRDF itself can vary based on device performance and resource constraints. See [Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation) for more details on the BRDF calculations.
+All implementations should use the same calculations for the BRDF inputs. Implementations of the BRDF itself can vary based on device performance and resource constraints. See [Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation) for more details on the BRDF calculations.
 
-As with the core glTF 2.0 spec, all coloured textures are assumed to be sRGB and all coloured factors are assumed to be linear.
+As with the core glTF 2.0 spec, all colored textures are assumed to be sRGB and all colored factors are assumed to be linear.
 
 |                                  | Type                                                                            | Description                            | Required             |
 |----------------------------------|---------------------------------------------------------------------------------|----------------------------------------|----------------------|
 |**clearcoatIor**               | `number`                                                                        | The clearcoat IOR.         | No, default: `1.5`   |
 |**clearcoatSpecularFactor**               | `number`                                                                        | The clearcoat specular factor.         | No, default: `1.0`   |
-|**clearcoatSpecularTexture**              | [`textureInfo`](/specification/2.0/README.md#reference-textureInfo)             | The clearcoat layer's specular amount, stored in the `B` channel of a texture. | No                   |
+|**clearcoatSpecularTexture**              | [`textureInfo`](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-textureInfo)             | The clearcoat layer's specular amount, stored in the `B` channel of a texture. | No                   |
 
-The clearcoat Fresnel contribution is usually calculated just as described for the base layer in [Appendix B](/specification/2.0/README.md#appendix-b-brdf-implementation).
+The clearcoat Fresnel contribution is usually calculated just as described for the base layer in [Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation).
 This extension modifies the Fresnel contribution of clearcoat as follows:
 The `clearcoatIor` can be used to calculate the reflectance at normal incidence for the coating (`coatBaseF0`) that will replace the default `F0` of `0.04`.
 

--- a/extensions/2.0/Vendor/ADOBE_materials_thin_transparency/README.md
+++ b/extensions/2.0/Vendor/ADOBE_materials_thin_transparency/README.md
@@ -84,7 +84,7 @@ Absorption is usually defined as an amount of light at each frequency that is ab
 
 ### Implementing Absorption ###
 
-Modeling absorption is relatively straightforward. From the [glTF BRDF](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#appendix-b-brdf-implementation), we have:
+Modeling absorption is relatively straightforward. From the [glTF BRDF](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation), we have:
 
 *f* = *f*<sub>*diffuse*</sub> + *f*<sub>*specular*</sub>
 *f*<sub>*diffuse*</sub> = (1 - *F*) * *diffuse*

--- a/extensions/2.0/Vendor/EXT_lights_image_based/README.md
+++ b/extensions/2.0/Vendor/EXT_lights_image_based/README.md
@@ -67,7 +67,7 @@ Cube faces are defined in the following order and adhere to the standard orienta
 <figcaption><em>Cube map orientation reference.<br>Image by <a href="//commons.wikimedia.org/w/index.php?title=User:Microwerx&amp;action=edit&amp;redlink=1" class="new" title="User:Microwerx (page does not exist)">Microwerx</a> - <span class="int-own-work" lang="en">Own work</span>, <a href="https://creativecommons.org/licenses/by-sa/4.0" title="Creative Commons Attribution-Share Alike 4.0">CC BY-SA 4.0</a>, <a href="https://commons.wikimedia.org/w/index.php?curid=48935423">Link</a></em></figcaption>
 </figure>
 
-Note that for this extension, each saved image must be flipped about its vertical axis to correspond with the way <a href="https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#images">glTF references texture space</a>.
+Note that for this extension, each saved image must be flipped about its vertical axis to correspond with the way <a href="https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#images">glTF references texture space</a>.
 
 https://en.wikipedia.org/wiki/Cube_mapping
 


### PR DESCRIPTION
This fixes a number of spec links to use the glTF registry.

(/cc @MiiBond this touches some ADOBE extensions too).