### PR TITLE
Use Github Markdown math for equations

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_transmission/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_transmission/README.md
@@ -180,33 +180,47 @@ Optical transparency does not require any changes whatsoever to the specular ter
 
 The specular transmission `specular_btdf(α)` is a microfacet BTDF
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle \text{MicrofacetBTDF} = \frac{G_T D_T}{4 \, \left|N \cdot L \right| \, \left| N \cdot V \right|}">
+$$
+\text{MicrofacetBTDF} = \frac{G_T D_T}{4 \left|N \cdot L \right| \left| N \cdot V \right|}
+$$
 
 with the Trowbridge-Reitz/GGX microfacet distribution
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle D_T = \frac{\alpha^2 \, \chi^%2B(N \cdot H_T)}{\pi ((N \cdot H_T)^2 (\alpha^2 - 1) %2B 1)^2}">
+$$
+D_T = \frac{\alpha^2 \chi^+(N \cdot H_T)}{\pi ((N \cdot H_T)^2 (\alpha^2 - 1) + 1)^2}
+$$
 
 and the separable form of the Smith joint masking-shadowing function
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle G_T = \frac{2 \, \left| N \cdot L \right| \, \chi^%2B\left(\frac{H_T \cdot L}{N \cdot L}\right)}{\left| N \cdot L \right| %2B \sqrt{\alpha^2 %2B (1 - \alpha^2) (N \cdot L)^2}} \frac{2 \, \left| N \cdot V \right| \, \chi^%2B\left(\frac{H_T \cdot V}{N \cdot V}\right)}{\left| N \cdot V \right| %2B \sqrt{\alpha^2 %2B (1 - \alpha^2) (N \cdot V)^2}}">,
+$$
+G_T = \frac{2 \left| N \cdot L \right| \chi^+\left(\frac{H_T \cdot L}{N \cdot L}\right)}{\left| N \cdot L \right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot L)^2}} \frac{2 \left| N \cdot V \right| \chi^+\left(\frac{H_T \cdot V}{N \cdot V}\right)}{\left| N \cdot V \right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot V)^2}}
+$$
 
-using the transmission half vector *H*<sub>*T*</sub>
+using the transmission half vector $H_T$
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle H_T = \text{normalize}(V %2B \, 2 \, \left| N \cdot L \right| \, N %2B L)">.
+$$
+H_T = \text{normalize}(V + 2 \left| N \cdot L \right| N + L)
+$$
 
-With the step function χ<sup>+</sup> we ensure that the microsurface is only visible for directions that are on the same side of the macro and microsurfaces. Macro and microsurfaces are oriented according to *N* and *H*<sub>*T*</sub>, respectively.
+With the step function $\chi^+$ we ensure that the microsurface is only visible for directions that are on the same side of the macro and microsurfaces. Macro and microsurfaces are oriented according to $N$ and $H_T$, respectively.
 
 Introducing the visibility function
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle V_T = \frac{G_T}{4 \, \left| N \cdot L \right| \, \left| N \cdot V \right|}">
+$$
+V_T = \frac{G_T}{4 \left| N \cdot L \right| \left| N \cdot V \right|}
+$$
 
 simplifies the original microfacet BTDF to
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle \text{MicrofacetBTDF} = V_T D_T">
+$$
+\text{MicrofacetBTDF} = V_T D_T
+$$
 
 with
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle V_T = \frac{\, \chi^%2B\left(\frac{H_T \cdot L}{N \cdot L}\right)}{\left| N \cdot L\right| %2B \sqrt{\alpha^2 %2B (1 - \alpha^2) (N \cdot L)^2}} \frac{\, \chi^%2B\left(\frac{H_T \cdot V}{N \cdot V}\right)}{\left| N \cdot V \right| %2B \sqrt{\alpha^2 %2B (1 - \alpha^2) (N \cdot V)^2}}">.
+$$
+V_T = \frac{\chi^+\left(\frac{H_T \cdot L}{N \cdot L}\right)}{\left| N \cdot L\right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot L)^2}} \frac{\chi^+\left(\frac{H_T \cdot V}{N \cdot V}\right)}{\left| N \cdot V \right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot V)^2}}
+$$
 
 Thus we have the function
 

--- a/extensions/2.0/Khronos/KHR_materials_volume/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_volume/README.md
@@ -178,31 +178,41 @@ Base color and absorption both have an effect on the final color of a volumetric
 
 The specular transmission `specular_btdf(α)` defined in `KHR_materials_transmission` now takes refraction into account. That means that we use Snell's law to compute the modified half vector:
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle H_{TR} = -\text{normalize}(\eta_i V %2B \eta_o L)">.
+$$
+H_{TR} = -\text{normalize}(\eta_i V + \eta_o L)
+$$
 
