### PR TITLE
EXT_lights_area

### DIFF
--- a/extensions/2.0/Vendor/EXT_lights_area/README.md
+++ b/extensions/2.0/Vendor/EXT_lights_area/README.md
@@ -33,18 +33,16 @@ The following example defines both a rectangular and a disk area light:
                 "color": [1.0, 1.0, 1.0],
                 "intensity": 1000.0,
                 "type": "rect",
+                "size": 1.0,
                 "rect": {
-                    "width": 2.0,
-                    "height": 1.0
+                    "aspect": 2.0
                 }
             },
             {
                 "color": [1.0, 0.9, 0.8],
                 "intensity": 1500.0,
                 "type": "disk",
-                "disk": {
-                    "radius": 1.2
-                }
+                "size": 1.2
             }
         ]
     }

--- a/extensions/2.0/Vendor/EXT_lights_area/README.md
+++ b/extensions/2.0/Vendor/EXT_lights_area/README.md
@@ -17,7 +17,7 @@ Written against the glTF 2.0 spec.
 This extension defines area lights with physically accurate intensity values for use with glTF 2.0.
 
 Area lights are flat surfaces that uniformly emit light from one side (the side facing in the -Z direction in local space).
-This extension defines two area light shapes: `rect` (rectangle) and `disk` (circle). These lights are referenced by nodes and inherit the transform of that node, allowing them to be placed in a scene.
+This extension defines two area light types: `rect` (rectangle) and `disk` (circle). These lights are referenced by nodes and inherit the transform of that node, allowing them to be placed in a scene.
 
 ## Defining Area Lights
 
@@ -86,7 +86,7 @@ All light types share the common set of properties listed below.
 
 ### Rectangle Lights
 
-When a light's `type` is `rect`, the `rect` property on the light is required. Its properties (below) are optional.
+When a light's `type` is `rect`, the `rect` property contains the following optional properties.
 
 | Property | Type | Description | Required | Default |
 |:---------|:-----|:------------|:---------|:--------|

