### PR TITLE
Removed attributes that are already available through composition

### DIFF
--- a/specification/2.0/schema/accessor.schema.json
+++ b/specification/2.0/schema/accessor.schema.json
@@ -124,10 +124,7 @@
         "sparse": {
             "allOf": [ { "$ref": "accessor.sparse.schema.json" } ],
             "description": "Sparse storage of elements that deviate from their initialization value."
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "dependencies": {
         "byteOffset": [ "bufferView" ]

--- a/specification/2.0/schema/accessor.sparse.indices.schema.json
+++ b/specification/2.0/schema/accessor.sparse.indices.schema.json
@@ -38,9 +38,7 @@
                     "type": "integer"
                 }
             ]
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "bufferView", "componentType" ]
 }

--- a/specification/2.0/schema/accessor.sparse.schema.json
+++ b/specification/2.0/schema/accessor.sparse.schema.json
@@ -18,9 +18,7 @@
         "values": {
             "allOf": [ { "$ref": "accessor.sparse.values.schema.json" } ],
             "description": "An object pointing to a buffer view containing the deviating accessor values."
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "count", "indices", "values" ]
 }

--- a/specification/2.0/schema/accessor.sparse.values.schema.json
+++ b/specification/2.0/schema/accessor.sparse.values.schema.json
@@ -15,9 +15,7 @@
             "description": "The offset relative to the start of the bufferView in bytes.",
             "minimum": 0,
             "default": 0
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "bufferView" ]
 }

--- a/specification/2.0/schema/animation.channel.schema.json
+++ b/specification/2.0/schema/animation.channel.schema.json
@@ -14,9 +14,7 @@
         "target": {
             "allOf": [ { "$ref": "animation.channel.target.schema.json" } ],
             "description": "The descriptor of the animated property."
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "sampler", "target" ]
 }

--- a/specification/2.0/schema/animation.channel.target.schema.json
+++ b/specification/2.0/schema/animation.channel.target.schema.json
@@ -29,9 +29,7 @@
                     "type": "string"
                 }
             ]
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "path" ]
 }

--- a/specification/2.0/schema/animation.sampler.schema.json
+++ b/specification/2.0/schema/animation.sampler.schema.json
@@ -36,9 +36,7 @@
         "output": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of an accessor, containing keyframe output values."
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "input", "output" ]
 }

--- a/specification/2.0/schema/animation.schema.json
+++ b/specification/2.0/schema/animation.schema.json
@@ -21,10 +21,7 @@
                 "$ref": "animation.sampler.schema.json"
             },
             "minItems": 1
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "channels", "samplers" ]
 }

--- a/specification/2.0/schema/asset.schema.json
+++ b/specification/2.0/schema/asset.schema.json
@@ -23,9 +23,7 @@
             "type": "string",
             "description": "The minimum glTF version in the form of `<major>.<minor>` that this asset targets. This property **MUST NOT** be greater than the asset version.",
             "pattern": "^[0-9]+\\.[0-9]+$"
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "version" ]
 }

--- a/specification/2.0/schema/buffer.schema.json
+++ b/specification/2.0/schema/buffer.schema.json
@@ -17,10 +17,7 @@
             "type": "integer",
             "description": "The length of the buffer in bytes.",
             "minimum": 1
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "byteLength" ]
 }

--- a/specification/2.0/schema/bufferView.schema.json
+++ b/specification/2.0/schema/bufferView.schema.json
@@ -48,10 +48,7 @@
                     "type": "integer"
                 }
             ]
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "buffer", "byteLength" ]
 }

--- a/specification/2.0/schema/camera.orthographic.schema.json
+++ b/specification/2.0/schema/camera.orthographic.schema.json
@@ -23,9 +23,7 @@
             "type": "number",
             "description": "The floating-point distance to the near clipping plane.",
             "minimum": 0.0
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "xmag", "ymag", "zfar", "znear" ]
 }

--- a/specification/2.0/schema/camera.perspective.schema.json
+++ b/specification/2.0/schema/camera.perspective.schema.json
@@ -28,9 +28,7 @@
             "description": "The floating-point distance to the near clipping plane.",
             "exclusiveMinimum": 0.0,
             "gltf_detailedDescription": "The floating-point distance to the near clipping plane."
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "yfov", "znear" ]
 }

--- a/specification/2.0/schema/camera.schema.json
+++ b/specification/2.0/schema/camera.schema.json
@@ -28,10 +28,7 @@
                     "type": "string"
                 }
             ]
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "type" ],
     "not": {

--- a/specification/2.0/schema/glTF.schema.json
+++ b/specification/2.0/schema/glTF.schema.json
@@ -145,9 +145,7 @@
                 "$ref": "texture.schema.json"
             },
             "minItems": 1
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "dependencies": {
         "scene": [ "scenes" ]

--- a/specification/2.0/schema/image.schema.json
+++ b/specification/2.0/schema/image.schema.json
@@ -30,10 +30,7 @@
         "bufferView": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined."
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "dependencies": {
         "bufferView": [ "mimeType" ]

--- a/specification/2.0/schema/material.normalTextureInfo.schema.json
+++ b/specification/2.0/schema/material.normalTextureInfo.schema.json
@@ -12,8 +12,6 @@
             "description": "The scalar parameter applied to each normal vector of the normal texture.",
             "default": 1.0,
             "gltf_detailedDescription": "The scalar parameter applied to each normal vector of the texture. This value scales the normal vector in X and Y directions using the formula: `scaledNormal =  normalize((<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0))`."
-        },
-        "extensions": { },
-        "extras": { }
+        }
     }
 }

