### PR TITLE
Add note about attribute name disambiguation

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -137,8 +137,11 @@ All glTF object properties (see [glTFProperty.schema.json](../specification/2.0/
 
 Extensions can't remove existing glTF properties or redefine existing glTF properties to mean something else.
 
-Examples include:
-* **New properties**: `KHR_texture_transform` introduces a set of texture transformation properties, e.g.,
+Extensions may add new properties and values, such as attribute semantics or texture mime types. In all Khronos (KHR) extensions, and as best practice for vendor extensions, these feature additions are designed to allow safe fallback consumption in tools that do not recognize an extension in the `extensionsUsed` array.
+
+### New properties
+
+Extensions can add new properties to existing glTF objects. For example, `KHR_texture_transform` introduces a set of texture transformation properties:
 ```json
 {
   "materials": [{
@@ -155,7 +158,31 @@ Examples include:
   }]
 }
 ```
-Extensions may add new properties and values, such as attribute semantics or texture mime types. In all Khronos (KHR) extensions, and as best practice for vendor extensions, these feature additions are designed to allow safe fallback consumption in tools that do not recognize an extension in the `extensionsUsed` array.
+
+### New attributes
+
+Extensions can introduce new vertex attributes for mesh primitives. In order to disambiguate the names of vertex attributes that are defined by different extensions, the attribute names must be prefixed by the full, case-sensitive name of the extension, followed by a `:` colon. For example, an extension that is called `EXT_example_extension` and that defines vertex attributes for a 'temperature' and a 'velocity' may call them `EXT_example_extension:TEMPERATURE` and `EXT_example_extension:VELOCITY`: 
+```json
+{
+  "meshes" : [
+    {
+      "primitives" : [
+        {
+          "attributes" : {
+            "POSITION" : 0,
+            "COLOR_0" : 1,
+            "EXT_example_extension:TEMPERATURE" : 2,
+            "EXT_example_extension:VELOCITY" : 3
+          },
+          "mode" : 0
+        }
+      ]
+    }
+  ],
+}
+```
+
+## Extension declarations
 
 All extensions used in a model are listed as strings in the top-level `extensionsUsed` array; all _required_ extensions are listed as strings in the top-level `extensionsRequired` array, e.g.,
 ```json


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/glTF/issues/2111 :  

As discussed in the issue and during the 3D Formats calls, the disambiguation between attribute semantic names that are defined by different extensions should happen by prefixing the attribute name with the full name of the extension, followed by a `:` colon.

This PR adds the corresponding information to the `extensions/README.md`, in the "Extension Mechanics" section. Apart from minor restructuring, this mainly adds a section "New Attributes" that defines these rules for extension-defined attributes, and gives an example.

Direct link to [the **new** state of the "Extension Mechanics" section](https://github.com/javagl/glTF/blob/d047e47b37ced23e0fdfcef312f4e7051019141c/extensions/README.md#extension-mechanics), with the "New attributes" section

I considered to use a real-world example instead of that `EXT_example_extension`. But given that there is not yet any extension _merged_ that requires this disambiguation, I chose to use a dummy example name.
