### PR TITLE
KHR_texture_video

### DIFF
--- a/extensions/2.0/Khronos/KHR_texture_video/README.md
+++ b/extensions/2.0/Khronos/KHR_texture_video/README.md
@@ -45,7 +45,9 @@ The following glTF will load `texture.webm` in clients that support this extensi
 "extensions": {
     "KHR_texture_video": {
         "videos": [
-            "uri": "texture.webm"
+            {
+                "uri": "texture.webm"
+            }
         ]
     }
 }


### PR DESCRIPTION
This is a proposal for an extension to standardize the way that video textures can be assigned in gltf. Currently video textures are supported by most standard 3D players on the web, but the configuration of the texture requires custom javascript unique to each player. This extension intends to standardize that.