### PR TITLE
EXT_mesh_gpu_instancing: Suggest extensionRequired usage

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_gpu_instancing/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_gpu_instancing/README.md
@@ -57,6 +57,8 @@ All attribute accessors in a given node **must** have the same `count`.
 
 > **Implementation Note:** When instancing is used on the node, the non-instanced version of the mesh should not be rendered.
 
+Because the extension does not provide a way to specify a non-instanced fallback, files that use the extension should specify it in `extensionsRequired` array.
+
 ## Transformation Order
 
 When using instancing, the instance transform matrix is constructed by multiplying translation (if present), rotation (if present), and scale in the same order as they are for nodes:


### PR DESCRIPTION
Using this extension without specifying it as required is guaranteed to lead to significant differences in appearance between renderers that support it and renderers that don't due to how it is specified.

Fixes #2402.