--- a/specification/2.0/schema/material.occlusionTextureInfo.schema.json
+++ b/specification/2.0/schema/material.occlusionTextureInfo.schema.json
@@ -14,8 +14,6 @@
             "minimum": 0.0,
             "maximum": 1.0,
             "gltf_detailedDescription": "A scalar parameter controlling the amount of occlusion applied. A value of `0.0` means no occlusion. A value of `1.0` means full occlusion. This value affects the final occlusion value as: `1.0 + strength * (<sampled occlusion texture value> - 1.0)`."
-        },
-        "extensions": { },
-        "extras": { }
+        }
     }
 }

--- a/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
+++ b/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
@@ -44,8 +44,6 @@
             "allOf": [ { "$ref": "textureInfo.schema.json" } ],
             "description": "The metallic-roughness texture.",
             "gltf_detailedDescription": "The metallic-roughness texture. The metalness values are sampled from the B channel. The roughness values are sampled from the G channel. These values **MUST** be encoded with a linear transfer function. If other channels are present (R or A), they **MUST** be ignored for metallic-roughness calculations. When undefined, the texture **MUST** be sampled as having `1.0` in G and B components."
-        },
-        "extensions": { },
-        "extras": { }
+        }
     }
 }

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -6,9 +6,6 @@
     "description": "The material appearance of a primitive.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
-        "name": { },
-        "extensions": { },
-        "extras": { },
         "pbrMetallicRoughness": {
             "allOf": [ { "$ref": "material.pbrMetallicRoughness.schema.json" } ],
             "description": "A set of parameter values that are used to define the metallic-roughness material model from Physically Based Rendering (PBR) methodology. When undefined, all the default values of `pbrMetallicRoughness` **MUST** apply."

--- a/specification/2.0/schema/mesh.primitive.schema.json
+++ b/specification/2.0/schema/mesh.primitive.schema.json
@@ -80,9 +80,7 @@
                 "description": "A plain JSON object specifying attributes displacements in a morph target, where each key corresponds to one of the three supported attribute semantic (`POSITION`, `NORMAL`, or `TANGENT`) and each value is the index of the accessor containing the attribute displacements' data."
             },
             "minItems": 1
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "gltf_webgl": "`drawElements()` and `drawArrays()`",
     "required": [ "attributes" ]

--- a/specification/2.0/schema/mesh.schema.json
+++ b/specification/2.0/schema/mesh.schema.json
@@ -21,10 +21,7 @@
                 "type": "number"
             },
             "minItems": 1
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "primitives" ]
 }

--- a/specification/2.0/schema/node.schema.json
+++ b/specification/2.0/schema/node.schema.json
@@ -78,10 +78,7 @@
             "items": {
                 "type": "number"
             }
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "dependencies": {
         "weights": [ "mesh" ],

--- a/specification/2.0/schema/sampler.schema.json
+++ b/specification/2.0/schema/sampler.schema.json
@@ -114,9 +114,6 @@
                     "type": "integer"
                 }
             ]
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     }
 }

--- a/specification/2.0/schema/scene.schema.json
+++ b/specification/2.0/schema/scene.schema.json
@@ -14,9 +14,6 @@
             },
             "uniqueItems": true,
             "minItems": 1
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     }
 }

--- a/specification/2.0/schema/skin.schema.json
+++ b/specification/2.0/schema/skin.schema.json
@@ -25,10 +25,7 @@
             "uniqueItems": true,
             "minItems": 1,
             "gltf_detailedDescription": "Indices of skeleton nodes, used as joints in this skin."
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "joints" ]
 }

--- a/specification/2.0/schema/texture.schema.json
+++ b/specification/2.0/schema/texture.schema.json
@@ -13,10 +13,7 @@
         "source": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of the image used by this texture. When undefined, an extension or other mechanism **SHOULD** supply an alternate texture source, otherwise behavior is undefined."
-        },
-        "name": { },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "gltf_webgl": "`createTexture()`, `deleteTexture()`, `bindTexture()`, `texImage2D()`, and `texParameterf()`"
 }

--- a/specification/2.0/schema/textureInfo.schema.json
+++ b/specification/2.0/schema/textureInfo.schema.json
@@ -16,9 +16,7 @@
             "default": 0,
             "minimum": 0,
             "gltf_detailedDescription": "This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in `mesh.primitives.attributes` (e.g. a value of `0` corresponds to `TEXCOORD_0`). A mesh primitive **MUST** have the corresponding texture coordinate attributes for the material to be applicable to it."
-        },
-        "extensions": { },
-        "extras": { }
+        }
     },
     "required": [ "index" ]
 }


### PR DESCRIPTION
The `extensions` and `extras` attributes are not needed when glTFProperty has already been composited into the type.
Additionally `name` is not needed when compositing glTFChildOfRootProperty instead.