### PR TITLE
EXT_mesh_lod extension proposal

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_lod/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_lod/README.md
@@ -1,0 +1,115 @@
+# EXT\_mesh\_lod
+
+## Contributors
+
+* Takahiro Aoyagi, Mozilla, [@takahirox](https://github.com/takahirox)
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This `EXT_mesh_lod` extension adds the ability to specify Levels of Detail
+(LOD) to glTF `mesh`. An implementation of this extension can use the
+LODs for various scenarios like rendering a different LOD based upon the
+distance of the object or progressively loading the glTF asset starting with
+the lowest LOD.
+
+This extension allows an LOD to be defined in a `node`. If the extension
+is defined in a `node`, `mesh` **MUST** also be defined in the `node`.
+The LODs can specify different meshes across various levels.
+
+The extension is added to the highest LOD level. The extension defines an
+`mesh_lod` property which is an array containing the objects including the
+`mesh` property that points to the index of the `mesehes` node as LOD mesh
+and the optional `skin` and `weights` property for skinning and morph for
+the LOD mesh, and the screen coverage number as a hint to determine the
+switching threshold for the LOD.
+
+Each `mesh` index in the array points to a LOD level that is lower in quality
+than the previous level.
+
+For example, if a `node` has a `mesh` and the extension, the `meshes` node
+referred by the `mesh` property in the `node` is the highest LOD level. Every
+`mesh` property specified in the array of the extension points to the index of
+`meshes` node which should be used as the lower LOD level.
+
+An implementation of this extension can parse through the array to create the
+list of LOD levels available for an asset. If an asset containing this extension
+is loaded in a client that doesn't implement the extension, then the highest
+LOD level will be loaded and all lower LODs will be ignored.
+
+## Examples
+
+```json
+"nodes": [{
+    "mesh": 0,
+    "extensions": {
+        "EXT_mesh_lod": {
+            "mesh_lod": [
+                {"mesh": 1, "coverage": 0.5},
+                {"mesh": 2, "coverage": 0.2}
+            ]
+        }
+    }
+}]
+ ```
+
+In this node, *mesh[0]* is the highest LOD. The first element in the `mesh_lod`
+array, *mesh[1]*, is the next lower LOD (or the Medium_LOD). The second element
+in the `mesh_lod` array, *mesh[2]*, is the lowest LOD.
+
+## Screen coverage
+
+The `coverage` property in the `mesh_lod` array specifies a screen coverage
+value that can be used as a hint to determine the switching threshold for the
+various LODs.
+
+Screen coverage is a ratio between `0.0` and `1.0` representing how big the
+mesh's rendered screen surface area is in the total screen surface area.
+
+The highest LOD `coverage` value is implied to `1.0`. The `coverage` value
+must be between `0.0` and `1.0`, and must be between the next higher LOD
+`coverage` value and the next lower LOD `coverage` value.
+
+The LOD is expected to be selected to be rendered if the current screen
+coverage is between the LOD's `coverage` value and the next lower LOD
+`coverage` value.
+
+In the example above the screen coverage values can be used as follows:
+
+* LOD0(high) Rendered from 1.0 to 0.5
+* LOD1(medium) Rendered from 0.5 to 0.2
+* LOD2(low) Rendered from 0.2 to 0
+
+## Mesh LOD Array property
+
+| Property | Type | Description | Requires |
+|:------|:------|:------|:------|
+| `mesh_lod` | `lod [1-*]` | Lower mesh LODs definition | :white_check_mark: Yes |
+
+## Properties of Mesh LOD Array entry
+
+| Property | Type | Description | Requires |
+|:------|:------|:------|:------|
+| `mesh` | `integer` | `mesh` index for this LOD level. Refer to [`node.mesh`](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#_node_mesh) in the core spec for the details. | :white_check_mark: Yes |
+| `skin` | `integer` | `skin` index for this LOD level `mesh` skinning. Refer to [`node.skin`](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#_node_skin) in the core spec for the details. | No |
+| `weights` | `number [1-*]` | `weights` for this LOD level `mesh` morph. Refer to [`node.weights`](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#_node_weights) in the core spec for the details. | No |
+| `coverage` | `number` | Screen coverage for switching for this LOD level. The value must be between `0.0` and `1.0`, and must be between the next higher LOD `coverage` value and the next lower LOD `coverage` value. | :white_check_mark: Yes |
+
+## Schema
+
+* [node.EXT_mesh_lod.schema.json](schema/node.EXT_mesh_lod.schema.json)
+
+## Reference
+
+* [glTF `MSFT_lod` extension](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/MSFT_lod):
+A glTF LOD vendor extension proposed by Microsoft. It allows more flexible
+LOD configuration. The `EXT_mesh_lod` extension has simpler data structure
+than `MSFT_lod` so less flexible but easier to handle for the extension
+handlers.

--- a/extensions/2.0/Vendor/EXT_mesh_lod/schema/node.EXT_mesh_lod.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_lod/schema/node.EXT_mesh_lod.schema.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "EXT_mesh_lod glTF extension",
+    "type": "object",
+    "description": "glTF extension for specifying levels of detail (LOD) for mesh.",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "mesh_lod": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+                "properties": {
+                    "mesh": {
+                        "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                        "description": "LOD mesh index"
+                    },
+                    "skin": {
+                        "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                        "description": "LOD skin index"
+                    },
+                    "weights": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        },
+                        "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                        "description": "Array containing weights values for morph",
+                        "minItems": 1
+                    },
+                    "coverage": {
+                        "type": "number",
+                        "minimum": 0.0,
+                        "maximum": 1.0,
+                        "description": "Screen coverage for switching"
+                    },
+                    "extensions": { },
+                    "extras": { }
+                }
+                "required": [ "mesh", "coverage" ]
+            },
+            "description": "Array containing the objects including the mesh index as lower LOD and screen coverage as a hint to switch.",
+            "minItems": 1
+        },
+        "extensions": { },
+        "extras": { }
+    },
+    "required": [ "mesh_lod" ]
+}


