### PR TITLE
Consistently add trailing slash to root URLs

### DIFF
--- a/extensions/Prefixes.md
+++ b/extensions/Prefixes.md
@@ -18,9 +18,9 @@ Once a prefix is approved, it should be added to the [glTF Validator's list of k
 
 | Prefix | Company or Project Name | Contacts | Request |
 |--------------|--------------------------------|---------------------------------------------------------------|-----------|
-| `ADOBE` | Adobe, Inc. | https://adobe.com | [#1431](https://github.com/KhronosGroup/glTF/issues/1431) |
-| `AGI` | Analytical Graphics, Inc. | https://agi.com | [#1405](https://github.com/KhronosGroup/glTF/pull/1405) |
-| `AGT` | Augment SAS | https://www.augment.com | [#1571](https://github.com/KhronosGroup/glTF/issues/1571) |
+| `ADOBE` | Adobe, Inc. | https://adobe.com/ | [#1431](https://github.com/KhronosGroup/glTF/issues/1431) |
+| `AGI` | Analytical Graphics, Inc. | https://agi.com/ | [#1405](https://github.com/KhronosGroup/glTF/pull/1405) |
+| `AGT` | Augment SAS | https://www.augment.com/ | [#1571](https://github.com/KhronosGroup/glTF/issues/1571) |
 | `ALCM` | Alchemisten AG | https://alchemisten.ag/<br>`viktor.spadi at alchemisten.ag` | [#1708](https://github.com/KhronosGroup/glTF/issues/1708) |
 | `ALI` | Alibaba Group | https://www.alibaba.com/ | [#1160](https://github.com/KhronosGroup/glTF/pull/1160) |
 | `AMZN` | Amazon | https://www.amazon.com/<br>`jasoncan at amazon.com` | [#1233](https://github.com/KhronosGroup/glTF/issues/1233) |
@@ -29,21 +29,21 @@ Once a prefix is approved, it should be added to the [glTF Validator's list of k
 | `AVR` | AltspaceVR, Inc. | https://altvr.com/ | [#1009](https://github.com/KhronosGroup/glTF/issues/1009) |
 | `BLENDER` | Blender Foundation | https://www.blender.org/ | [#865](https://github.com/KhronosGroup/glTF/issues/865) |
 | `CAPTURE` | Capture Visualisation AB | https://www.capture.se/ | [#1732](https://github.com/KhronosGroup/glTF/issues/1732) |
-| `CESIUM` | Cesium GS, Inc. | https://cesium.com |  |
+| `CESIUM` | Cesium GS, Inc. | https://cesium.com/ |  |
 | `CITRUS` | Citrus Toolbox | https://github.com/KenzieMac130/CitrusToolbox | [#1962](https://github.com/KhronosGroup/glTF/issues/1962) |
-| `CLO` | CLO Virtual Fashion | https://www.clo3d.com | [#1944](https://github.com/KhronosGroup/glTF/issues/1944) |
+| `CLO` | CLO Virtual Fashion | https://www.clo3d.com/ | [#1944](https://github.com/KhronosGroup/glTF/issues/1944) |
 | `CVTOOLS` | Canvas Tools | https://github.com/MackeyK24/CanvasTools | [#1389](https://github.com/KhronosGroup/glTF/issues/1389) |
-| `DOTV` | DotVision | https://dotvision.com<br>`guillaume.pelletier at dotvision.com` | [#2192](https://github.com/KhronosGroup/glTF/issues/2192) |
+| `DOTV` | DotVision | https://dotvision.com/<br>`guillaume.pelletier at dotvision.com` | [#2192](https://github.com/KhronosGroup/glTF/issues/2192) |
 | `EMBARK` | Embark Studios AB | https://www.embark-studios.com/ | [#2097](https://github.com/KhronosGroup/glTF/issues/2097) |
 | `EPIC` | Epic Games, Inc. | https://www.epicgames.com/ | [#1905](https://github.com/KhronosGroup/glTF/issues/1905) |
 | `ESSILORLUXOTTICA` | Luxottica Group S.p.A. | https://www.essilorluxottica.com/ | [#2204](https://github.com/KhronosGroup/glTF/issues/2204) |
 | `F8` | Forum8 Co., Ltd. | https://www.forum8.com/ | [#1999](https://github.com/KhronosGroup/glTF/issues/1999) |
 | `FB` | Facebook, Inc. | https://www.facebook.com/ | [#1139](https://github.com/KhronosGroup/glTF/pull/1139) |
-| `FOXIT` | Foxit Software, Inc. | https://foxitsoftware.com<br>`liqian_mu at foxitsoftware.com` | [#1712](https://github.com/KhronosGroup/glTF/issues/1712) |
+| `FOXIT` | Foxit Software, Inc. | https://foxitsoftware.com/<br>`liqian_mu at foxitsoftware.com` | [#1712](https://github.com/KhronosGroup/glTF/issues/1712) |
 | `GOOGLE` | Google, LLC | https://www.google.com/ | [#1123](https://github.com/KhronosGroup/glTF/issues/1123) |
 | `GRIFFEL` | Griffel Studio | https://griffelstudio.com/ | [#1861](https://github.com/KhronosGroup/glTF/issues/1861) |
 | `HEVOLUS` | Hevolus Srl | https://www.hevolus.it/ | [#2183](https://github.com/KhronosGroup/glTF/issues/2183) |
-| `ICOSA` | Icosa Foundation | https://icosa.foundation | [#2208](https://github.com/KhronosGroup/glTF/issues/2208) |
+| `ICOSA` | Icosa Foundation | https://icosa.foundation/ | [#2208](https://github.com/KhronosGroup/glTF/issues/2208) |
 | `INTEL` | Intel Corporation | https://www.intel.com/ | [#2142](https://github.com/KhronosGroup/glTF/issues/2142) |
 | `KDAB` | The KDAB Group | https://www.kdab.com/ | [#1728](https://github.com/KhronosGroup/glTF/pull/1728) |
 | `LLQ` | Lifeliqe, Inc. | https://www.lifeliqe.com/ | [#1414](https://github.com/KhronosGroup/glTF/issues/1414) |
@@ -56,10 +56,10 @@ Once a prefix is approved, it should be added to the [glTF Validator's list of k
 | `MX` | The Matrix.org Foundation | https://matrix.org/ | [#2126](https://github.com/KhronosGroup/glTF/issues/2126) |
 | `NEEDLE` | Needle Tools | https://needle.tools/<br>`felix at needle.tools` | [#2131](https://github.com/KhronosGroup/glTF/issues/2131) |
 | `NTAR` | Nextech AR Solutions Inc. | https://www.nextechar.com/<br>`mitch at nextechar.com` | [#2188](https://github.com/KhronosGroup/glTF/issues/2188) |
-| `NV` | NVIDIA Corporation | https://www.nvidia.com | [#1211](https://github.com/KhronosGroup/glTF/issues/1211) |
+| `NV` | NVIDIA Corporation | https://www.nvidia.com/ | [#1211](https://github.com/KhronosGroup/glTF/issues/1211) |
 | `OFT` | OppenFuture Technologies | https://www.hololux.cn/en/ | [#1957](https://github.com/KhronosGroup/glTF/issues/1957) |
 | `OMI` | Open Metaverse Interoperability Group | https://github.com/omigroup/OMI | [#2003](https://github.com/KhronosGroup/glTF/issues/2003) |
-| `OTOY` | OTOY, Inc. | https://otoy.com | [#2112](https://github.com/KhronosGroup/glTF/issues/2112) |
+| `OTOY` | OTOY, Inc. | https://otoy.com/ | [#2112](https://github.com/KhronosGroup/glTF/issues/2112) |
 | `OWLII` | Owlii, Inc. | https://www.owlii.com/ | [#1093](https://github.com/KhronosGroup/glTF/issues/1093) |
 | `PANDA3D` | Panda3D | https://www.panda3d.org/ | [#1828](https://github.com/KhronosGroup/glTF/pull/1828) |
 | `POLUTROPON` | Polutropon Games | https://polutropon.games/<br>`ybalrid at polutropon.games` | [#1632](https://github.com/KhronosGroup/glTF/issues/1632) |
@@ -74,8 +74,8 @@ Once a prefix is approved, it should be added to the [glTF Validator's list of k
 | `SNAP` | Snap, Inc. | https://snap.com/ | [#2125](https://github.com/KhronosGroup/glTF/issues/2125) |
 | `SPECTRUM` | Spectrum | https://spectrumcustomizer.com/ | [#1804](https://github.com/KhronosGroup/glTF/issues/1804) |
 | `TENCENT` | Tencent, Inc. | https://www.tencent.com/ | [#2118](https://github.com/KhronosGroup/glTF/issues/2118) |
-| `TRYON` | TRYON Technology Ltd. | https://tryon.technology | [#1785](https://github.com/KhronosGroup/glTF/issues/1785) |
-| `UNITY` | Unity Software Inc. | https://unity.com | [#2185](https://github.com/KhronosGroup/glTF/issues/2185) |
+| `TRYON` | TRYON Technology Ltd. | https://tryon.technology/ | [#1785](https://github.com/KhronosGroup/glTF/issues/1785) |
+| `UNITY` | Unity Software Inc. | https://unity.com/ | [#2185](https://github.com/KhronosGroup/glTF/issues/2185) |
 | `USSF` | US Space Force | https://www.spaceforce.mil/ | [#2177](https://github.com/KhronosGroup/glTF/issues/2177) |
 | `UX3D` | UX3D GmbH | https://ux3d.io/ | [#1896](https://github.com/KhronosGroup/glTF/pull/1896) |
 | `VRMC` | VRM Consortium | https://vrm-consortium.org/ | [#1874](https://github.com/KhronosGroup/glTF/issues/1874) |


### PR DESCRIPTION
As mentioned in https://github.com/KhronosGroup/glTF/pull/2209#discussion_r988238495 , most root URLs in the prefixes list did have trailing slashes `/`, but some didn't. This PR adds them where they have not been present.
