### PR TITLE
Fix `GRIFFEL_bim_data` extension schema

### DIFF
--- a/extensions/2.0/Vendor/GRIFFEL_bim_data/schema/GRIFFEL_bim_data.schema.json
+++ b/extensions/2.0/Vendor/GRIFFEL_bim_data/schema/GRIFFEL_bim_data.schema.json
@@ -17,7 +17,7 @@
                     "properties": {
                         "type": "array",
                         "uniqueItems": true,
-                        "item": {
+                        "items": {
                             "allOf": [ { "$ref": "glTFid.schema.json" } ],
                             "description": "Index of a property in the root level collection."
                         },


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/glTF/issues/2373 :

The [item](https://github.com/KhronosGroup/glTF/blob/ae1a90baf009203760304f06ed5645402de9dc09/extensions/2.0/Vendor/GRIFFEL_bim_data/schema/GRIFFEL_bim_data.schema.json#L20) property should have been called items.