### PR TITLE
Fix missing line break in attribute table

### DIFF
--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -1294,7 +1294,7 @@ Valid accessor type and component type for each attribute semantic property are 
                 VEC4            | _float_ +
                                   _unsigned byte_ normalized +
                                   _unsigned short_ normalized | RGB or RGBA vertex color linear multiplier
-| `JOINTS_n`  | VEC4            | _unsigned byte_
+| `JOINTS_n`  | VEC4            | _unsigned byte_ +
                                   _unsigned short_            | See <<skinned-mesh-attributes,Skinned Mesh Attributes>>
 | `WEIGHTS_n` | VEC4            | _float_ +
                                   _unsigned byte_ normalized +


### PR DESCRIPTION
Noticed that a line break was missing between the two valid component types for the `JOINTS_n` attribute. Instead of showing on individual lines, like the other entries in the table, they ended up on a single line. This PR simply adds the missing line break.