### PR TITLE
Remove max-width element style, and all its overrides

### DIFF
--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -13,7 +13,6 @@ The Khronos{regtitle} 3D Formats Working Group
 :toc2:
 :toclevels: 10
 :sectnumlevels: 10
-:max-width: 100%
 :numbered:
 :source-highlighter: coderay
 :title-logo-image: image:../figures/glTF_RGB_June16.svg[Logo,pdfwidth=4in,align=right]

--- a/specification/2.0/docinfo.html
+++ b/specification/2.0/docinfo.html
@@ -51,34 +51,6 @@
 .toc-expanded > ul {
     display: block;
 }
-@media only screen and (min-width: 1010px) {
-    #content {
-        max-width: 768px !important;
-        border-left: 1px solid #eee;
-        border-right: 1px solid #eee;
-        padding-left: 60px;
-        padding-right: 60px;
-    }
-    #header {
-        max-width: 768px !important;
-        padding-left: 60px;
-        padding-right: 60px;
-        margin-left: auto;
-        margin-right: auto;
-    }
-}
-@media only screen and (min-width:1400px) {
-    #content {
-        max-width: 1080px !important;
-        padding-left: 100px;
-        padding-right: 100px;
-    }
-    #header {
-        max-width: 1080px !important;
-        padding-left: 100px;
-        padding-right: 100px;
-    }
-}
 #header::before {
     content: ' ';
     display: block;


### PR DESCRIPTION
This PR removes a chunk of CSS styling that I had spent a little while crafting earlier this year.  It turns out that the base `khronos.css` stylesheet, shared by several Khronos standards, already included a maximum width.  But this max-width was being overridden by an AsciiDoctor directive of `:max-width: 100%` in both glTF and in Vulkan's main documentation (but oddly, not in the Vulkan man pages).  So I didn't realize any limit was in place, and ended up writing my own, isolated to glTF, that was quite similar in function.

This PR removes the offending AsciiDoctor directive.  Its Vulkan counterpart has recently been removed in https://github.com/KhronosGroup/Vulkan-Docs/pull/1660.

This also removes the glTF-specific CSS that replicated the width limitations.  With this gone, we lose the little faint siderails I had crafted down the sides of the spec, but they're not too visible or useful anyway.  We gain conformance with other Khronos specifications, including the newly-republished Vulkan spec, now sharing our max-width with them.

Ultimately, this PR produces very little visual difference in the glTF spec, but it's cleaner code and a slightly better match to other Khronos spec documents, so that's good I suppose.