-*η<sub>i</sub>* and *η<sub>o</sub>* denote the IOR of the incident and transmitted side of the surface, respectively. *V* is the vector pointing to the camera, *L* points to the light. In a path tracer, *V* corresponds to the incident side of the surface, which is the side of the medium with *η<sub>i</sub>*.
+$\eta_i$ and $\eta_o$ denote the IOR of the incident and transmitted side of the surface, respectively. $V$ is the vector pointing to the camera, $L$ points to the light. In a path tracer, $V$ corresponds to the incident side of the surface, which is the side of the medium with $\eta_i$.
 
 Incident and transmitted IOR have to be correctly set by the renderer, depending on whether light enters or leaves the object. An algorithm for tracking the IOR through overlapping objects was described by [Schmidt and Budge (2002)](#SchmidtBudge2002).
 
 The refractive microfacet BTDF is normalized in a different way.
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle \text{MicrofacetBTDF} = \frac{\left| H_{TR} \cdot L \right| \left| H_{TR} \cdot V \right|}{\left| N \cdot L \right| \left| N \cdot V \right|} \frac{\eta_o^2 G_{T} D_{TR}}{\left(\eta_i (H_{TR} \cdot V) %2B \eta_o (H_{TR} \cdot L)\right)^2}">
+$$
+\text{MicrofacetBTDF} = \frac{\left| H_{TR} \cdot L \right| \left| H_{TR} \cdot V \right|}{\left| N \cdot L \right| \left| N \cdot V \right|} \frac{\eta_o^2 G_{T} D_{TR}}{\left(\eta_i (H_{TR} \cdot V) + \eta_o (H_{TR} \cdot L)\right)^2}
+$$
 
-The *D<sub>T</sub>* and *G<sub>TR</sub>* terms are the same as in the specular transmission in `KHR_materials_transmission` except using the modified half vector *H<sub>TR</sub>* calculated from the refraction direction. See [Walter et al. (2007)](#Walter2007) for details.
+The $D_T$ and $G_{TR}$ terms are the same as in the specular transmission in `KHR_materials_transmission` except using the modified half vector $H_{TR}$ calculated from the refraction direction. See [Walter et al. (2007)](#Walter2007) for details.
 
 The Fresnel term also makes use of the modified half vector and, in addition, needs to take internal reflection into account. When using the Schlick approximation, care must be taken to use the angle that is on the dense side of the boundary, i.e., the side with the medium that has a higher IOR. In addition, total internal reflection has to be considered. Therefore, we have three cases:
 
-Light enters medium with higher IOR: *η<sub>o</sub>* ≥ *η<sub>i</sub>*.
+1. Light enters medium with higher IOR: $\eta_o \ge \eta_i$.
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle F_{TR}^%2B = f_0 %2B (1 - f_0) (1 - \left| V \cdot H_{TR} \right| )^5">
+$$
+F_{TR}^{+} = f_0 + (1 - f_0) (1 - \left| V \cdot H_{TR} \right| )^5
+$$
 
-Light enters medium with lower IOR and there is no total internal reflection: *η<sub>o</sub>* < *η<sub>i</sub>* and sin<sup>2</sup>(*θ<sub>o</sub>*) < 1. The angle at the transmitted side of the boundary (medium with lower IOR) *θ<sub>o</sub>* is computed from the angle of incidence via sin<sup>2</sup>(*θ<sub>o</sub>*) = (*η<sub>i</sub>* / *η<sub>o</sub>*)<sup>2</sup> (1 - dot(*V*, *H<sub>TR</sub>*)<sup>2</sup>) and thus cos(*θ<sub>o</sub>*) = sqrt(1 - sin<sup>2</sup>(*θ<sub>o</sub>*)).
+2. Light enters medium with lower IOR and there is no total internal reflection: $\eta_o < \eta_i$ and $\sin^2 \theta_o < 1$. The angle at the transmitted side of the boundary (medium with lower IOR) $\theta_o$ is computed from the angle of incidence via $\sin^2 \theta_o = \left(\frac{\eta_i}{\eta_o}\right)^2 (1 - (V \cdot H_{TR})^2)$ and thus $\cos \theta_o = \sqrt{1 - \sin^2 \theta_o}$.
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle F_{TR}^{-} = f_0 %2B (1 - f_0) (1 - \left| \cos\,\theta_o \right| )^5">
+$$
+F_{TR}^{-} = f_0 + (1 - f_0) (1 - \left| \cos\theta_o \right| )^5
+$$
 
-Light enters medium with lower IOR and there is total internal reflection: *η<sub>o</sub>* < *η<sub>i</sub>* and sin<sup>2</sup>(*θ<sub>o</sub>*) ≥ 1.
+3. Light enters medium with lower IOR and there is total internal reflection: $\eta_o < \eta_i$ and and $\sin^2 \theta_o \ge 1$.
 
-<img src="https://render.githubusercontent.com/render/math?math=\displaystyle F_{TR}^\text{TIR} = 1">
+$$
+F_{TR}^\text{TIR} = 1
+$$
 
 ## Interaction with other extensions
 


### PR DESCRIPTION
[Github added support for Latex math in Markdown](https://github.blog/2022-05-19-math-support-in-markdown/). This PR replaces the `<img>` tags by `$` and `$$`.