### PR TITLE
chore: Add Legal mandated AI block to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -36,6 +36,17 @@ file, and link to the full license text from link:LICENSE.adoc.
 == Contributor License Agreement
 
 When you propose a pull request on KhronosGroup/glTF you must execute the
-Khronos Mixed Repository Contributor License Agreement, to confirm you own
+link:https://cla-assistant.io/KhronosGroup/glTF[Khronos Mixed Repository Contributor License Agreement (CLA)], to confirm you own
 your work and are granting Khronos the necessary permissions to redistribute
 it under our licenses.
+
+== AI-Assisted Contributions
+
+By submitting a Contribution to this repository, you additionally represent
+that, to the extent any of Your Contributions were developed with the
+assistance of artificial intelligence tools or AI-generated code, You have
+exercised sufficient review, judgment, and creative direction over such tools
+and resulting material to reasonably consider it Your original creation, and
+You are not aware of any third-party license, intellectual property claim, or
+other restriction arising from such use that is associated with any part of
+Your Contribution or use thereof.


### PR DESCRIPTION
This commit adds an AI block to the CONTRIBUTING.adoc file, and a link to the CLA. 