### PR TITLE
KHR_billboard Draft Proposal

### DIFF
--- a/extensions/2.0/Khronos/KHR_billboard/README.md
+++ b/extensions/2.0/Khronos/KHR_billboard/README.md
@@ -58,7 +58,7 @@ The content of a billboard is defined by the meshes and children of the Node. Th
                 "scaleWithDistance" : false,
                 "viewDirection": [0, 0, 1],
                 "up": [0, 1, 0],
-                "rotationAxis": "All",
+                "rotationAxis": ["X", "Y", "Z"],
                 "overlay": false
             }
         }

--- a/extensions/2.0/Khronos/KHR_billboard/README.md
+++ b/extensions/2.0/Khronos/KHR_billboard/README.md
@@ -72,7 +72,7 @@ When the `KHR_billboard` extension is defined on a node, the node's global rotat
 
 ### Child Nodes
 
-Children of a node that defines `KHR_billboard` are treated normally within the context of the glTF node transform. (See: [glTF 2.0 Specification, §3.5.3 Transformations](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#transformations)) This allows content creators to apply an additional adjustment to the billboard that will be applied.
+Children of a node that defines `KHR_billboard` are treated normally within the context of the glTF node transform. (See: [glTF 2.0 Specification, §3.5.3 Transformations](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#transformations)) This allows content creators to apply an additional adjustment to the billboard content.
 
 _Note: If a child node also defines `KHR_billboard`, the child must be treated independently of the parent declaration higher in the node hierarchy. In this case, the child node's global rotation and scale are replaced by the extension as defined in [Handling defined Billboards](#handling-defined-billboards)._
 

--- a/extensions/2.0/Khronos/KHR_billboard/README.md
+++ b/extensions/2.0/Khronos/KHR_billboard/README.md
@@ -1,0 +1,113 @@
+# KHR_billboard
+
+## Contributors
+
+- Adam Morris, Bentley Systems
+- Sean Lilley, Bentley Systems
+- Paul Connelly, Bentley Systems
+- Patrick Härtl, UX3D
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Table of Contents
+
+// TODO
+
+## Overview
+
+Billboards are viewport-aligned images that are positioned within a 3D scene. Billboards can be used for rendering vegetation, 3D UI elements such as spatial markers and tex labels, low level of detail sprites in the distance, animated particles, and more in a computationally efficient manner. This extension specifies support for defining billboards in glTF models and scenes.
+
+Many engines support billboards and can use this extension to import billboards into a scene.
+
+Billboards can be defined for any glTF Node in a model. The content for the billboard is handled by the Node's mesh or child nodes. Properties for the billboard allow content creators to define the view direction, rotational axis, up vector (when view direction is parallel to the up vector), if the billboard scales with distance, and whether or not the billboard should always be visible.
+
+## Defining a Billboard
+
+To enable a Node to be used as a billboard, the desired Node object should include the `KHR_billboard` extension with the desired properties. All properties are optional and define sensible defaults.
+
+The content of a billboard is defined by the meshes and children of the Node. This allows a wide array of different content types to be handled by the extension.
+
+### Properties
+
+| Property | Default | Description |
+| -------- | ------- | ----------- |
+| `scaleWithDistance` | `false` | Defines if the billboard should scale on distance change or not. The initial distance between camera and node is used as reference. |
+| `viewDirection` | `[0,0,1]` | Can be used to change the facing direction of a node (default defined by glTF spec: +Z)
+| `up` | `[0,1,0]` | Needs to be defined if `viewDirection` is parallel to the default `up` vector. `up` and `viewDirection` do not need to be perpendicular (this can be computed by the implementation)
+| `rotationAxis` | `"None"` | Can be used to limit the billboard rotation to an axis. By default it is rotated around all axes. Possible values: `"None"`, `"X"`, `"Y"`, `"Z"` 
+| `overlay` | `false` | Defines if the billboard should be renderer in front of all other meshes and therefore never occluded. If two billboards with this property set to `true` overlap, their original node translation should be considered for ordering.
+
+### Example
+
+```json
+"nodes": [
+    {
+        "extensions": {
+            "KHR_billboard" : {
+                "scaleWithDistance" : false,
+                "viewDirection": [0, 0, 1],
+                "up": [0, 1, 0],
+                "rotationAxis": "None",
+                "overlay": false
+            }
+        }
+    }
+]
+```
+
+## Handling defined Billboards
+
+When the `KHR_billboard` extension is defined on a node, the node's rotation and scale are replaced by the extension. Implementations should make a best effort to follow the parameters of the billboard's properties. The updated transform of the node is applied to associated meshes and children as defined by the core glTF specification.
+
+### Child Nodes
+
+Children of a node that defines `KHR_billboard` should be treated normally within the context of the glTF node transform. (See: [glTF 2.0 Specification, §3.5.3 Transformations]) This allows content creators to apply an additional adjustment to the billboard that will be applied.
+
+If a child node defines `KHR_billboard` itself, the properties of the child's billboard definition override the parents, and the rotation and scale are replaced to follow the parameters of the billboard's properties.
+
+## Known Implementations
+
+- TODO: List of known implementations, with links to each if available.
+
+## Sample Implementation
+
+_Note: This section is non-normative and only describes one approach to implementing billboards._
+
+All vectors should be normalized between operations if not mentioned otherwise. 
+
+If `viewDirection` and `up` are not orthogonal one can fix it by calculating the cross product between them to get the right vector and doing another cross product with this right vector and `viewDirection` to get the corrected `up` vector.
+
+$up = (forward \times up) \times forward$
+
+To start with calculating the correct model rotation, extract the world translation from the target node. To compute the new model forward vector subtract the world translation from the camera translation. For implementing the `rotationAxis` set the specific axis of the calculated camera position to zero.
+
+Now we can compute the rotation $r_1$ between the current model forward vector and the new model forward vector. Most math libraries have an inbuilt function for this. This rotation should also be applied to the `up` vector.
+
+Now we need to calculate the correct rotation for the up vector of the model. Coincidentally, this can be deferred from the up vector of the camera:
+
+Fist, calculate the cross product of the camera right vector and the negated new model forward vector to get the new up vector. Now, compute the rotation $r_2$ between the the previously rotated `up` vector and the new up vector.
+
+To get the model local rotation, both rotations need to be multiplied.
+
+$model_{rotation} = r_1 * r_2$
+
+Therefore, the rotation consists of the $r_1$ which rotates the model to look at the camera and $r_2$ which makes sure that camera up and model up vector are aligned.
+
+To compose the model matrix, one first adds the model scale. If `scaleWithDistance` is `true`, a scaling factor needs to be applied based on the initial distance between the camera and the model.
+
+$scaleFactor = \frac{(worldTranslation_{model} * viewMatrix).z}{(worldTranslation_{model} * initialViewMatrix).z}$
+
+Now we can apply the $model_{rotation}$ to the model matrix and set the translation of the model matrix to the original one, since billboards only affect rotation and scale.
+
+If `overlay` option is given, the depth value of affected primitives needs to be set to zero. If multiple billboards with overlay are present, than they need to be depth sorted based on their position and an increasing Z value near zero should be used. This avoids Z-fighting.
+
+## Resources
+
+- [Billboard explainer in glTF-External-Reference](https://github.com/KhronosGroup/glTF-External-Reference/blob/main/explainers/billboard.md)
+- [glTF 2.0 Specification §3.5.2](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#transformations)

--- a/extensions/2.0/Khronos/KHR_billboard/README.md
+++ b/extensions/2.0/Khronos/KHR_billboard/README.md
@@ -63,13 +63,13 @@ The content of a billboard is defined by the meshes and children of the Node. Th
 
 ## Handling defined Billboards
 
-When the `KHR_billboard` extension is defined on a node, the node's rotation and scale are replaced by the extension. Implementations should make a best effort to follow the parameters of the billboard's properties. The updated transform of the node is applied to associated meshes and children as defined by the core glTF specification.
+When the `KHR_billboard` extension is defined on a node, the node's global rotation and scale are replaced by the extension and node's parent global rotation and scale are not used. The updated global transform of the node is applied to associated meshes and children as defined by the core glTF specification. Implementations should make a best effort to follow the parameters of the billboard's properties.
 
 ### Child Nodes
 
-Children of a node that defines `KHR_billboard` should be treated normally within the context of the glTF node transform. (See: [glTF 2.0 Specification, §3.5.3 Transformations]) This allows content creators to apply an additional adjustment to the billboard that will be applied.
+Children of a node that defines `KHR_billboard` are treated normally within the context of the glTF node transform. (See: [glTF 2.0 Specification, §3.5.3 Transformations](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#transformations)) This allows content creators to apply an additional adjustment to the billboard that will be applied.
 
-If a child node defines `KHR_billboard` itself, the properties of the child's billboard definition override the parents, and the rotation and scale are replaced to follow the parameters of the billboard's properties.
+_Note: If a child node also defines `KHR_billboard`, the child must be treated independently of the parent declaration higher in the node hierarchy. In this case, the child node's global rotation and scale are replaced by the extension as defined in [Handling defined Billboards](#handling-defined-billboards)._
 
 ## Known Implementations
 

--- a/extensions/2.0/Khronos/KHR_billboard/README.md
+++ b/extensions/2.0/Khronos/KHR_billboard/README.md
@@ -40,7 +40,7 @@ The content of a billboard is defined by the meshes and children of the Node. Th
 | `scaleWithDistance` | `false` | Defines if the billboard should scale on distance change or not. The initial distance between camera and node is used as reference. |
 | `viewDirection` | `[0,0,1]` | Can be used to change the facing direction of a node (default defined by glTF spec: +Z)
 | `up` | `[0,1,0]` | Needs to be defined if `viewDirection` is parallel to the default `up` vector. `up` and `viewDirection` do not need to be perpendicular (this can be computed by the implementation)
-| `rotationAxis` | `"None"` | Can be used to limit the billboard rotation to an axis. By default it is rotated around all axes. Possible values: `"None"`, `"X"`, `"Y"`, `"Z"` 
+| `rotationAxis` | `"All"` | Can be used to limit the billboard rotation to an axis. By default it is rotated around all axes. Possible values: `"All"`, `"X"`, `"Y"`, `"Z"` 
 | `overlay` | `false` | Defines if the billboard should be renderer in front of all other meshes and therefore never occluded. If two billboards with this property set to `true` overlap, their original node translation should be considered for ordering.
 
 ### Example
@@ -53,7 +53,7 @@ The content of a billboard is defined by the meshes and children of the Node. Th
                 "scaleWithDistance" : false,
                 "viewDirection": [0, 0, 1],
                 "up": [0, 1, 0],
-                "rotationAxis": "None",
+                "rotationAxis": "All",
                 "overlay": false
             }
         }

--- a/extensions/2.0/Khronos/KHR_billboard/README.md
+++ b/extensions/2.0/Khronos/KHR_billboard/README.md
@@ -17,7 +17,12 @@ Written against the glTF 2.0 spec.
 
 ## Table of Contents
 
-// TODO
+- [Overview](#overview)
+- [Defining a Billboard](#defining-a-billboard)
+- [Handling defined Billboards](#handling-defined-billboards)
+- [Known Implementations](#known-implementations)
+- [Sample Implementation](#sample-implementation)
+- [Resources](#resources)
 
 ## Overview
 

--- a/extensions/2.0/Khronos/KHR_billboard/README.md
+++ b/extensions/2.0/Khronos/KHR_billboard/README.md
@@ -42,11 +42,11 @@ The content of a billboard is defined by the meshes and children of the Node. Th
 
 | Property | Default | Description |
 | -------- | ------- | ----------- |
-| `scaleWithDistance` | `false` | Defines if the billboard should scale on distance change or not. The initial distance between camera and node is used as reference. |
-| `viewDirection` | `[0,0,1]` | Can be used to change the facing direction of a node (default defined by glTF spec: +Z)
-| `up` | `[0,1,0]` | Needs to be defined if `viewDirection` is parallel to the default `up` vector. `up` and `viewDirection` do not need to be perpendicular (this can be computed by the implementation)
-| `rotationAxis` | `"All"` | Can be used to limit the billboard rotation to an axis. By default it is rotated around all axes. Possible values: `"All"`, `"X"`, `"Y"`, `"Z"` 
-| `overlay` | `false` | Defines if the billboard should be renderer in front of all other meshes and therefore never occluded. If two billboards with this property set to `true` overlap, their original node translation should be considered for ordering.
+| `scaleWithDistance` | `false` | Defines if the billboard should scale on distance change or not. The initial distance between the active camera and node is used as reference. |
+| `viewDirection` | `[0,0,1]` | Can be used to change the facing direction of a node (default defined by glTF spec: +Z) |
+| `up` | `[0,1,0]` | Needs to be defined if `viewDirection` is parallel to the default `up` vector. `up` and `viewDirection` do not need to be perpendicular (this can be computed by the implementation) |
+| `rotationAxis` | `["X", "Y", "Z"]` | An array defining the axes used for rotation. By default the billboard is rotated around all axes. Possible values are `X`, `Y`, and/or `Z`. For example, to only rotate around the Y axis, set this property to `["Y"]`. |
+| `overlay` | `false` | Defines if the billboard should be renderer in front of all other meshes and therefore never occluded. If two billboards with this property set to `true` overlap, their original node translation should be considered for ordering. |
 
 ### Example
 

--- a/extensions/2.0/Khronos/KHR_billboard/README.md
+++ b/extensions/2.0/Khronos/KHR_billboard/README.md
@@ -15,6 +15,8 @@ Draft
 
 Written against the glTF 2.0 spec.
 
+This extension assumes the presence of an active camera in the rendering environment.
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -66,19 +68,62 @@ The content of a billboard is defined by the meshes and children of the Node. Th
 ]
 ```
 
-## Handling defined Billboards
+## Handling Defined Billboards
 
-When the `KHR_billboard` extension is defined on a node, the node's global rotation and scale are replaced by the extension and node's parent global rotation and scale are not used. The updated global transform of the node is applied to associated meshes and children as defined by the core glTF specification. Implementations should make a best effort to follow the parameters of the billboard's properties.
+When `KHR_billboard` is present on a node, that node **does not inherit orientation from its parent nodes**. The node's global transform is computed as follows:
+
+1. The global translation is computed normally per the glTF 2.0 specification (§3.5.3), accumulating the full parent `T * R * S` chain but extracting only the resulting global-space position.
+2. The global rotation and global scale of all ancestor nodes are **discarded** and replaced by a camera-derived rotation and billboard scale as defined below.
+
+The final global transform of a billboard node MUST be:
+
+```math
+G_{billboard} = T_{global} \cdot R_{camera} \cdot S_{billboard}
+```
+
+where $T_{global}$ is the global translation derived from the ancestor chain, $R_{camera}$ is the camera-derived rotation matrix, and $S_{billboard}$ is the effective scale as defined below.
+
+### Camera-Derived Rotation
+
+Let $\hat{f}$ be the unit vector from the node's global position toward the camera position, projected and/or zeroed according to `rotationAxis` as defined in [Rotation Axis Constraints](#rotation-axis-constraints). Let $\hat{u}$ be the billboard's effective up vector as defined in [Up Vector](#up-vector). The camera-derived rotation matrix $R_{camera}$ is the unique rotation that maps `viewDirection` to $\hat{f}$ and aligns the node's local up axis with $\hat{u}$.
+
+### Rotation Axis Constraints
+
+The `rotationAxis` property restricts which axes of the camera-facing direction are applied. The constraint is applied in global space by zeroing the components of the camera-facing vector $\vec{f}$ (prior to normalization to $\hat{f}$) along axes not present in `rotationAxis`, then normalizing. If the resulting vector has zero length, the behavior is implementation-defined; implementations SHOULD fall back to the node's `viewDirection` transformed to global space.
+
+When `rotationAxis` does not include all three axes, the billboard is constrained to face the camera only in the specified directions. For example, `["Y"]` produces a billboard that rotates to face the camera only around the global Y axis, suitable for upright objects such as trees or vertical signs.
+
+### Up Vector
+
+The `up` property defines the local up direction of the billboard in the node's local space. Implementations MUST use this vector when computing $R_{camera}$ to resolve the rotational degree of freedom around $\hat{f}$.
+
+If `viewDirection` and `up` are parallel (within a tolerance of 1e-6 radians), the behavior is implementation-defined. Content MUST NOT define a `viewDirection` that is parallel to `up`.
+
+### Effective Scale
+
+If `scaleWithDistance` is `false`, $S_{billboard}$ is the node's local scale as defined in the glTF node properties.
+
+If `scaleWithDistance` is `true`, $S_{billboard}$ is the node's local scale multiplied by a uniform scale factor:
+
+```math
+k = \frac{d_{current}}{d_{initial}}
+```
+
+where $d_{initial}$ is the view-space depth (camera-space Z) of the node's global position at the time the node is first rendered by the active camera, and $d_{current}$ is the view-space depth at the current frame. Implementations MUST recompute $d_{initial}$ if the node is removed from the scene and re-added.
 
 ### Child Nodes
 
-Children of a node that defines `KHR_billboard` are treated normally within the context of the glTF node transform. (See: [glTF 2.0 Specification, §3.5.3 Transformations](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#transformations)) This allows content creators to apply an additional adjustment to the billboard content.
+Children of a billboard node inherit the billboard node's final global transform $G_{billboard}$ as their parent transform, per the glTF 2.0 specification (§3.5.3). The scene graph suspension applies only to the billboard node itself; children accumulate their local TRS on top of $G_{billboard}$ normally.
 
-_Note: If a child node also defines `KHR_billboard`, the child must be treated independently of the parent declaration higher in the node hierarchy. In this case, the child node's global rotation and scale are replaced by the extension as defined in [Handling defined Billboards](#handling-defined-billboards)._
+If a child node also defines `KHR_billboard`, that child's global transform is computed independently using the same rules, with the global translation derived from $G_{billboard}$ of the parent billboard node and all ancestor orientations again discarded.
+
+### Overlay Rendering
+
+If `overlay` is `true`, the billboard's primitives MUST be rendered after all non-overlay geometry. Depth testing against non-overlay geometry MUST be disabled for overlay primitives. When multiple overlay billboards overlap, they MUST be depth-sorted in descending order of their global-space distance from the camera and rendered back-to-front to produce correct alpha compositing order.
 
 ## Known Implementations
 
-- TODO: List of known implementations, with links to each if available.
+- Basic partial implementation in a CesiumJS prototype branch.
 
 ## Sample Implementation
 
@@ -90,7 +135,7 @@ If `viewDirection` and `up` are not orthogonal one can fix it by calculating the
 
 $up = (forward \times up) \times forward$
 
-To start with calculating the correct model rotation, extract the world translation from the target node. To compute the new model forward vector subtract the world translation from the camera translation. For implementing the `rotationAxis` set the specific axis of the calculated camera position to zero.
+To start with calculating the correct model rotation, extract the global translation from the target node. To compute the new model forward vector subtract the global translation from the camera translation. For implementing the `rotationAxis` set the specific axis of the calculated camera position to zero.
 
 Now we can compute the rotation $r_1$ between the current model forward vector and the new model forward vector. Most math libraries have an inbuilt function for this. This rotation should also be applied to the `up` vector.
 
@@ -106,7 +151,7 @@ Therefore, the rotation consists of the $r_1$ which rotates the model to look at
 
 To compose the model matrix, one first adds the model scale. If `scaleWithDistance` is `true`, a scaling factor needs to be applied based on the initial distance between the camera and the model.
 
-$scaleFactor = \frac{(worldTranslation_{model} * viewMatrix).z}{(worldTranslation_{model} * initialViewMatrix).z}$
+$scaleFactor = \frac{(globalTranslation_{model} * viewMatrix).z}{(globalTranslation_{model} * initialViewMatrix).z}$
 
 Now we can apply the $model_{rotation}$ to the model matrix and set the translation of the model matrix to the original one, since billboards only affect rotation and scale.
 

--- a/extensions/2.0/Khronos/KHR_billboard/README.md
+++ b/extensions/2.0/Khronos/KHR_billboard/README.md
@@ -73,15 +73,15 @@ The content of a billboard is defined by the meshes and children of the Node. Th
 When `KHR_billboard` is present on a node, that node **does not inherit orientation from its parent nodes**. The node's global transform is computed as follows:
 
 1. The global translation is computed normally per the glTF 2.0 specification (§3.5.3), accumulating the full parent `T * R * S` chain but extracting only the resulting global-space position.
-2. The global rotation and global scale of all ancestor nodes are **discarded** and replaced by a camera-derived rotation and billboard scale as defined below.
+2. The global rotation and global scale of all parent nodes are **discarded** and replaced by a camera-derived rotation and billboard scale as defined below.
 
 The final global transform of a billboard node MUST be:
 
 ```math
-G_{billboard} = T_{global} \cdot R_{camera} \cdot S_{billboard}
+G_{billboard} = T_{G_{parent}} \cdot R_{camera} \cdot S_{billboard}
 ```
 
-where $T_{global}$ is the global translation derived from the ancestor chain, $R_{camera}$ is the camera-derived rotation matrix, and $S_{billboard}$ is the effective scale as defined below.
+where $T_{G_{parent}}$ is the global translation derived from the parent chain, $R_{camera}$ is the camera-derived rotation matrix, and $S_{billboard}$ is the effective scale as defined below.
 
 ### Camera-Derived Rotation
 
@@ -115,7 +115,7 @@ where $d_{initial}$ is the view-space depth (camera-space Z) of the node's globa
 
 Children of a billboard node inherit the billboard node's final global transform $G_{billboard}$ as their parent transform, per the glTF 2.0 specification (§3.5.3). The scene graph suspension applies only to the billboard node itself; children accumulate their local TRS on top of $G_{billboard}$ normally.
 
-If a child node also defines `KHR_billboard`, that child's global transform is computed independently using the same rules, with the global translation derived from $G_{billboard}$ of the parent billboard node and all ancestor orientations again discarded.
+If a child node also defines `KHR_billboard`, that child's global transform is computed independently using the same rules, with the global translation derived from $G_{billboard}$ of the parent billboard node and all parent orientations again discarded.
 
 ### Overlay Rendering
 

--- a/extensions/2.0/Khronos/KHR_billboard/schema/node.KHR_billboard.schema.json
+++ b/extensions/2.0/Khronos/KHR_billboard/schema/node.KHR_billboard.schema.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_billboard glTF Node Extension",
+    "type": "object",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "overlay": {
+            "type": "boolean",
+            "description": "If true, the billboard is rendered on top of other objects. (Default: false)",
+            "default": false
+        },
+        "rotationAxis": {
+            "type": "string",
+            "enum": [ "None", "X", "Y", "Z" ],
+            "description": "The axis around which the billboard rotates. 'None' means it rotates around all axes. (Default: None)",
+            "default": "None"
+        },
+        "scaleWithDistance": {
+            "type": "boolean",
+            "description": "If true, the billboard scales with distance from the camera. (Default: false)",
+            "default": false
+        },
+        "up": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            },
+            "minItems": 3,
+            "maxItems": 3,
+            "description": "The up direction of the billboard. Must be defined if `viewDirection` is parallel to the default up vector. (Default: +Y)",
+            "default": [0, 1, 0]
+        },
+        "viewDirection": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            },
+            "minItems": 3,
+            "maxItems": 3,
+            "description": "The view direction of the billboard. (Default: +Z)",
+            "default": [0, 0, 1]
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}

--- a/extensions/2.0/Khronos/KHR_billboard/schema/node.KHR_billboard.schema.json
+++ b/extensions/2.0/Khronos/KHR_billboard/schema/node.KHR_billboard.schema.json
@@ -11,9 +11,9 @@
         },
         "rotationAxis": {
             "type": "string",
-            "enum": [ "None", "X", "Y", "Z" ],
-            "description": "The axis around which the billboard rotates. 'None' means it rotates around all axes. (Default: None)",
-            "default": "None"
+            "enum": [ "All", "X", "Y", "Z" ],
+            "description": "The axis around which the billboard rotates. 'All' rotates around all axes. (Default: All)",
+            "default": "All"
         },
         "scaleWithDistance": {
             "type": "boolean",

--- a/extensions/2.0/Khronos/KHR_billboard/schema/node.KHR_billboard.schema.json
+++ b/extensions/2.0/Khronos/KHR_billboard/schema/node.KHR_billboard.schema.json
@@ -10,10 +10,15 @@
             "default": false
         },
         "rotationAxis": {
-            "type": "string",
-            "enum": [ "All", "X", "Y", "Z" ],
-            "description": "The axis around which the billboard rotates. 'All' rotates around all axes. (Default: All)",
-            "default": "All"
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [ "X", "Y", "Z" ]
+            },
+            "minItems": 1,
+            "maxItems": 3,
+            "description": "The axes around which the billboard rotates. 'X', 'Y', and/or 'Z'. (Default: ['X', 'Y', 'Z'])",
+            "default": ["X", "Y", "Z"]
         },
         "scaleWithDistance": {
             "type": "boolean",


### PR DESCRIPTION
Billboards have been [discussed within the context of glTF for some time now](https://github.com/KhronosGroup/glTF-External-Reference/blob/main/explainers/billboard.md) and we've found a growing need for being able to define them within a glTF for 3D Tiles and other geospatial use cases. This draft proposal is for `KHR_billboard`, an extension based on [the Billboard explainer](https://github.com/KhronosGroup/glTF-External-Reference/blob/main/explainers/billboard.md) that @UX3D-haertl wrote last year.

Human-readable link to [KHR_billboard](https://github.com/CesiumGS/glTF/tree/billboard-draft/extensions/2.0/Khronos/KHR_billboard/README.md).

Billboards are viewport-aligned meshes or images that have many uses including:

 - Spatially-oriented labels.
 - Displaying foliage, trees, clouds with 2D sprites.
 - Animated visual effects and particles.
 - Distant low level-of-detail sprites.

Most CGI tools and game engines support some sort of Billboard functionality. While this proposal is based on the excellent explainer written by @UX3D-haertl, I have done some further analysis and looked into how the popular engines support billboards. Given that, I made some small adjustments to how rotation axis is defined and attempted to make it clearer how the parent-child relationship should work with children of a billboard node.

In the full spirit of the [explainer](https://github.com/KhronosGroup/glTF-External-Reference/blob/main/explainers/billboard.md) the content of the billboard is handled by the associated mesh or children of the billboard node. This allows a variety of content to be handled by the billboard.

_Note: We are also investigating an extension for defining labels for use with billboards similar to what we do in CesiumJS and we'll share that soon._