### PR TITLE
KHR_anchors_face_landmarks - rigid face AR try-on extension

### DIFF
--- a/extensions/2.0/Khronos/KHR_anchors_face_landmarks/README.md
+++ b/extensions/2.0/Khronos/KHR_anchors_face_landmarks/README.md
@@ -1,0 +1,72 @@
+# KHR_anchor_face_landmarks
+
+## Contributors
+
+- Ben Houston, Threekit, @bhouston
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension allows a glTF to specify that it can bind and orient rigid models to face landmarks.  This extension follows in the paradigm established by KHR_anchor_plane.
+
+## Design Goals
+
+The goal is to enable glTF files to intrinsically denote that they are designed and are capable of binding, in a rigid fashion, to specific locations on faces.  The attachment specification should be compatible with existing augmented reality tool kits.
+
+This extension specifically does not deal with deformable objects on the face.  Deformable object attachments can not use named attachment locations and are thus left to further extensions.
+
+## Similar Capabilities
+
+There are AR toolkits that have similar capabilities upon which this extension is modelled.
+
+Lens Studio has a similar concept of "Head Bindings."  This capability is documented here: https://docs.snap.com/lens-studio/references/guides/lens-features/tracking/face/face-effects/head-attached-3d-objects/#modifying-the-head-binding
+
+Meta's Spark AR toolkit also supports Face Landmakr Patches where specifically rigid transforms can be extracted from a tracked face.  It is described here: https://sparkar.facebook.com/ar-studio/learn/patch-editor/face-landmarks#textures-you-can-make-in-spark-ar-studio
+
+Google's FaceMesh capability within MediaPipe tracks the face as a face mask that deforms and tracks on each frame.  The landmarks below can be extracted from that face geometry relatively straight forwardly. https://google.github.io/mediapipe/solutions/face_mesh.html
+
+Apple's ARFaceAnchor system also has similar deformed geometry to Google's FaceMesh capabilities.  The same process for extracting landmark rigid body transforms from deformable geometry can be employed.  https://developer.apple.com/documentation/arkit/arfaceanchor/2928271-geometry
+## Anchors
+
+Only one face anchor per model is supported.  This choice was made to simplify user experience.
+
+[Comment by Ben: if we wanted to allow for sub elements of a glTF to each have their own face attachment lcoations, then one could ship a single glTF that say attaches a goatie to the chin, and bushy eyebrows above the eye and a weird hat all together.  This would be a multiple face attachment glTF.  Do we want to do this in the initial version?  I suspect it isn't that much harder to implement for implementers.]
+
+```
+"extensions": {
+    "KHR_anchors_face_rigid" : {
+        "name": "glasses"
+        "landmark": "face-center",
+    }
+}
+```
+
+### Names
+
+We are allowing each name to have an optional name.  This enables the anchors to be used in the future in more generic fashions, such as support general mate points.
+
+### Landmarks
+
+These are the locations on the face/head to which one can attach.
+
+**forehead** anchors to the center both vertically and horizontally of the forehead.  This is useful for hats, headbands and other similar headwear.  The z-axis is oriented such that it goes directly through the skull such that it can be used for aligning a hat on the head, it is not aligned with the slope of the forehead.  The orientation of the anchor relative to the forehead is such that X is to the right, Y is up, and Z is out of the head.
+
+**eyes-center** anchors to half way between the two eyes.  This is useful for glasses and other eyewear.  The z-axis is oriented such that it goes directly through the skull such objects align with it will sit flat on the face.  The orientation of the anchor relative to the face is such that X is to the right, Y is up, and Z is out of the head. 
+
+[Comment by Ben: Often this is called "face-center".]
+
+**nose** anchors to the tip of the nose.  This is useful for hallowe'end disguises and nose rings and similar nose-specific appareal.  The z-axis is oriented such that it goes directly through the skull such objects align with it will sit flat on the face.  The orientation of the anchor relative to the face is such that X is to the right, Y is up, and Z is out of the head. 
+
+**chin** anchors to the tip of the chin.  This is useful for goatie and chin guards.  The z-axis is oriented such that it goes directly through the skull such objects align with it will sit flat on the face.  The orientation of the anchor relative to the face is such that X is to the right, Y is up, and Z is out of the head. 
+
+**mouth-center** anchors to the center of the mouth whether it is open or closed.  This is useful for a soother and similar types of inserts into the mount.  The z-axis is oriented such that it goes directly through the skull such objects align with it will sit flat on the face.  The orientation of the anchor relative to the face is such that X is to the right, Y is up, and Z is out of the head.
+
+[Comment by Ben: I've also seen other options such as "eye-left", "eye-right", "cheek-left", "cheek-right".  I am unsure how useful they are.]
+


### PR DESCRIPTION
This is another anchor extension that enables augmented reality (AR) try-on experiences on the face using rigid predefined landmarks.

It supports in this first draft these locations:
* Forehead
* Eyes-center
* Nose
* Chin
* Mouth-Center

There are other landmarks I could add based on interest/usefulness:
* Eye-Left/Eye-Right - I am unsure the usefulness?  Maybe coloured contact try-on?
* Cheek-Left/Cheek-Right - Maybe whiskers try on?

This extension is modelled at a high level on:
* Lens Studio has a similar concept of "Head Bindings."  This capability is documented here: https://docs.snap.com/lens-studio/references/guides/lens-features/tracking/face/face-effects/head-attached-3d-objects/#modifying-the-head-binding
* Meta's Spark AR toolkit also supports Face Landmark Patches where specifically rigid transforms can be extracted from a tracked face.  It is described here: https://sparkar.facebook.com/ar-studio/learn/patch-editor/face-landmarks#textures-you-can-make-in-spark-ar-studio

The biggest open question is whether we should support one or more landmarks per glTF file.  If you want to do a multi-part glTF file where you put some of it on your "forehead" (like a hat) and then also put some of it on another part of the face, like glasses on your "eyes-centre" and then maybe put a clown nose on the "nose" landmark.  I am unsure if that should be a supported use case in the first pass of this, or not?