--- a/extensions/2.0/Vendor/EXT_lights_area/README.md
+++ b/extensions/2.0/Vendor/EXT_lights_area/README.md
@@ -1,0 +1,140 @@
+# EXT_lights_area
+
+## Contributors
+
+* Mike Bond, Adobe, [@miibond](https://github.com/MiiBond)
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+## Overview
+
+This extension defines area lights with physically accurate intensity values for use with glTF 2.0.
+
+Area lights are flat surfaces that uniformly emit light from one side (the side facing in the -Z direction in local space).
+This extension defines two area light shapes: `rect` (rectangle) and `disk` (circle). These lights are referenced by nodes and inherit the transform of that node, allowing them to be placed in a scene.
+
+## Defining Area Lights
+
+As with KHR_lights_punctual, area lights are defined as a `lights` array inside the `EXT_lights_area` extension at the root of the document.
+
+The following example defines both a rectangular and a disk area light:
+
+```json
+"extensions": {
+    "EXT_lights_area": {
+        "lights": [
+            {
+                "color": [1.0, 1.0, 1.0],
+                "intensity": 1000.0,
+                "shape": "rect",
+                "width": 2.0,
+                "height": 1.0
+            },
+            {
+                "color": [1.0, 0.9, 0.8],
+                "intensity": 1500.0,
+                "shape": "disk",
+                "radius": 1.2
+            }
+        ]
+    }
+}
+```
+
+## Adding Light Instances to Nodes
+
+Lights must be attached to a node by defining the `extensions.EXT_lights_area` property and, within that, an index into the `lights` array using the `light` property.
+
+```json
+"nodes": [
+    {
+        "extensions": {
+            "EXT_lights_area": {
+                "light": 0
+            }
+        }
+    }
+]
+```
+
+## Behaviour
+
+The light will inherit the transform of the node that it is attached to. Area lights are centered at the origin in local space:
+
+* **Rectangular lights**: extend from -width/2 to +width/2 along the local X-axis, and from -height/2 to +height/2 along the Y-axis
+* **Disk lights**: extend in a circle of the specified radius 
+around the origin in the local XY-plane
+
+Area lights emit light uniformly from one side of the surface (the side facing in the -Z direction in local space). The light emission follows Lambert's cosine law.
+
+**Lambert's Cosine Law**: This law states that the radiant intensity (or luminous intensity) observed from a perfectly diffusing surface is directly proportional to the cosine of the angle between the direction of the incident light and the surface normal. In practical terms, this means that an area light appears brightest when viewed straight-on (perpendicular to the surface) and dimmer as the viewing angle increases, creating realistic soft lighting that mimics real-world diffuse light sources like LED panels or softboxes.
+
+## Properties
+
+### Light Properties
+
+| Property | Type | Description | Required | Default |
+|:---------|:-----|:------------|:---------|:--------|
+| `color` | `number[3]` | RGB color of the light in linear space. Each component should be in the range [0, 1]. | No | `[1.0, 1.0, 1.0]` |
+| `intensity` | `number` | The luminance of the light surface in nits (cd/m²). Must be a positive value. | No | `1000.0` |
+| `shape` | `string` | The shape of the area light. Must be either `"rect"` or `"disk"`. | Yes | - |
+| `width` | `number` | Width of the rectangular light in meters. Must be a positive value. Required for `rect` lights, ignored for `disk` lights. | Conditional | `1.0` |
+| `height` | `number` | Height of the rectangular light in meters. Must be a positive value. Required for `rect` lights, ignored for `disk` lights. | Conditional | `1.0` |
+| `radius` | `number` | Radius of the disk light in meters. Must be a positive value. Required for `disk` lights, ignored for `rect` lights. | Conditional | `1.0` |
+
+### Node Extension Properties
+
+| Property | Type | Description | Required |
+|:---------|:-----|:------------|:---------|
+| `light` | `integer` | Index of the light in the lights array. | Yes |
+
+## Implementation Notes
+
+### Luminance Units
+
+The `intensity` property is specified in nits (cd/m²), which is the standard unit for surface luminance. This provides physically accurate lighting values:
+
+* Typical indoor lighting: 100-500 nits
+* Bright office lighting: 1,000 nits  
+* Sunlit white paper: 30,000 nits
+* Direct sunlight: 1,000,000,000+ nits
+
+### Light Emission
+
+Area lights emit light uniformly across their surface following Lambert's cosine law. The total luminous flux (in lumens) emitted by the light is:
+
+```
+Flux = luminance × area × π
+```
+
+Where:
+
+* `luminance` is in nits (cd/m²)
+* `area` is the surface area of the light in square meters:
+  * For rectangular lights: `area = width × height`
+  * For disk lights: `area = π × radius²`
+* The result is in lumens
+
+### Transform Inheritance
+
+The light inherits the full transform of its parent node, including:
+
+* Position (translation)
+* Orientation (rotation) 
+* Scale
+
+If the node is scaled:
+
+* For rectangular lights: the width and height are scaled accordingly
+* For disk lights: the radius is scaled by the average of the X and Y scale factors
+* The intensity value remains constant, but the total emitted flux will change proportionally to the change in area
+
+## JSON Schema
+
+* [light.EXT_lights_area.schema.json](schema/light.area.schema.json)

--- a/extensions/2.0/Vendor/EXT_lights_area/README.md
+++ b/extensions/2.0/Vendor/EXT_lights_area/README.md
@@ -68,7 +68,7 @@ Lights must be attached to a node by defining the `extensions.EXT_lights_area` p
 The light will inherit the transform of the node in the following manner:
 1. The light's centre is defined as the node's world location.
 2. The light's direction is defined as the 3-vector `(0.0, 0.0, -1.0)` and the rotation of the node orients the light accordingly. That is, an untransformed light points down the -Z axis.
-3. The light's size is defined as its "size" property multiplied by the absolute value of the largest component of the node's world scale. i.e. the scaling is always uniform and positive.
+3. The light's size is defined as its "size" property multiplied by the absolute value of the largest component of the node's world scale, i.e., the scaling is always uniform and positive.
 
 ## Light Types
 

--- a/extensions/2.0/Vendor/EXT_lights_area/README.md
+++ b/extensions/2.0/Vendor/EXT_lights_area/README.md
@@ -94,7 +94,7 @@ When a light's `type` is `rect`, the `rect` property on the light is required. I
 
 The rectangle area light's shape extends from -width/2 to +width/2 along the local X-axis, and from -height/2 to +height/2 along the Y-axis where width and height are defined as follows:
 
-`width = world scale * size * aspect`
+`width = world scale * size * aspect` \
 `height = world scale * size`
 
 `world scale` is the largest component of the absolute value of the node's scale.

--- a/extensions/2.0/Vendor/EXT_lights_area/schema/glTF.EXT_lights_area.schema.json
+++ b/extensions/2.0/Vendor/EXT_lights_area/schema/glTF.EXT_lights_area.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "EXT_lights_area glTF Document Extension",
+    "type": "object",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "lights": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "$ref": "light.area.schema.json"
+            },
+            "minItems": 1,
+            "description": "An array of area lights (rectangular and disk)."
+        },
+        "extensions": { },
+        "extras": { }
+    },
+    "required": [
+        "lights"
+    ]
+}

