### PR TITLE
Adding a copyright SPDX back to the mesh primitive restart extension

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_primitive_restart/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_primitive_restart/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 Bentley Systems, Incorporated
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # EXT_mesh_primitive_restart
 
 ## Contributors


### PR DESCRIPTION
Correcting this. Our intent is to release this extension openly for use by others.