### PR TITLE
Use friendly unique names for all Khronos extension schemas

### DIFF
--- a/extensions/2.0/Khronos/KHR_draco_mesh_compression/schema/mesh.primitive.KHR_draco_mesh_compression.schema.json
+++ b/extensions/2.0/Khronos/KHR_draco_mesh_compression/schema/mesh.primitive.KHR_draco_mesh_compression.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_draco_mesh_compression extension",
+    "title": "KHR_draco_mesh_compression glTF Mesh Primitive Extension",
     "type": "object",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {

--- a/extensions/2.0/Khronos/KHR_lights_punctual/schema/glTF.KHR_lights_punctual.schema.json
+++ b/extensions/2.0/Khronos/KHR_lights_punctual/schema/glTF.KHR_lights_punctual.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_lights_punctual glTF extension",
+    "title": "KHR_lights_punctual glTF Document Extension",
     "type": "object",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {

--- a/extensions/2.0/Khronos/KHR_lights_punctual/schema/light.schema.json
+++ b/extensions/2.0/Khronos/KHR_lights_punctual/schema/light.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "light",
+    "title": "KHR_lights_punctual Light Properties",
     "type": "object",
     "description": "A directional, point, or spot light.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_lights_punctual/schema/light.spot.schema.json
+++ b/extensions/2.0/Khronos/KHR_lights_punctual/schema/light.spot.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema" : "http://json-schema.org/draft-04/schema",
-    "title" : "light/spot",
+    "title" : "KHR_lights_punctual Light Spot Properties",
     "type" : "object",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties" : {

--- a/extensions/2.0/Khronos/KHR_lights_punctual/schema/node.KHR_lights_punctual.schema.json
+++ b/extensions/2.0/Khronos/KHR_lights_punctual/schema/node.KHR_lights_punctual.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_lights_punctual node extension",
+    "title": "KHR_lights_punctual glTF Node Extension",
     "type": "object",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {

--- a/extensions/2.0/Khronos/KHR_materials_anisotropy/schema/glTF.KHR_materials_anisotropy.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_anisotropy/schema/glTF.KHR_materials_anisotropy.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_anisotropy glTF extension",
+    "title": "KHR_materials_anisotropy glTF Material Extension",
     "type": "object",
     "description": "glTF extension that defines anisotropy.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_materials_clearcoat/schema/glTF.KHR_materials_clearcoat.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_clearcoat/schema/glTF.KHR_materials_clearcoat.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_clearcoat glTF extension",
+    "title": "KHR_materials_clearcoat glTF Material Extension",
     "type": "object",
     "description": "glTF extension that defines the clearcoat material layer.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_materials_emissive_strength/schema/glTF.KHR_materials_emissive_strength.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_emissive_strength/schema/glTF.KHR_materials_emissive_strength.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_emissive_strength glTF extension",
+    "title": "KHR_materials_emissive_strength glTF Material Extension",
     "type": "object",
     "description": "glTF extension that adjusts the strength of emissive material properties.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_materials_ior/schema/glTF.KHR_materials_ior.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_ior/schema/glTF.KHR_materials_ior.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_ior glTF extension",
+    "title": "KHR_materials_ior glTF Material Extension",
     "type": "object",
     "description": "glTF extension that defines the index of refraction of a material.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_materials_iridescence/schema/glTF.KHR_materials_iridescence.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_iridescence/schema/glTF.KHR_materials_iridescence.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_iridescence glTF extension",
+    "title": "KHR_materials_iridescence glTF Material Extension",
     "type": "object",
     "description": "glTF extension that defines an iridescence effect.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_materials_sheen/schema/glTF.KHR_materials_sheen.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_sheen/schema/glTF.KHR_materials_sheen.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_sheen glTF extension",
+    "title": "KHR_materials_sheen glTF Material Extension",
     "type": "object",
     "description": "glTF extension that defines the sheen material model.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_materials_specular/schema/glTF.KHR_materials_specular.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_specular/schema/glTF.KHR_materials_specular.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_specular glTF extension",
+    "title": "KHR_materials_specular glTF Material Extension",
     "type": "object",
     "description": "glTF extension that defines the strength of the specular reflection.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_materials_transmission/schema/glTF.KHR_materials_transmission.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_transmission/schema/glTF.KHR_materials_transmission.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_transmission glTF extension",
+    "title": "KHR_materials_transmission glTF Material Extension",
     "type": "object",
     "description": "glTF extension that defines the optical transmission of a material.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_materials_unlit/schema/glTF.KHR_materials_unlit.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_unlit/schema/glTF.KHR_materials_unlit.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_unlit glTF extension",
+    "title": "KHR_materials_unlit glTF Material Extension",
     "type": "object",
     "description": "glTF extension that defines the unlit material model.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_materials_variants/schema/glTF.KHR_materials_variants.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_variants/schema/glTF.KHR_materials_variants.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_variants glTF extension",
+    "title": "KHR_materials_variants glTF Document Extension",
     "type": "object",
     "description": "glTF extension that defines a material variations for mesh primitives",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_materials_variants/schema/mesh.primitive.KHR_materials_variants.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_variants/schema/mesh.primitive.KHR_materials_variants.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_variants mesh primitive extension",
+    "title": "KHR_materials_variants glTF Mesh Primitive Extension",
     "type": "object",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {

--- a/extensions/2.0/Khronos/KHR_materials_volume/schema/glTF.KHR_materials_volume.schema.json
+++ b/extensions/2.0/Khronos/KHR_materials_volume/schema/glTF.KHR_materials_volume.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_materials_volume glTF extension",
+    "title": "KHR_materials_volume glTF Material Extension",
     "type": "object",
     "description": "glTF extension that defines the parameters for the volume of a material.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_texture_basisu/schema/texture.KHR_texture_basisu.schema.json
+++ b/extensions/2.0/Khronos/KHR_texture_basisu/schema/texture.KHR_texture_basisu.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_texture_basisu glTF extension",
+    "title": "KHR_texture_basisu glTF Texture Extension",
     "type": "object",
     "description": "glTF extension to specify textures using the KTX v2 images with Basis Universal supercompression.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_texture_transform/schema/KHR_texture_transform.textureInfo.schema.json
+++ b/extensions/2.0/Khronos/KHR_texture_transform/schema/KHR_texture_transform.textureInfo.schema.json
@@ -1,7 +1,7 @@
 {
-    "$schema" : "http://json-schema.org/draft-04/schema",
-    "title" : "KHR_texture_transform textureInfo extension",
-    "type" : "object",
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_texture_transform glTF TextureInfo Extension",
+    "type": "object",
     "description": "glTF extension that enables shifting and scaling UV coordinates on a per-texture basis",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties" : {

--- a/extensions/2.0/Khronos/KHR_xmp_json_ld/schema/KHR_xmp_json_ld.schema.json
+++ b/extensions/2.0/Khronos/KHR_xmp_json_ld/schema/KHR_xmp_json_ld.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_xmp_json_ld extension",
+    "title": "KHR_xmp_json_ld glTF Extension",
     "type": "object",
     "description": "References an XMP packet listed in `KHR_xmp_json_ld glTF extension`",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_xmp_json_ld/schema/glTF.KHR_xmp_json_ld.schema.json
+++ b/extensions/2.0/Khronos/KHR_xmp_json_ld/schema/glTF.KHR_xmp_json_ld.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title" : "KHR_xmp_json_ld glTF extension",
+    "title": "KHR_xmp_json_ld glTF Document Extension",
     "type": "object",
     "description": "Metadata about the glTF asset.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],


### PR DESCRIPTION
This PR improves the schema titles. This is mostly cosmetic, but it may have practical benefits, such as improved human and machine parsability, and it gives us the ability to uniquely identify a schema file from its title alone.

When making this PR, I used the following rules:

* All titles should be in Title Case where words start with a capital letter except for stylized `glTF`.
* All extension schemas should include the extension name at the start. For example, all `KHR_lights_punctual` schemas should start the title with "KHR_lights_punctual".
    * Previously the light properties schema was just titled `"light"`. This is not unique enough to be helpful without the context of knowing you are dealing with `KHR_lights_punctual`.
* Schemas that extend a specific part of glTF should specify that part in the format "glTF \<something\> Extension".
    * If the extension is applied on the base document, use the text "glTF Document Extension".
    * Note that `KHR_xmp_json_ld.schema.json` can be applied anywhere, so it does not apply to a specific part, so I kept it as just "glTF Extension".

In this PR, I only touched the Khronos extensions in the 2.0 folder.