### PR TITLE
Add license info to Microsoft extensions

### DIFF
--- a/extensions/2.0/Vendor/EXT_lights_image_based/README.md
+++ b/extensions/2.0/Vendor/EXT_lights_image_based/README.md
@@ -111,7 +111,7 @@ Each scene can have a single IBL light attached to it by defining the `extension
                 "light" : 0
             }
         }
-    }            
+    }
 ]
 ```
 
@@ -126,3 +126,5 @@ Each scene can have a single IBL light attached to it by defining the `extension
 | `specularImages` | Declares an array of the first N mips of the prefiltered cubemap. Each mip is, in turn, defined with an array of 6 images, one for each cube face. i.e. this is an Nx6 array. | :white_check_mark: Yes |
 | `specularImageSize` | The dimension (in pixels) of the first specular mip. This is needed to determine, pre-load, the total number of mips needed. | :white_check_mark: Yes |
 
+## License
+Adobe and Microsoft has made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.

--- a/extensions/2.0/Vendor/EXT_lights_image_based/README.md
+++ b/extensions/2.0/Vendor/EXT_lights_image_based/README.md
@@ -127,4 +127,4 @@ Each scene can have a single IBL light attached to it by defining the `extension
 | `specularImageSize` | The dimension (in pixels) of the first specular mip. This is needed to determine, pre-load, the total number of mips needed. | :white_check_mark: Yes |
 
 ## License
-Adobe and Microsoft has made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.
+Adobe and Microsoft have made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.

--- a/extensions/2.0/Vendor/EXT_lights_image_based/README.md
+++ b/extensions/2.0/Vendor/EXT_lights_image_based/README.md
@@ -127,4 +127,5 @@ Each scene can have a single IBL light attached to it by defining the `extension
 | `specularImageSize` | The dimension (in pixels) of the first specular mip. This is needed to determine, pre-load, the total number of mips needed. | :white_check_mark: Yes |
 
 ## License
+
 Adobe and Microsoft have made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.

--- a/extensions/2.0/Vendor/MSFT_lod/README.md
+++ b/extensions/2.0/Vendor/MSFT_lod/README.md
@@ -125,4 +125,5 @@ If both node level and material level LODs are specified then the material level
 * [BabylonJS](https://github.com/BabylonJS/Babylon.js/tree/master/loaders/src/glTF) has support for `MSFT_lod` extension defined at the material or node level. The current implementation progressively loads each LOD to improve the initial load time of the asset.  
 * Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality use `MSFT_lod` at the `node` level to support switching LODs based on the render distance.
 
-
+## License
+Microsoft has made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.

--- a/extensions/2.0/Vendor/MSFT_lod/README.md
+++ b/extensions/2.0/Vendor/MSFT_lod/README.md
@@ -126,4 +126,5 @@ If both node level and material level LODs are specified then the material level
 * Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality use `MSFT_lod` at the `node` level to support switching LODs based on the render distance.
 
 ## License
+
 Microsoft has made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.

--- a/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/README.md
+++ b/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/README.md
@@ -117,4 +117,5 @@ The example below shows how this extension can be used along with the MSFT_textu
 This extension is used by Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality to improve performance by using the specially packed textures. [glTF-Toolkit](https://github.com/Microsoft/glTF-Toolkit) can be used to generate files that use this extension.
 
 ## License
+
 Microsoft has made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.

--- a/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/README.md
+++ b/extensions/2.0/Vendor/MSFT_packing_normalRoughnessMetallic/README.md
@@ -115,3 +115,6 @@ The example below shows how this extension can be used along with the MSFT_textu
 ## Known Implementations
 
 This extension is used by Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality to improve performance by using the specially packed textures. [glTF-Toolkit](https://github.com/Microsoft/glTF-Toolkit) can be used to generate files that use this extension.
+
+## License
+Microsoft has made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.

--- a/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md
+++ b/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md
@@ -140,3 +140,5 @@ The example below shows how this extension can be used along with the MSFT_textu
 
 This extension is used by Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality to improve performance by using the specially packed textures. [glTF-Toolkit](https://github.com/Microsoft/glTF-Toolkit) can be used to generate files that use this extension.
 
+## License
+Microsoft has made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.

--- a/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md
+++ b/extensions/2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md
@@ -141,4 +141,5 @@ The example below shows how this extension can be used along with the MSFT_textu
 This extension is used by Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality to improve performance by using the specially packed textures. [glTF-Toolkit](https://github.com/Microsoft/glTF-Toolkit) can be used to generate files that use this extension.
 
 ## License
+
 Microsoft has made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.

--- a/extensions/2.0/Vendor/MSFT_texture_dds/README.md
+++ b/extensions/2.0/Vendor/MSFT_texture_dds/README.md
@@ -74,3 +74,6 @@ When used in the glTF Binary (.glb) format the `images` node that points to the 
 ## Known Implementations
 
 This extension is used by Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality to improve performance by including DDS textures. [glTF-Toolkit](https://github.com/Microsoft/glTF-Toolkit) can be used to generate files that use this extension.
+
+## License
+Microsoft has made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.

--- a/extensions/2.0/Vendor/MSFT_texture_dds/README.md
+++ b/extensions/2.0/Vendor/MSFT_texture_dds/README.md
@@ -76,4 +76,5 @@ When used in the glTF Binary (.glb) format the `images` node that points to the 
 This extension is used by Windows Mixed Reality Home and 3D Launchers for Windows Mixed Reality to improve performance by including DDS textures. [glTF-Toolkit](https://github.com/Microsoft/glTF-Toolkit) can be used to generate files that use this extension.
 
 ## License
+
 Microsoft has made this Specification available under the Open Web Foundation Agreement Version 1.0, which is available at https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0.


### PR DESCRIPTION
See #2210.

TODO
- [x] Adobe signs off on EXT_lights_image_based wording.