### PR TITLE
Add NV_texture_swizzle extension

### DIFF
--- a/extensions/2.0/Vendor/NV_texture_swizzle/README.md
+++ b/extensions/2.0/Vendor/NV_texture_swizzle/README.md
@@ -1,0 +1,76 @@
+# NV_texture_swizzle
+
+## Contributors
+
+* Alexey Panteleev, NVIDIA, alpanteleev@nvidia.com
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension provides the ability to use image compression and storage formats that have more than 4 channels as textures in glTF assets. This is achieved by specifying a subset or slice of channels from such image and using those channels as a glTF texture. The extension does not specify which image formats may be used as sources for channel slicing, leaving that up to implementations.
+
+The motivation for this extension is to support new neural texture compression formats. Such formats are designed to store multiple or all of the PBR texture channels for a single material in one container: this way, higher compression ratios can be achieved, and decompressing all channels at once is faster than doing it per-texture. The neural texture set can be used directly in the renderer's shaders or decompressed and transcoded to any other format such as BCn on load. Although the extension is designed primarily for neural texture compression, it can also be useful for other containers that support storing multiple channels, such as OpenEXR.
+
+## Specification
+
+The extension is added to the `textures` node and specifies a single property `options`. The `options` property contains an array of dictionaries following the same format. Each option dictionary contains a `source` property that points to the index of the `images` node which in turn poins to the source image file. Additionally, it specifies a `channels` property that contains an ordered array of up to 4 integers, indicating which channels from the image are to be used for this texture's red, green, blue and alpha channels, in that order. 0 means the first channel, 1 the second, and so on. A special value of -1 is reserved to mean that the channel may contain arbitrary data and is unused in this texture: this can be useful for e.g. `metallicRoughnessTexture` that doesn't use the red channel.
+
+If multiple entries are specified in the `options` array, they should be considered equivalent, and the implementation is free to choose any of the options. This is intended to provide glTF assets referencing multichannel textures in multiple formats and/or containers, so that implementations could choose one that they support.
+
+```json
+"textures": [
+    {
+        "sampler": 0,
+        "extensions": {
+            "NV_texture_swizzle": {
+                "options": [
+                    {
+                        "source": 0,
+                        // Extract channels 0-2 as an RGB texture
+                        "channels": [ 0, 1, 2 ]
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "sampler": 0,
+        "extensions": {
+            "NV_texture_swizzle": {
+                "options": [
+                    {
+                        "source": 0,
+                        // Store arbitrary data in the Red channel
+                        // Swap channels 3-4 into the Green and Blue channels
+                        "channels": [ -1, 4, 3 ]
+                    }
+                ]
+            }
+        }
+    }
+],
+"images": [
+    {
+        "uri": "MaterialTextureSet.ntc"
+    }
+]
+```
+
+Optionally, an `arrayLayer` attribute may be added to the extension. In case the image format supports storing texture arrays, this attribute would specify the index of a single array layer that is used for the texture, as a non-negative integer. If the `arrayLayer` attribute is not specified, it is assumed to be zero.
+
+Using `NV_texture_swizzle` on a texture does not preclude using other sources on the same texture, including regular images or e.g. `MSFT_texture_dds`. When multiple sources are specified, implementations may choose the image format that they support or prefer.
+
+## glTF Schema Updates
+
+* **JSON schema**: [glTF.NV_texture_swizzle.schema.json](schema/glTF.NV_texture_swizzle.schema.json)
+
+## Known Implementations
+
+* The NVIDIA [RTXNTC SDK](https://github.com/NVIDIA-RTX/RTXNTC) implements this extension in the NTC Renderer sample and in the glTF asset preparation script that converts materials to the NTC format.

--- a/extensions/2.0/Vendor/NV_texture_swizzle/schema/glTF.NV_texture_swizzle.schema.json
+++ b/extensions/2.0/Vendor/NV_texture_swizzle/schema/glTF.NV_texture_swizzle.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "NV_texture_swizzle glTF extension",
+  "type": "object",
+  "description": "glTF extension to specify textures as a subset of channels from an image",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+  "properties": {
+    "options": {
+      "type": "array",
+      "description": "The array of options for the texture swizzle.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
+            "description": "The index of the images node which points to a source image file."
+          },
+          "channels": {
+            "type": "array",
+            "description": "The array of channel indices.",
+            "gltf_detailedDescription": "The indices specify which channels of the source image must be used to fill the R, G, B, A channels of the texture, in that order. The value of -1 means the texture channel is not used and may be filled with arbitrary data.",
+            "items": {
+                "type": "integer",
+                "minimum": -1
+            },
+            "minItems": 1,
+            "maxItems": 4
+          },
+          "arrayLayer": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The layer of the image array to get texture data from."
+          }
+        },
+        "required": [
+          "source",
+          "channels"
+        ]
+      },
+      "minItems": 1
+    },
+    "extensions": {},
+    "extras": {}
+  },
+  "required": [
+    "options"
+  ]
+}

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -112,6 +112,7 @@ Vendor extensions are not covered by the Khronos IP framework.
 * [MSFT_packing_occlusionRoughnessMetallic](2.0/Vendor/MSFT_packing_occlusionRoughnessMetallic/README.md)
 * [MSFT_texture_dds](2.0/Vendor/MSFT_texture_dds/README.md)
 * [NV_materials_mdl](2.0/Vendor/NV_materials_mdl/README.md)
+* [NV_texture_swizzle](2.0/Vendor/NV_texture_swizzle/README.md)
 
 The list of vendor prefixes is maintained in [Prefixes.md](Prefixes.md).  Any vendor, not just Khronos members, can request an extension prefix by submitting an [issue on GitHub](https://github.com/KhronosGroup/glTF/issues/new) requesting one.  Requests should include:
 


### PR DESCRIPTION
This extension has been discussed in the Khronos 3D Formats Working Group meetings a couple of months ago. It is designed to support referencing Neural Texture Compression and other formats storing multiple channels in one container, as glTF textures.