### PR TITLE
Fix `GRIFFEL_bim_data` extension schema

### DIFF
--- a/extensions/2.0/Vendor/GRIFFEL_bim_data/schema/GRIFFEL_bim_data.schema.json
+++ b/extensions/2.0/Vendor/GRIFFEL_bim_data/schema/GRIFFEL_bim_data.schema.json
@@ -17,7 +17,7 @@
                     "properties": {
                         "type": "array",
                         "uniqueItems": true,
-                        "item": {
+                        "items": {
                             "allOf": [ { "$ref": "glTFid.schema.json" } ],
                             "description": "Index of a property in the root level collection."
                         },

--- a/extensions/Prefixes.md
+++ b/extensions/Prefixes.md
@@ -39,6 +39,7 @@ Once a prefix is approved, it should be added to the [glTF Validator's list of k
 | `DGG` | Darmstadt Graphics Group GmbH | https://dgg3d.com/ | [#2303](https://github.com/KhronosGroup/glTF/issues/2303) |
 | `DOTV` | DotVision | https://dotvision.com/<br>`guillaume.pelletier at dotvision.com` | [#2192](https://github.com/KhronosGroup/glTF/issues/2192) |
 | `EMBARK` | Embark Studios AB | https://www.embark-studios.com/ | [#2097](https://github.com/KhronosGroup/glTF/issues/2097) |
+| `ENVOKE` | Envoke | https://envoke-demos.com/ | [#2363](https://github.com/KhronosGroup/glTF/issues/2363) |
 | `EPIC` | Epic Games, Inc. | https://www.epicgames.com/ | [#1905](https://github.com/KhronosGroup/glTF/issues/1905) |
 | `ESSILORLUXOTTICA` | Luxottica Group S.p.A. | https://www.essilorluxottica.com/ | [#2204](https://github.com/KhronosGroup/glTF/issues/2204) |
 | `F8` | Forum8 Co., Ltd. | https://www.forum8.com/ | [#1999](https://github.com/KhronosGroup/glTF/issues/1999) |


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/glTF/issues/2373 :  

The [`item`](https://github.com/KhronosGroup/glTF/blob/ae1a90baf009203760304f06ed5645402de9dc09/extensions/2.0/Vendor/GRIFFEL_bim_data/schema/GRIFFEL_bim_data.schema.json#L20) property should have been called `items`.
