### PR TITLE
Change dependencies to dependentRequired for JSON schema draft 2020-12

### DIFF
--- a/specification/2.0/schema/accessor.schema.json
+++ b/specification/2.0/schema/accessor.schema.json
@@ -129,7 +129,7 @@
         "extensions": { },
         "extras": { }
     },
-    "dependencies": {
+    "dependentRequired": {
         "byteOffset": [ "bufferView" ]
     },
     "required": [ "componentType", "count", "type" ]

--- a/specification/2.0/schema/glTF.schema.json
+++ b/specification/2.0/schema/glTF.schema.json
@@ -149,7 +149,7 @@
         "extensions": { },
         "extras": { }
     },
-    "dependencies": {
+    "dependentRequired": {
         "scene": [ "scenes" ]
     },
     "required": [ "asset" ]

--- a/specification/2.0/schema/image.schema.json
+++ b/specification/2.0/schema/image.schema.json
@@ -35,7 +35,7 @@
         "extensions": { },
         "extras": { }
     },
-    "dependencies": {
+    "dependentRequired": {
         "bufferView": [ "mimeType" ]
     },
     "oneOf": [

--- a/specification/2.0/schema/material.schema.json
+++ b/specification/2.0/schema/material.schema.json
@@ -77,7 +77,7 @@
             "gltf_detailedDescription": "Specifies whether the material is double sided. When this value is false, back-face culling is enabled. When this value is true, back-face culling is disabled and double-sided lighting is enabled. The back-face **MUST** have its normals reversed before the lighting equation is evaluated."
         }
     },
-     "dependencies" : {
+    "dependentRequired" : {
         "alphaCutoff" : ["alphaMode"]
     }
 }

--- a/specification/2.0/schema/node.schema.json
+++ b/specification/2.0/schema/node.schema.json
@@ -83,7 +83,7 @@
         "extensions": { },
         "extras": { }
     },
-    "dependencies": {
+    "dependentRequired": {
         "weights": [ "mesh" ],
         "skin": [ "mesh" ]
     },


### PR DESCRIPTION
PR #2034 upgraded the glTF schemas to JSON schema draft 2020-12, but forgot to replace `"dependencies"` with `"dependentRequired"`, which is the name of the property in JSON schema draft 2020-12.

See here: https://json-schema.org/understanding-json-schema/reference/conditionals#dependentRequired