### PR TITLE
Add: EXT_texture_qoi

### DIFF
--- a/extensions/2.0/Vendor/EXT_texture_qoi/README.md
+++ b/extensions/2.0/Vendor/EXT_texture_qoi/README.md
@@ -1,0 +1,97 @@
+# EXT_texture_qoi
+
+## Contributors
+
+* Sean, [@spnda](https://github.com/spnda)
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension allows glTF models to use QOI as a valid image format. A client that does not implement this extension can ignore the provided QOI image and continue to rely on the PNG and JPG textures available in the base specification. Defining a fallback texture is optional.
+
+QOI is an image format developed and maintained by Dominic Szablewski that provides lossless image compression with a similar size compared to PNGs exported by libpng and stbi, while being much faster to decode and encode - [source](https://qoiformat.org/).
+
+## glTF Schema Updates
+
+The `EXT_texture_qoi` extension is added to the `textures` node and specifies a `source` property that points to the index of the `images` node which in turn points to the QOI image.
+
+The following glTF will load `image.qoi` in clients that support this extension, and otherwise fall back to `image.png`.
+
+```json
+"textures": [
+    {
+        "source": 0,
+        "extensions": {
+            "EXT_texture_qoi": {
+                "source": 1
+            }
+        }
+    }
+],
+"images": [
+    {
+        "uri": "image.png"
+    },
+    {
+        "uri": "image.qoi"
+    }
+]
+```
+
+When used in the glTF Binary (.glb) format the `images` node that points to the QOI image uses the `mimeType` value of `image/qoi`.
+
+```json
+"textures": [
+    {
+        "source": 0,
+        "extensions": {
+            "EXT_texture_qoi": {
+                "source": 1
+            }
+        }
+    }
+],
+"images": [
+    {
+        "mimeType": "image/png",
+        "bufferView": 1
+    },
+    {
+        "mimeType": "image/qoi",
+        "bufferView": 2
+    }
+]
+```
+
+### Using without a fallback
+
+To use QOI images without a fallback, define `EXT_texture_qoi` in both `extensionsUsed` and `extensionsRequired`. The `texture` node will then only have an `extensions` property as shown below.
+
+```json
+"textures": [
+    {
+        "extensions": {
+            "EXT_texture_qoi": {
+                "source": 0
+            }
+        }
+    }
+],
+```
+
+If a glTF contains a QOI texture with no fallback texture, the client should either display an error or use a default texture.
+
+## Known implementations
+
+* [fastgltf](https://github.com/spnda/fastgltf), a glTF library aimed at greatly improving speeds in every way.
+
+## Resources
+
+The [QOI website](https://qoiformat.org/) and the [QOI format specification](https://qoiformat.org/qoi-specification.pdf) contains everything you need to know about the format, including implementations, benchmarks, and the file structure.

--- a/extensions/2.0/Vendor/EXT_texture_qoi/schema/glTF.EXT_texture_qoi.schema.json
+++ b/extensions/2.0/Vendor/EXT_texture_qoi/schema/glTF.EXT_texture_qoi.schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "EXT_texture_qoi glTF extension",
+    "type": "object",
+    "description": "glTF extension to specify textures using the QOI image format.",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "source": {
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
+            "description": "The index of the images node which points to a QOI image."
+        },
+        "extensions": {},
+        "extras": {}
+    }
+}

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -37,6 +37,7 @@ When an extension is implemented by more than one vendor, its name can use the r
 * [EXT_lights_image_based](2.0/Vendor/EXT_lights_image_based/README.md)
 * [EXT_mesh_gpu_instancing](2.0/Vendor/EXT_mesh_gpu_instancing/README.md)
 * [EXT_meshopt_compression](2.0/Vendor/EXT_meshopt_compression/README.md)
+* [EXT_texture_qoi](2.0/Vendor/EXT_texture_qoi/README.md)
 * [EXT_texture_webp](2.0/Vendor/EXT_texture_webp/README.md)
 
 ### Vendor Extensions for glTF 2.0


### PR DESCRIPTION
This adds an extension for the [QOI image format](https://qoiformat.org/), which is an incredibly simple format that losslessly compresses images to a similar size of PNG, while offering 20x-50x faster encoding and 3x-4x faster decoding compared to libpng and stbi.

I came across this format recently and thought it'd make a great addition to glTF to vastly increase load times while still being supported by virtually any platform just like PNG and JPEG are. The reference decoder and encoder is only 300 loc in C, making QOI a format that's incredibly easy to implement. I've noted that my own glTF library now supports the extension (albeit on [another branch](https://github.com/spnda/fastgltf/tree/EXT_texture_qoi)).