### PR TITLE
Mark several recently ratified extensions as complete, update registry

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md
@@ -23,7 +23,7 @@ See [Appendix](#appendix-full-khronos-copyright-statement) for full Khronos Copy
 
 ## Status
 
-Release Candidate
+Complete, Ratified by the Khronos Group
 
 ## Dependencies
 

--- a/extensions/2.0/Vendor/EXT_mesh_gpu_instancing/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_gpu_instancing/README.md
@@ -8,7 +8,7 @@
 
 ## Status
 
-Experimental
+Complete, Ratified by the Khronos Group
 
 ## Dependencies
 

--- a/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+++ b/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
@@ -7,7 +7,7 @@
 
 ## Status
 
-Complete
+Complete, Ratified by the Khronos Group
 
 ## Dependencies
 

--- a/extensions/2.0/Vendor/EXT_texture_webp/README.md
+++ b/extensions/2.0/Vendor/EXT_texture_webp/README.md
@@ -7,7 +7,7 @@
 
 ## Status
 
-Complete
+Complete, Ratified by the Khronos Group
 
 ## Dependencies
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -15,6 +15,7 @@ The following extensions have been ratified by the Khronos Group:
 
 * [KHR_draco_mesh_compression](2.0/Khronos/KHR_draco_mesh_compression/README.md)
 * [KHR_lights_punctual](2.0/Khronos/KHR_lights_punctual/README.md)
+* [KHR_materials_anisotropy](2.0/Khronos/KHR_materials_anisotropy/README.md)
 * [KHR_materials_clearcoat](2.0/Khronos/KHR_materials_clearcoat/README.md)
 * [KHR_materials_emissive_strength](2.0/Khronos/KHR_materials_emissive_strength/README.md)
 * [KHR_materials_ior](2.0/Khronos/KHR_materials_ior/README.md)
@@ -29,16 +30,16 @@ The following extensions have been ratified by the Khronos Group:
 * [KHR_texture_basisu](2.0/Khronos/KHR_texture_basisu/README.md)
 * [KHR_texture_transform](2.0/Khronos/KHR_texture_transform/README.md)
 * [KHR_xmp_json_ld](2.0/Khronos/KHR_xmp_json_ld/README.md)
-
-### Multi-Vendor Extensions for glTF 2.0
-
-When an extension is implemented by more than one vendor, its name can use the reserved `EXT` prefix. Multi-vendor extensions are not covered by the Khronos IP framework.
-
-* [EXT_lights_ies](2.0/Vendor/EXT_lights_ies/README.md)
-* [EXT_lights_image_based](2.0/Vendor/EXT_lights_image_based/README.md)
 * [EXT_mesh_gpu_instancing](2.0/Vendor/EXT_mesh_gpu_instancing/README.md)
 * [EXT_meshopt_compression](2.0/Vendor/EXT_meshopt_compression/README.md)
 * [EXT_texture_webp](2.0/Vendor/EXT_texture_webp/README.md)
+
+### Multi-Vendor Extensions for glTF 2.0
+
+When an extension is implemented by more than one vendor, its name can use the reserved `EXT` prefix. Multi-vendor extensions are typically not covered by the Khronos IP framework, with a few notable exceptions (listed above) that have been through the Khronos ratification process after becoming widely used under the `EXT` prefix.
+
+* [EXT_lights_ies](2.0/Vendor/EXT_lights_ies/README.md)
+* [EXT_lights_image_based](2.0/Vendor/EXT_lights_image_based/README.md)
 
 ### Vendor Extensions for glTF 2.0
 
@@ -97,21 +98,8 @@ extensions, Khronos extensions, or inclusion in a future version of the glTF spe
 |-----------|--------|
 | [KHR_animation_pointer](https://github.com/KhronosGroup/glTF/pull/2147) | Ready for testing. |
 | [KHR_audio](https://github.com/KhronosGroup/glTF/pull/2137) | Ready for testing. |
-| [KHR_materials_anisotropy](https://github.com/KhronosGroup/glTF/pull/1798) | Ready for testing. |
 | [KHR_materials_diffuse_transmission](https://github.com/KhronosGroup/glTF/pull/1825) | Ready for testing. |
 | [KHR_materials_sss](https://github.com/KhronosGroup/glTF/pull/1928) | In development. |
-
-## Extensions for glTF 1.0
-
-### Khronos extensions for glTF 1.0
-
-* [KHR_binary_glTF](1.0/Khronos/KHR_binary_glTF/README.md)
-* [KHR_materials_common](1.0/Khronos/KHR_materials_common/README.md)
-
-### Vendor extensions for glTF 1.0
-
-* [CESIUM_RTC](1.0/Vendor/CESIUM_RTC/README.md)
-* [WEB3D_quantized_attributes](1.0/Vendor/WEB3D_quantized_attributes/README.md)
 
 # About glTF Extensions
 
@@ -147,14 +135,16 @@ All extensions used in a model are listed as strings in the top-level `extension
 ```json
 {
   "extensionsUsed": [
-    "KHR_materials_pbrSpecularGlossiness", "VENDOR_physics"
+    "KHR_draco_mesh_compression", "VENDOR_physics"
   ],
   "extensionsRequired": [
-    "KHR_materials_pbrSpecularGlossiness"
+    "KHR_draco_mesh_compression"
   ]
 }
 ```
 This allows an engine to quickly determine if it supports the extensions needed to render the model without inspecting the `extensions` property of all objects.
+
+An extension is considered _required_ if a typical glTF loader would fail to load the asset in the absence of support for that extension.  For example, any mesh compression extension must be listed as _required_ unless an uncompressed fallback mesh is provided with the asset.  Likewise, a texture image format extension must be listed as _required_ unless fallback textures in core formats (JPG, PNG) are also supplied. Typically, PBR or other kinds of material extensions should not be listed in _required_, because the core glTF material can be considered a valid fallback for these kinds of extensions, and such extensions will not cause a conformant glTF loader to fail.
 
 ## Creating Extensions
 


### PR DESCRIPTION
The following extensions have been ratified this year:

- KHR_materials_anisotropy
- EXT_mesh_gpu_instancing
- EXT_meshopt_compression
- EXT_texture_webp

Additionally, some wording was adjusted to allow EXT extensions to become ratified, and to clarify when _required_ status should be marked on an extension.

(Also, some links to glTF 1.0 extensions removed. Anyone who needs those should click on the relevant folder, no need to advertise them anymore).