### PR TITLE
Fix type of CESIUM_primitive_outline's `indices` property.

### DIFF
--- a/extensions/2.0/Vendor/CESIUM_primitive_outline/schema/primitive.CESIUM_primitive_outline.schema.json
+++ b/extensions/2.0/Vendor/CESIUM_primitive_outline/schema/primitive.CESIUM_primitive_outline.schema.json
@@ -6,7 +6,7 @@
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "indices": {
-            "type": "integer",
+            "allOf": [ { "$ref" : "glTFid.schema.json" } ],
             "description": "The index of the accessor providing the list of highlighted lines at the edge of this primitive's triangles."
         },
         "extensions": { },


### PR DESCRIPTION
When I wrote the schema for this extension, I incorrectly used `integer` as the type for the `indices` property, which is meant to refer to an accessor in the glTF. It should instead be `"allOf": [ { "$ref" : "glTFid.schema.json" } ]`.