--- a/extensions/2.0/Vendor/EXT_lights_area/schema/light.area.schema.json
+++ b/extensions/2.0/Vendor/EXT_lights_area/schema/light.area.schema.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "EXT_lights_area Area Light Properties",
+    "type": "object",
+    "description": "An area light (rectangular or disk) that emits light uniformly from one side following Lambert's cosine law.",
+    "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
+    "properties": {
+        "color": {
+            "type": "array",
+            "items": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0
+            },
+            "minItems": 3,
+            "maxItems": 3,
+            "description": "RGB color of the light in linear space. Each component should be in the range [0, 1].",
+            "default": [1.0, 1.0, 1.0]
+        },
+        "luminance": {
+            "type": "number",
+            "description": "The luminance of the light surface in nits (cd/m²). Must be a positive value.",
+            "default": 1000.0,
+            "minimum": 0.0,
+            "exclusiveMinimum": true
+        },
+        "shape": {
+            "type": "string",
+            "description": "The shape of the area light.",
+            "enum": ["rect", "disk"]
+        },
+        "width": {
+            "type": "number",
+            "description": "Width of the rectangular light in meters. Must be a positive value. Required for rect lights, ignored for disk lights.",
+            "default": 1.0,
+            "minimum": 0.0,
+            "exclusiveMinimum": true
+        },
+        "height": {
+            "type": "number",
+            "description": "Height of the rectangular light in meters. Must be a positive value. Required for rect lights, ignored for disk lights.",
+            "default": 1.0,
+            "minimum": 0.0,
+            "exclusiveMinimum": true
+        },
+        "radius": {
+            "type": "number",
+            "description": "Radius of the disk light in meters. Must be a positive value. Required for disk lights, ignored for rect lights.",
+            "default": 1.0,
+            "minimum": 0.0,
+            "exclusiveMinimum": true
+        },
+        "name": { },
+        "extensions": { },
+        "extras": { }
+    },
+    "required": [
+        "shape"
+    ]
+}

--- a/extensions/2.0/Vendor/EXT_lights_area/schema/light.rect.schema.json
+++ b/extensions/2.0/Vendor/EXT_lights_area/schema/light.rect.schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema" : "http://json-schema.org/draft-04/schema",
+    "title" : "EXT_lights_area Rectangular Light Properties",
+    "type" : "object",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties" : {
+        "aspect" : {
+            "type" : "number",
+            "description" : "Aspect ratio of the light (width / height).",
+            "default" : 1.0,
+            "minimum": 0.0,
+            "exclusiveMinimum": true
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}

--- a/extensions/2.0/Vendor/EXT_lights_area/schema/light.schema.json
+++ b/extensions/2.0/Vendor/EXT_lights_area/schema/light.schema.json
@@ -5,6 +5,10 @@
     "description": "An area light (rectangular or disk) that emits light uniformly from one side following Lambert's cosine law.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
+        "name": {
+            "type": "string",
+            "description": "The name of the light. This is not necessarily unique."
+        },
         "color": {
             "type": "array",
             "items": {
@@ -17,40 +21,37 @@
             "description": "RGB color of the light in linear space. Each component should be in the range [0, 1].",
             "default": [1.0, 1.0, 1.0]
         },
-        "luminance": {
+        "intensity": {
             "type": "number",
             "description": "The luminance of the light surface in nits (cd/m²). Must be a positive value.",
             "default": 1000.0,
+            "minimum": 0.0
+        },
+        "size": {
+            "type": "number",
+            "description": "Size of the light. For rectangular lights, this is the height (y-axis) in local space. Must be a positive value. For disk lights, it is the diameter.",
+            "default": 1.0,
             "minimum": 0.0,
             "exclusiveMinimum": true
         },
-        "shape": {
+        "rect": {
+            "type": "object",
+            "$ref": "light.rect.schema.json"
+        },
+        "type": {
             "type": "string",
-            "description": "The shape of the area light.",
-            "enum": ["rect", "disk"]
+            "description": "Specifies the type of area light.",
+            "anyOf": [
+                {
+                    "enum": [ "rect" ],
+                    "description": "Rectangle lights emit light from a rectangular area."
+                },
+                {
+                    "enum": [ "disk" ],
+                    "description": "Disk lights emit light from a circular area."
+                }
+            ]
         },
-        "width": {
-            "type": "number",
-            "description": "Width of the rectangular light in meters. Must be a positive value. Required for rect lights, ignored for disk lights.",
-            "default": 1.0,
-            "minimum": 0.0,
-            "exclusiveMinimum": true
-        },
-        "height": {
-            "type": "number",
-            "description": "Height of the rectangular light in meters. Must be a positive value. Required for rect lights, ignored for disk lights.",
-            "default": 1.0,
-            "minimum": 0.0,
-            "exclusiveMinimum": true
-        },
-        "radius": {
-            "type": "number",
-            "description": "Radius of the disk light in meters. Must be a positive value. Required for disk lights, ignored for rect lights.",
-            "default": 1.0,
-            "minimum": 0.0,
-            "exclusiveMinimum": true
-        },
-        "name": { },
         "extensions": { },
         "extras": { }
     },

--- a/extensions/2.0/Vendor/EXT_lights_area/schema/node.EXT_lights_area.schema.json
+++ b/extensions/2.0/Vendor/EXT_lights_area/schema/node.EXT_lights_area.schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "EXT_lights_area glTF Node Extension",
+    "type": "object",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "light": {
+            "allOf": [
+                {
+                    "$ref": "glTFid.schema.json"
+                }
+            ],
+            "description": "The index of the area light referenced by this node."
+        },
+        "extensions": { },
+        "extras": { }
+    },
+    "required": [
+        "light"
+    ]
+}


### PR DESCRIPTION
This is almost identical to the previously-proposed KHR area lights extension except that it excludes "sphere" as a valid shape in favour of only flat lights. (See https://github.com/KhronosGroup/glTF/pull/1948).