### PR TITLE
Additional fix to `GRIFFEL_bim_data` extension schema

### DIFF
--- a/extensions/2.0/Vendor/GRIFFEL_bim_data/schema/glTF.GRIFFEL_bim_data.schema.json
+++ b/extensions/2.0/Vendor/GRIFFEL_bim_data/schema/glTF.GRIFFEL_bim_data.schema.json
@@ -61,7 +61,7 @@
                     "properties": {
                         "type": "array",
                         "uniqueItems": true,
-                        "item": {
+                        "items": {
                             "allOf": [ { "$ref": "glTFid.schema.json" } ],
                             "description": "Index of a property in the root level collection."
                         },


### PR DESCRIPTION
Fixes #2373

There was another instance of the `item` property inside of an array instance type, which should have been `items`. (`item` is not a known property in json schema draft 4)