### PR TITLE
Fix missing glyph

### DIFF
--- a/extensions/2.0/Khronos/KHR_materials_sheen/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_sheen/README.md
@@ -91,10 +91,10 @@ Not all incoming light is reflected at a micro-fiber. Some of the light may hit 
 
 All implementations should use the same calculations for the BRDF inputs. See [Appendix B](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#appendix-b-brdf-implementation) for more details on the BRDF calculations.
 
-The sheen formula follows the common microfacet form with visibility term $\mathcal{V}_s$:
+The sheen formula follows the common microfacet form with visibility term $\nu_s$:
 
 $$
-\text{SheenBRDF} = \frac{G_S D_S}{4 \, \left|N \cdot L \right| \, \left| N \cdot V \right|} = \mathcal{V}_S D_S
+\text{SheenBRDF} = \frac{G_S D_S}{4 \, \left|N \cdot L \right| \, \left| N \cdot V \right|} = \nu_S D_S
 $$
 
 
@@ -112,7 +112,7 @@ sheen_distribution = (2 + inv_r) * pow(sin2h, inv_r * 0.5) / (2 * PI);
 
 ### Sheen visibility
 
-The "Charlie" sheen visibility $\mathcal{V}_s = \frac{G_s}{4 \, \left|N \cdot L \right| \, \left| N \cdot V \right|}$ is also defined in the same document:
+The "Charlie" sheen visibility $\nu_s = \frac{G_s}{4 \, \left|N \cdot L \right| \, \left| N \cdot V \right|}$ is also defined in the same document:
 
 ```glsl
 float l(float x, float alpha_g)

--- a/extensions/2.0/Khronos/KHR_materials_transmission/README.md
+++ b/extensions/2.0/Khronos/KHR_materials_transmission/README.md
@@ -207,19 +207,19 @@ With the step function $\chi^+$ we ensure that the microsurface is only visible 
 Introducing the visibility function
 
 $$
-\mathcal{V}_T = \frac{G_T}{4 \left| N \cdot L \right| \left| N \cdot V \right|}
+\nu_T = \frac{G_T}{4 \left| N \cdot L \right| \left| N \cdot V \right|}
 $$
 
 simplifies the original microfacet BTDF to
 
 $$
-\text{MicrofacetBTDF} = \mathcal{V}_T D_T
+\text{MicrofacetBTDF} = \nu_T D_T
 $$
 
 with
 
 $$
-\mathcal{V}_T = \frac{\chi^+\left(\frac{H_T \cdot L}{N \cdot L}\right)}{\left| N \cdot L\right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot L)^2}} \frac{\chi^+\left(\frac{H_T \cdot V}{N \cdot V}\right)}{\left| N \cdot V \right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot V)^2}}
+\nu_T = \frac{\chi^+\left(\frac{H_T \cdot L}{N \cdot L}\right)}{\left| N \cdot L\right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot L)^2}} \frac{\chi^+\left(\frac{H_T \cdot V}{N \cdot V}\right)}{\left| N \cdot V \right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot V)^2}}
 $$
 
 Thus we have the function

--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -3058,25 +3058,25 @@ G = \frac{2 \, \left| N \cdot L \right| \, \chi^{+}(H \cdot L)}{\left| N \cdot L
 
 where χ^+^(*x*) denotes the Heaviside function: 1 if *x* > 0 and 0 if *x* <= 0. See <<Heitz2014,Heitz (2014)>> for a derivation of the formulas.
 
-Introducing the visibility function latexmath:[\mathcal{V}]
+Introducing the visibility function latexmath:[\nu]
 
 [latexmath]
 ++++
-\mathcal{V} = \frac{G}{4 \, \left| N \cdot L \right| \, \left| N \cdot V \right|}
+\nu = \frac{G}{4 \, \left| N \cdot L \right| \, \left| N \cdot V \right|}
 ++++
 
 simplifies the original microfacet BRDF to
 
 [latexmath]
 ++++
-\text{MicrofacetBRDF} = \mathcal{V} D
+\text{MicrofacetBRDF} = \nu D
 ++++
 
 with
 
 [latexmath]
 ++++
-\mathcal{V} = \frac{\, \chi^{+}(H \cdot L)}{\left| N \cdot L\right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot L)^2}} \frac{\, \chi^{+}(H \cdot V)}{\left| N \cdot V \right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot V)^2}}
+\nu = \frac{\, \chi^{+}(H \cdot L)}{\left| N \cdot L\right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot L)^2}} \frac{\, \chi^{+}(H \cdot V)}{\left| N \cdot V \right| + \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot V)^2}}
 ++++
 
 Thus, we have the function


### PR DESCRIPTION
This is a simple search-and-replace of `\mathcal{V}` with `\nu` as a fix for the PDF render issue in #2401.

@bsdorra @proog128 Any objection to changing the letter like this?