### PR TITLE
Changing the masking-shadowing function referenced in the 2.0 specifications

### DIFF
--- a/specification/2.0/Specification.adoc
+++ b/specification/2.0/Specification.adoc
@@ -3076,7 +3076,7 @@ with
 
 [latexmath]
 ++++
-G = \frac{\chi^{+}(H \cdot L) \, \chi^{+}(H \cdot V)}{2 \, (\left| N \cdot V \right| \, \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot L)^2} + \left| N \cdot L \right| \, \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot V)^2})}
+\nu = \frac{\chi^{+}(H \cdot L) \, \chi^{+}(H \cdot V)}{2 \, (\left| N \cdot V \right| \, \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot L)^2} + \left| N \cdot L \right| \, \sqrt{\alpha^2 + (1 - \alpha^2) (N \cdot V)^2})}
 ++++
 
 Thus, we have the function


### PR DESCRIPTION
Hello,

It has recently dawned on me that the GGX visibility term implemented in the glTF-Sample-Renderer as of now uses the *height-correlated* form of the Smith joint masking-shadowing function, instead of the alleged *separable* form in the spec.

I believe this would be a good revision if the intention is to maintain reasonable consistency between the sample implementation in the specification and the glTF-Sample-Renderer project.

Provided are links to the most up-to-date version of `glTF-Sample-Renderer/source/Renderer/shaders/brdf.glsl`, as well as the full expansions of both the *height-correlated* and *separable* forms from Heitz (2014).

Please let me know if you have any questions. Thank you.

* https://github.com/KhronosGroup/glTF-Sample-Renderer/blob/e6b052db89fb2adbaf31da4565a08265c96c2b9f/source/Renderer/shaders/brdf.glsl#L74
* https://observablehq.com/@n-a33/smith-joint-masking-shadowing-function