### PR TITLE
Anisotropy strength: Fix choice of JSON schema field

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_anisotropy/schema/glTF.KHR_materials_anisotropy.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_anisotropy/schema/glTF.KHR_materials_anisotropy.schema.json
@@ -7,11 +7,11 @@
     "properties": {
         "anisotropyStrength": {
             "type": "number",
-            "description": "The anisotropy strength. When anisotropyTexture is present, this value is multiplied by the blue channel.",
+            "description": "Anisotropic strength",
             "default": 0.0,
             "minimum": 0.0,
             "maximum": 1.0,
-            "gltf_detailedDescription": ""
+            "gltf_detailedDescription": "The anisotropy strength. When anisotropyTexture is present, this value is multiplied by the blue channel."
         },
         "anisotropyRotation": {
             "type": "number",

--- a/extensions/2.0/Khronos/KHR_materials_anisotropy/schema/glTF.KHR_materials_anisotropy.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_anisotropy/schema/glTF.KHR_materials_anisotropy.schema.json
@@ -7,7 +7,7 @@
     "properties": {
         "anisotropyStrength": {
             "type": "number",
-            "description": "Anisotropic strength",
+            "description": "The anisotropy strength.",
             "default": 0.0,
             "minimum": 0.0,
             "maximum": 1.0,
@@ -15,13 +15,13 @@
         },
         "anisotropyRotation": {
             "type": "number",
-            "description": "Anisotropic rotation",
+            "description": "The rotation of the anisotropy.",
             "default": 0.0,
             "gltf_detailedDescription": "The rotation of the anisotropy in tangent, bitangent space, measured in radians counter-clockwise from the tangent. When anisotropyTexture is present, anisotropyRotation provides additional rotation to the vectors in the texture."
         },
         "anisotropyTexture": {
             "allOf": [ { "$ref": "textureInfo.schema.json" } ],
-            "description": "Anisotropy texture",
+            "description": "The anisotropy texture.",
             "gltf_detailedDescription": "The anisotropy texture. Red and green channels represent the anisotropy direction in [-1, 1] tangent, bitangent space, to be rotated by anisotropyRotation. The blue channel contains strength as [0, 1] to be multiplied by anisotropyStrength."
         },
         "extensions": { },


### PR DESCRIPTION
The "detailed description" for strength had accidentally been placed in the ordinary JSON description property.  I moved it where it should have been, in `gltf_detailedDescription` like the other long descriptions.

This does not change the REAMDE, or behavior, and has no IP changes for ratification.