### PR TITLE
Remove obsolete reference to the validator's old list of prefixes

### DIFF
--- a/extensions/Prefixes.md
+++ b/extensions/Prefixes.md
@@ -12,8 +12,6 @@ The following extension prefixes are reserved by the spec maintainers:
 
 To request a prefix, submit a [GitHub issue](https://github.com/KhronosGroup/glTF/issues/new) with the name of the requested prefix and the vendor that will be using it. Maintainers, please assign the `extension` label to the issue.
 
-Once a prefix is approved, it should be added to the [glTF Validator's list of known prefixes](https://github.com/KhronosGroup/glTF-Validator/blob/master/lib/src/ext/extensions.dart).
-
 ## Registered Vendor Prefixes
 
 | Prefix | Company or Project Name | Contacts | Request |


### PR DESCRIPTION
Following https://github.com/KhronosGroup/glTF-Validator/pull/218