### PR TITLE
`KHR_lights_punctual`: Clarify relationship between intensity and color. Also some grammar.

### DIFF
--- a/extensions/2.0/Khronos/KHR_lights_punctual/README.md
+++ b/extensions/2.0/Khronos/KHR_lights_punctual/README.md
@@ -86,12 +86,14 @@ All light types share the common set of properties listed below.
 | Property | Description | Required |
 |:-----------------------|:------------------------------------------| :--------------------------|
 | `name` | Name of the light. | No, Default: `""` |
-| `color` | RGB value for light's color in linear space. | No, Default: `[1.0, 1.0, 1.0]` |
-| `intensity` | Brightness of light in. The units that this is defined in depend on the type of light. `point` and `spot` lights use luminous intensity in candela (lm/sr) while `directional` lights use illuminance in lux (lm/m<sup>2</sup>) | No, Default: `1.0` |
+| `color` | RGB value for the light's color in linear space. | No, Default: `[1.0, 1.0, 1.0]` |
+| `intensity` | Brightness of the light. The units that this is defined in depend on the type of light. `point` and `spot` lights use luminous intensity in candela (lm/sr) while `directional` lights use illuminance in lux (lm/m<sup>2</sup>) | No, Default: `1.0` |
 | `type` | Declares the type of the light. | :white_check_mark: Yes |
 | `range` | Hint defining a distance cutoff at which the light's intensity may be considered to have reached zero. Supported only for `point` and `spot` lights. Must be > 0. When undefined, range is assumed to be infinite. | No |
 
 Light properties are unaffected by node transforms — for example, `range` and `intensity` do not change with scale.
+
+The `intensity` represents the luminous intensity that the light would emit if it were colored pure white (`[1.0, 1.0, 1.0]`). The `color` property acts as a wavelength-specific multiplier.
 
 ## Range Property
 

--- a/extensions/2.0/Khronos/KHR_lights_punctual/README.md
+++ b/extensions/2.0/Khronos/KHR_lights_punctual/README.md
@@ -79,9 +79,9 @@ For light types that have a direction (`directional` and `spot` lights), the lig
 
 ## Light Types
 
-All light types share the common set of properties listed below.
-
 ### Light Shared Properties
+
+All light types share the common set of properties listed below.
 
 | Property | Description | Required |
 |:-----------------------|:------------------------------------------| :--------------------------|
@@ -95,7 +95,7 @@ Light properties are unaffected by node transforms — for example, `range` and 
 
 The `intensity` represents the luminous intensity that the light would emit if it were colored pure white (`[1.0, 1.0, 1.0]`). The `color` property acts as a wavelength-specific multiplier.
 
-## Range Property
+#### Range Property
 
 The range property (allowed only on point and spot lights) defines a distance cutoff at which the light's intensity must be considered zero, meaning the light no longer affects the surrounding area. This can be useful to cull geometry that a light may not visibly affect, potentially having a significant positive impact on rendering performance. It is required that, when given a non-zero value, rendering engines ignore the light beyond this range.
 
@@ -107,7 +107,7 @@ A recommended implementation for this attenuation with a cutoff range is as foll
 
 ### Directional
 
-Directional lights are light sources that act as though they are infinitely far away and emit light in the direction of the local -z axis. This light type inherits the orientation of the node that it belongs to; position and scale are ignored except for their effect on the inherited node orientation. Because it is at an infinite distance, the light is not attenuated. Its intensity is defined in lumens per metre squared, or lux (lm/m<sup>2</sup>).
+Directional lights are light sources that act as though they are infinitely far away and emit light in the direction of the local -z axis. This light type inherits the orientation of the node that it belongs to; position and scale are ignored except for their effect on the inherited node orientation. Because it is at an infinite distance, the light is not attenuated. Directional light intensity is defined in lumens per metre squared, or lux (lm/m<sup>2</sup>).
 
 ### Point
 


### PR DESCRIPTION
In #2214 I ended up also making explicit the presumed separation between light intensity and light colour. (I.E. Light colour does not get normalized to match the intensity.) I also did some minor grammar and formatting changes/fixes.

This `cherry-pick`s those changes.

This is not meant to change what the specification says, only make clearer and explicit what I believed was already presumed.