### PR TITLE
KHR_materials_anisotropy should be exclusive vs unlit

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md
@@ -31,6 +31,7 @@ Written against the glTF 2.0 spec.
 
 ## Exclusions
 
+- This extension must not be used on a material that also uses `KHR_materials_pbrSpecularGlossiness`.
 - This extension must not be used on a material that also uses `KHR_materials_unlit`.
 
 ## Overview

--- a/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md
@@ -29,6 +29,10 @@ Complete, Ratified by the Khronos Group
 
 Written against the glTF 2.0 spec.
 
+## Exclusions
+
+- This extension must not be used on a material that also uses `KHR_materials_unlit`.
+
 ## Overview
 
 This extension defines the anisotropic property of a material as observable with brushed metals for example.


### PR DESCRIPTION
This exclusion note is present in every single material extension except for this one. I assume this is an omission since it's not clear why anisotropy specifically would be okay to mix with unlit and every other KHR_materials_ extension isn't.

Note that other material extensions also say it's not okay to mix them with `KHR_materials_pbrSpecularGlossiness`. I did not add this exclusion for now to reduce the scope of the change but let me know if that is preferred here as well.

If we don't end up adding this exclusion I feel like we should explicitly clarify the opposite.