### PR TITLE
KHR_lights_shadows extension

### DIFF
--- a/extensions/2.0/Khronos/KHR_lights_shadows/Readme.md
+++ b/extensions/2.0/Khronos/KHR_lights_shadows/Readme.md
@@ -1,0 +1,110 @@
+# KHR\_lights\_shadows
+
+## Contributors
+
+* Takahiro Aoyagi, Mozilla, [@takahirox](https://github.com/takahirox)
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec and
+[`KHR_lights_punctual`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_lights_punctual).
+
+## Overview
+
+This `KHR_lights_shadows` extension defines what meshes cast or receive shadows
+and what lights cast shadows against
+[`KHR_lights_punctual`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_lights_punctual).
+
+Rendering with shadows needs a lot of calculation. It is a common technique to
+select objects which cast or receive shadows in a scene.
+`KHR_lights_punctual` extension has the capability of defining lights but doesn't
+have the capability of defining shadows.
+
+This `KHR_lights_shadows` extension provides a way to let applications or
+engines know what meshes should cast or receive shadows and what lights should
+cast shadows.
+
+## Cast/Receive shadows for Meshes
+
+Whether a mesh casts shadows and whether it receives shadows are defined by
+adding `extensions.KHR_lights_shadows` property to a `mesh` definition
+with `castShadows` and `receiveShadows` boolean properties inside it.
+
+```
+"meshes": [{
+    "primitives": [
+        ...
+    ],
+    "extensions": {
+        "KHR_lights_shadows": {
+            "castShadows": false,
+            "receiveShadows": true
+        }
+    }
+}, {
+    "primitives": [
+        ...
+    ],
+    "extensions": {
+        "KHR_lights_shadows": {
+            "castShadows": false,
+            "receiveShadows": true
+        }
+    }
+}]
+```
+
+## Turn on/off shadows for Lights
+
+Whether a light casts shadows is defined by adding
+`extensions.KHR_lights_shadows` property to a top-level
+`extensions.KHR_lights_punctual` definition with `castShadows` boolean property
+inside it.
+
+```
+"extensions": {
+    "KHR_lights_punctual": {
+        "lights": [{
+            "type": ...,
+            "color": ...,
+            "extensions": {
+                "KHR_lights_shadows": {
+                    "castShadows": true
+                }
+            }
+        }]
+    }
+}]
+```
+
+## Cast/Receive Shadows properties for Mesh
+
+| Property | Type | Description | Requires |
+|:------|:------|:------|:------|
+| `castShadows` | `boolean` | Whether the mesh casts shadows | No, default: `true` |
+| `receiveShadows` | `boolean` | Whether the mesh receives shadows | No, default: `true` |
+
+## Cast shadows property for Light
+
+| Property | Type | Description | Requires |
+|:------|:------|:------|:------|
+| `castShadows` | `boolean` | Whether the light casts shadows | No, default: `true` |
+
+## glTF Schema Updates
+
+* **JSON schema**:
+  * [mesh.KHR_lights_shadows.schema.json](schema/mesh.KHR_lights_shadows.schema.json)
+  * [glTF.KHR_lights_punctual.KHR_lights_shadows.schema.json](schema/glTF.KHR_lights_punctual.KHR_lights_shadows.schema.json)
+
+## Implementation Note
+
+This extension doesn't define shadow rendering techniques (ie. Shadow Map) or
+shadow types (ie. PCF). They should be application or engine specific.
+
+`castShadows` and `receiveShadows` properties for Meshes don't define whether the
+mesh is visible. Similarly `castShadows` property for Lights doesn't define whether
+the light is active.

--- a/extensions/2.0/Khronos/KHR_lights_shadows/schema/glTF.KHR_lights_punctual.KHR_lights_shadows.schema.json
+++ b/extensions/2.0/Khronos/KHR_lights_shadows/schema/glTF.KHR_lights_punctual.KHR_lights_shadows.schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "KHR_lights_shadows glTF.extensions.KHR_lights_punctual extension",
+    "type": "object",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "castShadows": {
+            "type": "boolean",
+            "description": "Whether the light node casts shadows."
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}

--- a/extensions/2.0/Khronos/KHR_lights_shadows/schema/mesh.KHR_lights_shadows.schema.json
+++ b/extensions/2.0/Khronos/KHR_lights_shadows/schema/mesh.KHR_lights_shadows.schema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "KHR_lights_shadows mesh extension",
+    "type": "object",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "castShadows": {
+            "type": "boolean",
+            "description": "Whether the mesh casts shadows."
+        },
+        "receiveShadows": {
+            "type": "boolean",
+            "description": "Whether the mesh receives shadows."
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}


### PR DESCRIPTION
Working repository https://github.com/takahirox/KHR_lights_shadows

I would like to propose `KHR_lights_shadows` extension that allows to define whether a mesh casts or receives shadows and whether a light casts shadows against [`KHR_lights_punctual`](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_lights_punctual/README.md) extension.

Rendering with shadows needs a lot of calculation. It is a common technique to select objects which cast or receive shadows in a scene. `KHR_lights_punctual` extension has the capability of defining lights but doesn't have the capability of defining shadows.

This `KHR_lights_shadows` extension provides a way to let applications or engines know what meshes should cast or receive shadows and what lights should cast shadows.

Note that this extension doesn't define shadow rendering techniques (ie. Shadow Map) or shadow types (ie. PCF). They should be application or engine specific.

And also it doesn't define whether a mesh is visible and doesn't define whether a light is active.

**Examples**

Define whether a mesh casts/receives shadows in `glTF.mesh`.

```
"meshes": [{
    "primitives": [
        ...
    ],
    "extensions": {
        "KHR_lights_shadows": {
            "castShadows": false,
            "receiveShadows": true
        }
    }
}, {
    "primitives": [
        ...
    ],
    "extensions": {
        "KHR_lights_shadows": {
            "castShadows": false,
            "receiveShadows": true
        }
    }
}]
```

Define whether a light casts shadows in `glTF.extensions.KHR_lights_punctual.light.extensions.KHR_lights_shadows`.

```
"extensions": {
    "KHR_lights_punctual": {
        "lights": [{
            "type": ...,
            "color": ...,
            "extensions": {
                "KHR_lights_shadows": {
                    "castShadows": true
                }
            }
        }]
    }
}]
```
