### PR TITLE
KHR_materials_transmission: Minor fix to implementation note.

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_transmission/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_transmission/README.md
@@ -199,7 +199,7 @@ $$
 using the transmission half vector $H_T$
 
 $$
-H_T = \text{normalize}(V + 2 \left( N \cdot -L \right) N + L)
+H_T = \text{normalize}(V - 2 \left( N \cdot L \right) N + L)
 $$
 
 With the step function $\chi^+$ we ensure that the microsurface is only visible for directions that are on the same side of the macro and microsurfaces. Macro and microsurfaces are oriented according to $N$ and $H_T$, respectively.

--- a/extensions/2.0/Khronos/KHR_materials_transmission/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_transmission/README.md
@@ -199,7 +199,7 @@ $$
 using the transmission half vector $H_T$
 
 $$
-H_T = \text{normalize}(V + 2 \left| N \cdot L \right| N + L)
+H_T = \text{normalize}(V + 2 \left| N \cdot -L \right| N + L)
 $$
 
 With the step function $\chi^+$ we ensure that the microsurface is only visible for directions that are on the same side of the macro and microsurfaces. Macro and microsurfaces are oriented according to $N$ and $H_T$, respectively.

--- a/extensions/2.0/Khronos/KHR_materials_transmission/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_transmission/README.md
@@ -199,7 +199,7 @@ $$
 using the transmission half vector $H_T$
 
 $$
-H_T = \text{normalize}(V + 2 \left| N \cdot -L \right| N + L)
+H_T = \text{normalize}(V + 2 \left( N \cdot -L \right) N + L)
 $$
 
 With the step function $\chi^+$ we ensure that the microsurface is only visible for directions that are on the same side of the macro and microsurfaces. Macro and microsurfaces are oriented according to $N$ and $H_T$, respectively.


### PR DESCRIPTION
This is a minor fix to an implementation note in the KHR_materials_transmission extension. I believe there's a missing negative sign in our computation for the transmission half vector (must use dot(N,-L)).

This is already done correctly in the sample viewer: [punctional.glsl](https://github.com/KhronosGroup/glTF-Sample-Viewer/blob/9693a0380cd268f18e7523a3e2b961cda58b3c02/source/Renderer/shaders/punctual.glsl#L83)

I also confirmed that EnterprisePBR also uses the correct dot(N,-L). See equation 5 in [EnterprisePBR](https://dassaultsystemes-technology.github.io/EnterprisePBRShadingModel/spec-2022x.md.html#components/core/dielectricbsdffortransparentsurfaces)