### PR TITLE
EXT_accessor_additional_types

### DIFF
--- a/extensions/2.0/Vendor/EXT_accessor_additional_types/README.md
+++ b/extensions/2.0/Vendor/EXT_accessor_additional_types/README.md
@@ -1,0 +1,52 @@
+# EXT\_accessor\_additional\_types
+
+## Contributors
+
+- Sean, [@spnda](https://github.com/spnda)
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+Similarly to the `KHR_mesh_quantization` extension, this extension offers additional accessor data types for use-cases where the traditional values either offer too much precision, and are therefore wasting memory, or offer too little precision.
+
+This extension expands the list of component types to additionally support 16-bit half-precision floats, which are commonly used for UV texture coordinates, and for larger data types, such as 64-bit double precision floats, and 64-bit integers.
+
+This extension adds an exhaustive list of all currently supportable types, so that other extensions can make use of them for different use-cases. Additionally, this extension also allows 16-bit half-precision floats as an additional type for UV texture coordinates, as they are commonly used to optimise memory usage, since they often have next to no effect on quality, and is supported by most modern GPUs and graphics APIs.
+
+Assets that make use of this extension must mark it as required, as it cannot be optional, since there is no method of switching component types based on supported extensions.
+
+## Extending Accessor Data Types
+
+When the `EXT_accessor_additional_types` extension is supported, the following **extra** accessor data types are allowed for usage in accessors in addition to the types defined in [Section 3.6.2.2](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#accessor-data-types).
+
+|componentType|Data type|Signed|Bits|
+|-------------|---------|------|----|
+|5124|signed int|Signed, two’s complement|32|
+|5130|double|Signed|64|
+|5131|half float|Signed|16|
+|5135|unsigned long|Unsigned|64|
+
+The new floating point accessor data types must use IEEE754 double-precision format (binary64) and half-precision format (binary16), respectively.
+
+## Extending Mesh Attributes
+
+When `EXT_accessor_additional_types` extension is supported, the following **extra** types are allowed for storing mesh attributes in addition to the types defined in [Section 3.7.2.1](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#meshes-overview).
+
+|Name|Accessor Type(s)|Component Type(s)|
+|----|----------------|-----------------|
+|`TEXCOORD_n`|VEC2|_half float_|
+
+## Extending Morph Target Attributes
+
+When `EXT_accessor_additional_types` extension is supported, the following **extra** types are allowed for storing morph target attributes in addition to the types defined in [Section 3.7.2.2](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#morph-targets).
+
+|Name|Accessor Type(s)|Component Type(s)|
+|----|----------------|-----------------|
+|`TEXCOORD_n`|VEC2|_half float_|


### PR DESCRIPTION
Addresses #2216.

This PR adds a new extension, `EXT_accessor_additional_types`. This extension simply defines more valid accessor types, equivalent to `GL_INT`, `GL_UNSIGNED_INT64_ARB`, `GL_HALF_FLOAT`, and `GL_DOUBLE`, and doesn't allow their usage for meshes, animations, morph targets, ...

However, this extension does also allow the use of half-precision floating point numbers for UV coordinates, as this is commonly used nowadays for reducing vertex memory cost, and is quite simple to implement. And this avoids the possible quantization errors that would otherwise occur with `KHR_mesh_quantization`.

Open questions:
- Could this become a KHR extension, similar to `KHR_mesh_quantization`? Not sure on the procedure there.
- Should the allowance of half-precision floats for `TEXCOORD` attributes be put into another question, something like `KHR_mesh_quantization_2`?
- Should this also add a signed 64-bit integer? I couldn't find an OpenGL type for that, which is why I did not add it. For completeness, perhaps it could make sense to also define it. Though this would require adding a enum constant which does not align with OpenGL.

I'd really like to see this properly considered by the glTF team, especially since half floats are quite important in the modern graphics world for various reasons. Also, assets using double-precision positions have existed for a while, and it is already supported by a lot of glTF tooling.