### PR DESCRIPTION
Working repository: https://github.com/takahirox/EXT_mesh_lod

I would like to propose `EXT_mesh_lod` extension that allows LODs for `mesh` in glTF.

I know already [`MSFT_lod`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/MSFT_lod) extension exists for LOD. The new extension is less flexible but simpler than `MSFT_lod` so it should be easier for the handlers (implementations) to handle.

**JSON structure and examples**

`EXT_mesh_lod` can be defined at the `node` level.

```json
"nodes": [{
    "mesh": 0,
    "extensions": {
        "EXT_mesh_lod": {
            "mesh_lod": [
                {"mesh": 1, "coverage": 0.5},
                {"mesh": 2, "coverage": 0.2}
            ]
        }
    }
}]
 ```

```json
"nodes": [{
    "mesh": 0,
    "skin": 0,
    "weights": [0.0, 1.0],
    "extensions": {
        "EXT_mesh_lod": {
            "mesh_lod": [
                {"mesh": 1, "skin": 1, "weights": [0.0, 1.0], "coverage": 0.5},
                {"mesh": 2, "skin": 2, "weights": [0.0, 1.0], "coverage": 0.2}
            ]
        }
    }
}]
 ```

**Difficulty of handling `MSFT_lod`**

While I was writing [a handler for `MSFT_lod`](https://github.com/takahirox/three-gltf-extensions/tree/main/loaders/MSFT_lod) I realized that `MSFT_lod` has some difficulties to handle.

* Both `node` and `material` can define LOD. The behavior is unstated in the specification if `material` containing LOD is referred by `node` containing LOD.
* A `node` can specify other `node`s so LOD `node` can form nest or even infinity loop. And the behavior for them is unstated in the specification.
* A node can specify other `node`s. `node` can have multiple type objects; `mesh`, `camera`, `light` (with the extension). The behavior is unstated in the specification if LODs have different type objects ex: High LOD has only `mesh` and Low LOD has only `camera` or even doesn't have any objects.
* Threshold for switching LOD is defined in `extra` as optional. Unclear how to switch LOD for applications/viewers/engines if it is undefined because they don't know the qualities of LODs.

Even the behaviors are stated in the specification, the implementations can be complex because they need to check a lot of definitions.

**Simplification ideas**

I would like to suggest to simplify the specification. It will lose some flexibilities but be simpler for the handlers to handle.

* Allow to define LOD only at node for `mesh`. This change can avoid the case where both node and material have LOD. Material LOD capability is still covered by LOD meshes refer to the same geometry attributes and refer to different materials. And the change can clarify what LOD can be defined for.
* The extension in a node specifies mesh indices as LOD meshes. This can avoid the nest and different type node object LOD.
* Require threshold values. This can avoid unknown threasholds for applications/viewers/engines.

**Additional notes**

* The reason why allowing the extension at `node`, not `mesh`, is to avoid nest across `mesh`es caused by refering a `mesh` from another (or self) `mesh`. And also to allow `skin` and `weights` properties for LOD. If LOD is defined at `mesh`, lower LOD `mesh`es must have the same bones/morphs with the highest LOD `mesh`, it may be a bit too limited.
* With the simplification suggestions, the extension will be easier to be handled so I think it would be good to be a multi-vendor extension (`EXT_` prefix) rather than a vendor extension.

**Discussions**

I'm still thinking how threshold values should be, screen coverage, distance from camera, or others. In the current PR, I chose screen coverage for now. Probably compatibility is important so we may need to choose the one that can be handled consistently across applications/viewers/engines.

https://github.com/takahirox/EXT_mesh_lod/issues/1

**Related threads**

* https://github.com/KhronosGroup/glTF/issues/1045
* https://github.com/KhronosGroup/glTF/issues/1743
* https://github.com/KhronosGroup/glTF/issues/1952
* https://github.com/KhronosGroup/glTF/issues/1953
