### PR TITLE
Draft changes for External Assets and Unified File References in glTF 2.1

### DIFF
--- a/specification/2.1/Specification.adoc
+++ b/specification/2.1/Specification.adoc
@@ -752,7 +752,7 @@ The node hierarchy is defined using a node's `children` property, as in the foll
 
 The node named `Car` has four children. Each of those nodes could in turn have its own children, creating a hierarchy of nodes.
 
-Nodes **MAY** reference external assets. Nodes which contain an external reference **SHOULD NOT** include a camera or mesh. After loading the external asset file, implementations **SHOULD** connect the external asset to the parent file's node hierarchy by attaching all root nodes in the default scene as children.
+Nodes **MAY** reference external assets. After loading the external asset file, implementations **SHOULD** connect the external asset to the parent file's node hierarchy by attaching all root nodes in the default scene as children.
 
 [[transformations]]
 === Transformations

--- a/specification/2.1/Specification.adoc
+++ b/specification/2.1/Specification.adoc
@@ -752,6 +752,7 @@ The node hierarchy is defined using a node's `children` property, as in the foll
 
 The node named `Car` has four children. Each of those nodes could in turn have its own children, creating a hierarchy of nodes.
 
+Nodes **MAY** reference external assets. Nodes which contain an external reference **SHOULD NOT** include a camera or mesh. After loading the external asset file, implementations **SHOULD** connect the external asset to the parent file's node hierarchy by attaching all root nodes in the default scene as children.
 
 [[transformations]]
 === Transformations
@@ -1083,7 +1084,7 @@ On top of that, a sparse accessor includes a `sparse` JSON object describing the
 
 - `count`: number of displaced elements. This number **MUST NOT** be greater than the number of the base accessor elements.
 
-- `indices`: object describing the location and the component type of indices of values to be replaced. The indices **MUST** form a strictly increasing sequence. The indices **MUST NOT** be greater than or equal to the number of the base accessor elements. 
+- `indices`: object describing the location and the component type of indices of values to be replaced. The indices **MUST** form a strictly increasing sequence. The indices **MUST NOT** be greater than or equal to the number of the base accessor elements.
 
 - `values`: object describing the location of displaced elements corresponding to the indices referred from the `indices`.
 
@@ -2588,6 +2589,144 @@ See <<appendix-c-interpolation,Appendix C>> for additional information about int
 
 Skinned animation is achieved by animating the joints in the skin's joint hierarchy.
 
+[[file-references]]
+== Unified file references
+
+Files **MAY** be added to a top-level `files` array. The file's data **MAY** be stored externally and referenced by a `uri` or stored as binary in a buffer and referenced by `bufferView` index.
+
+Each file object **MUST** define a `mimeType` property, which may be any media type that matches the file's contents. Cyclical references between files are strictly prohibited.
+
+Files with a `mimeType` of `model/gltf+json` or `model/gltf-binary` **MAY** define a list of `aliases` that can be used to match and redirect a `uri` inside of the referred file. Any `uri` in the referenced file that matches the value `alias` exactly **SHOULD** use the associated `file` instead. This allows for efficient packing of resources shared across several referred files, or overriding inner data. Aliases are not inherited from the parent asset. Extensions may add additional mime types that can define `aliases`.
+
+[NOTE]
+.Implementation Note
+====
+If the same `uri` is used within multiple file references, implementations should not assume that the files are identical without validation.
+====
+
+[source,json]
+----
+{
+    "files": [
+        {
+            "uri": "path-to-a.gltf",
+            "mimeType": "model/gltf+json",
+            "aliases": [
+                {
+                    "alias": "path-to-a.bin",
+                    "file": 1
+                }
+            ]
+        },
+        {
+            "uri": "path-to-a.bin",
+            "mimeType": "application/gltf-buffer"
+        },
+        {
+            "uri": "https://example.org/path-to-a.glb",
+            "mimeType": "model/gltf-binary"
+        },
+        {
+            "bufferView": 0,
+            "mimeType": "model/gltf-binary"
+        }
+    ]
+}
+----
+
+[[external-assets]]
+== Referencing external assets
+
+glTF 2.1 defines the ability to compose multiple glTF files together, by referencing external glTF files from another glTF file. Any glTF file which references another glTF file as an external asset is called a complex scene. Complex scenes are defined using multiple components: file references to define where the data is stored and external asset definitions that define the properties of the asset node.
+
+External glTF assets **MAY** be added to a top-level `externalAssets` array. The external asset **MUST** contain a `file` property that refers to an object in the `files` array by index. Multiple objects in the `externalAssets` array may refer to the same `file`. All external assets **MUST** refer to files with the `"model/gltf-binary"` or `"model/gltf+json"` media types.
+
+[source,json]
+----
+{
+    "files": [
+        {
+            "uri": "path-to-a.gltf",
+            "mimeType": "model/gltf+json"
+        },
+        {
+            "uri": "path-to-a.bin",
+            "mimeType": "application/gltf-buffer"
+        },
+        {
+            "uri": "path-to-b.glb",
+            "mimeType": "model/gltf-binary"
+        },
+        {
+            "bufferView": 0
+            "mimeType": "model/gltf-binary"
+        }
+    ],
+    "externalAssets": [
+        {
+            "file": 0
+        },
+        {
+            "file": 2
+        },
+        {
+            "file": 3
+        }
+    ],
+}
+----
+
+[NOTE]
+.Implementation Note
+====
+When an embedded external asset is embedded via a <<data-uri,Data URI>> or a `bufferView`, any relative URIs it contains should resolve against the same filesystem root as the parent asset, unless the URI is remapped by an alias. _E.g._, If asset `A` embeds external asset `B`, and `B` references textures at the relative path `./textures/**`, those textures resolve relative to the location of `A`, making them accessible to both `A` and `B`.
+====
+
+Nodes *MAY* contain an `externalAsset` property that refers to an external glTF asset in the `externalAssets` array by index.
+
+[NOTE]
+.Implementation Note
+====
+When the same external asset is referenced by multiple nodes, implementations should load independent copies of the external asset. Each copy of the external asset should copy any glTF JSON and hierarchy, but may share buffer data between the copies. This balances compatibility with existing features and extensions while also minimizing the amount of copied data.
+====
+
+Once loaded, the root nodes defined by the external asset's default scene and those root nodes full node hierarchies *SHOULD* be treated as being attached as a child to the node containing the `externalAsset` reference.
+
+[source,json]
+----
+{
+    "nodes": [
+        {
+            "name": "RootNode",
+            "translation": [0, 0, 0],
+            "children": [1, 2]
+        },
+        {
+            "translation": [2, 0, 20],
+            "externalAsset": 0
+        },
+        {
+            "translation": [0, 0, 0],
+            "children": [3],
+            "externalAsset": 1
+        },
+        {
+            "translation": [0, 1, 1],
+            "externalAsset": 2
+        }
+    ]
+}
+----
+
+This instantiates the external asset as this node in the scene hierarchy, such that the root of the file becomes this node. The root nodes in the default `scene` of the nested glTF become children of this external asset node. Assets that have no `scenes` array or lack a default `scene` are valid but have nothing to attach to the node hierarchy and should be treated as such. Extensions or future spec versions **MAY** alter this behavior.
+
+[NOTE]
+.Implementation Note
+====
+Nodes may contain both an `externalAsset` and other `children`. For consistency between implementations, it is recommended that the root node(s) of the external asset are attached after the other children of the node.
+====
+
+See <<appendix-d-external-asset-diagrams, Appendix D>> for detailed diagrams outlining a sample structure and the expected scene graph.
 
 [[specifying-extensions]]
 == Specifying Extensions
@@ -3374,3 +3513,132 @@ This can be achieved by ensuring that stem:[v_k != -v_{k+1}] for all keyframes.
 ====
 
 The first in-tangent stem:[a_1] and last out-tangent stem:[b_n] **SHOULD** be zeros as they are not used in the spline calculations.
+
+[appendix]
+[[appendix-d-external-asset-diagrams]]
+= External Asset Scene Graph Diagrams
+
+== Overview
+
+This section provides informative example JSON and diagrams of External Assets to demonstrate the expected node hierarchy from implementations. For full normative details, see the sections on <<nodes-and-hierarchy>>, <<file-references>>, and <<external-assets>>.
+
+The following three sections represent the same asset and structure. The first two sections are diagrams to visually demonstrate hierarchy, and the third section is the equivalent glTF JSON for the assets represented within the diagrams.
+
+== Expected Scene Graph
+
+.Expected Scene Graph
+image::figures/external-assets-expected-scene-graph.svg[pdfwidth=100%,align=left]
+
+== glTF Structure & Hierarchy
+
+.glTF Structure & Hierarchy
+image::figures/external-assets-hierarchy.svg[pdfwidth=100%,align=left]
+
+== JSON
+
+=== Asset A
+
+[source,json]
+----
+{
+    "asset": {
+        "version": "2.1"
+    },
+    "scene": 0,
+    "scenes": [ { "nodes": [0] } ],
+    "files": [
+        {
+            "name": "File Ref. to Asset B",
+            "uri": "asset-b.glb",
+            "mimeType": "model/gltf-binary"
+        },
+        {
+            "name": "File Ref. to Asset C",
+            "uri": "asset-c.glb",
+            "mimeType": "model/gltf-binary"
+        },
+    ],
+    "externalAssets": [
+        {
+            "name": "External Asset 1",
+            "file": 0
+        },
+        {
+            "name": "External Asset 2",
+            "file": 1
+        }
+    ],
+    "nodes": [
+        {
+            "name": "Root Node A1",
+            "children": [ 1, 2, 3 ]
+        },
+        {
+            "name": "Node A1",
+            "externalAsset": 0
+        },
+        {
+            "name": "Node A2",
+            "externalAsset": 0
+        },
+        {
+            "name": "Node A3",
+            "externalAsset": 1
+        }
+    ]
+}
+----
+
+=== Asset B
+
+[source,json]
+----
+{
+    "asset": {
+        "version": "2.1"
+    },
+    "scene": 0,
+    "scenes": [ { "nodes": [0] } ],
+    "nodes": [
+        {
+            "name": "Root Node B1",
+            "children": [ 1, 2 ]
+        },
+        {
+            "name": "Node B1",
+        },
+        {
+            "name": "Node B2",
+        }
+    ]
+}
+----
+
+=== Asset C
+
+[source,json]
+----
+{
+    "asset": {
+        "version": "2.1"
+    },
+    "scene": 0,
+    "scenes": [ { "nodes": [0, 1] } ],
+    "nodes": [
+        {
+            "name": "Root Node C1",
+            "children": [ 2 ]
+        },
+        {
+            "name": "Root Node C2",
+            "children": [ 3 ]
+        },
+        {
+            "name": "Node C1",
+        },
+        {
+            "name": "Node C2",
+        }
+    ]
+}
+----

--- a/specification/2.1/Specification.adoc
+++ b/specification/2.1/Specification.adoc
@@ -537,7 +537,7 @@ This is typically achieved with algorithms like Grisu2 used by common JSON libra
 [[uris]]
 == URIs
 
-glTF assets use <<uri,URIs>> or <<iri,IRIs>> to reference buffers and image resources. Assets **MAY** contain at least these two URI types:
+glTF assets use <<uri,URIs>> or <<iri,IRIs>> to reference buffers, files, and image resources. Assets **MAY** contain at least these two URI types:
 
 - **Data URIs** that embed binary resources in the glTF JSON as defined by the <<data-uri,RFC 2397>>. The Data URI's `mediatype` field **MUST** match the encoded content.
 +

--- a/specification/2.1/Specification.adoc
+++ b/specification/2.1/Specification.adoc
@@ -752,7 +752,7 @@ The node hierarchy is defined using a node's `children` property, as in the foll
 
 The node named `Car` has four children. Each of those nodes could in turn have its own children, creating a hierarchy of nodes.
 
-Nodes **MAY** reference external assets. After loading the external asset file, implementations **SHOULD** connect the external asset to the parent file's node hierarchy by attaching all root nodes in the default scene as children. See the section on <<external-assets,referencing External Assets>> for further details.
+Nodes **MAY** reference external assets. After loading the external asset file, the root nodes in the external asset's default scene are treated as children of the referencing node. See the section on <<external-assets,referencing External Assets>> for further details.
 
 [[transformations]]
 === Transformations
@@ -2687,10 +2687,10 @@ Nodes *MAY* contain an `externalAsset` property that refers to an external glTF 
 [NOTE]
 .Implementation Note
 ====
-When the same external asset is referenced by multiple nodes, implementations should load independent copies of the external asset. Each copy of the external asset should copy any glTF JSON and hierarchy, but may share buffer data between the copies. This balances compatibility with existing features and extensions while also minimizing the amount of copied data.
+When the same external asset is referenced by multiple nodes, it is recommended that all related JSON objects except for `buffer` objects are cloned. The `buffer` reference may be retained to allow sharing binary data between external asset instances. This maximizes compatibility with existing extensions while also minimizing the amount of duplicated binary data. Future specification versions or extensions may introduce mechanisms to allow better sharing of object definitions across external asset instances.
 ====
 
-Once loaded, the root nodes defined by the external asset's default scene and those root nodes full node hierarchies *SHOULD* be treated as being attached as a child to the node containing the `externalAsset` reference.
+Once loaded, the root nodes defined by the external asset's default scene and their node hierarchies are treated as being attached as children to the node containing the `externalAsset` reference.
 
 [source,json]
 ----

--- a/specification/2.1/Specification.adoc
+++ b/specification/2.1/Specification.adoc
@@ -752,7 +752,7 @@ The node hierarchy is defined using a node's `children` property, as in the foll
 
 The node named `Car` has four children. Each of those nodes could in turn have its own children, creating a hierarchy of nodes.
 
-Nodes **MAY** reference external assets. After loading the external asset file, implementations **SHOULD** connect the external asset to the parent file's node hierarchy by attaching all root nodes in the default scene as children.
+Nodes **MAY** reference external assets. After loading the external asset file, implementations **SHOULD** connect the external asset to the parent file's node hierarchy by attaching all root nodes in the default scene as children. See the section on <<external-assets,referencing External Assets>> for further details.
 
 [[transformations]]
 === Transformations
@@ -2590,13 +2590,13 @@ See <<appendix-c-interpolation,Appendix C>> for additional information about int
 Skinned animation is achieved by animating the joints in the skin's joint hierarchy.
 
 [[file-references]]
-== Unified file references
+== File references
 
-Files **MAY** be added to a top-level `files` array. The file's data **MAY** be stored externally and referenced by a `uri` or stored as binary in a buffer and referenced by `bufferView` index.
+Files references **MAY** be added to a top-level `files` array. The file's data **MAY** be stored externally and referenced by a `uri` or stored as binary in a buffer and referenced by `bufferView` index.
 
-Each file object **MUST** define a `mimeType` property, which may be any media type that matches the file's contents. Cyclical references between files are strictly prohibited.
+Each file object **MUST** define a `mimeType` property, which may be any media type that matches the file's contents. 
 
-Files with a `mimeType` of `model/gltf+json` or `model/gltf-binary` **MAY** define a list of `aliases` that can be used to match and redirect a `uri` inside of the referred file. Any `uri` in the referenced file that matches the value `alias` exactly **SHOULD** use the associated `file` instead. This allows for efficient packing of resources shared across several referred files, or overriding inner data. Aliases are not inherited from the parent asset. Extensions may add additional mime types that can define `aliases`.
+Files with a `mimeType` of `model/gltf+json` or `model/gltf-binary` **MAY** define a list of `aliases` that can be used to match and redirect a `uri` inside of the referred file. Any `uri` in the referenced file that matches the value `alias` exactly **SHOULD** use the associated `file` instead. This allows for efficient packing of resources shared across several referenced files, or overriding inner data. Aliases are not inherited from the parent asset. Extensions may add additional mime types that can define `aliases`.
 
 [NOTE]
 .Implementation Note
@@ -2637,9 +2637,9 @@ If the same `uri` is used within multiple file references, implementations shoul
 [[external-assets]]
 == Referencing external assets
 
-glTF 2.1 defines the ability to compose multiple glTF files together, by referencing external glTF files from another glTF file. Any glTF file which references another glTF file as an external asset is called a complex scene. Complex scenes are defined using multiple components: file references to define where the data is stored and external asset definitions that define the properties of the asset node.
+glTF 2.1 defines the ability to compose complex scenes. A complex scene is one or more glTF assets including a scene from another glTF asset by referencing that glTF as an external asset. Complex scenes are defined using multiple components: file references to define where the data is stored and external asset definitions that define the scene from the referenced glTF asset to include.
 
-External glTF assets **MAY** be added to a top-level `externalAssets` array. The external asset **MUST** contain a `file` property that refers to an object in the `files` array by index. Multiple objects in the `externalAssets` array may refer to the same `file`. All external assets **MUST** refer to files with the `"model/gltf-binary"` or `"model/gltf+json"` media types.
+External glTF assets **MAY** be added to a top-level `externalAssets` array. The external asset **MUST** contain a `file` property that refers to an object in the `files` array by index. Multiple objects in the `externalAssets` array may refer to the same `file`. All external assets **MUST** refer to files with the `"model/gltf-binary"` or `"model/gltf+json"` media types. Cyclical references between external assets are strictly prohibited. 
 
 [source,json]
 ----
@@ -2658,7 +2658,7 @@ External glTF assets **MAY** be added to a top-level `externalAssets` array. The
             "mimeType": "model/gltf-binary"
         },
         {
-            "bufferView": 0
+            "bufferView": 0,
             "mimeType": "model/gltf-binary"
         }
     ],
@@ -2718,7 +2718,7 @@ Once loaded, the root nodes defined by the external asset's default scene and th
 }
 ----
 
-This instantiates the external asset as this node in the scene hierarchy, such that the root of the file becomes this node. The root nodes in the default `scene` of the nested glTF become children of this external asset node. Assets that have no `scenes` array or lack a default `scene` are valid but have nothing to attach to the node hierarchy and should be treated as such. Extensions or future spec versions **MAY** alter this behavior.
+This instantiates the external asset as this node in the scene hierarchy. The root nodes in the default `scene` of the nested glTF become children of this external asset node. Assets that have no `scenes` array or lack a default `scene` are valid but have nothing to attach to the node hierarchy and should be treated as such. Extensions or future spec versions **MAY** alter this behavior.
 
 [NOTE]
 .Implementation Note

--- a/specification/2.1/schema/externalAsset.schema.json
+++ b/specification/2.1/schema/externalAsset.schema.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "externalAsset.schema.json",
+    "title": "External Asset",
+    "type": "object",
+    "description": "An external asset referenced by a node.",
+    "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
+    "properties": {
+        "file": {
+            "$ref": "glTFid.schema.json",
+            "description": "The index of the file reference used for this external asset.",
+            "gltf_detailedDescription": "The index of the file reference used for this external asset."
+        }
+    },
+    "required": [ "file" ]
+}

--- a/specification/2.1/schema/externalAsset.schema.json
+++ b/specification/2.1/schema/externalAsset.schema.json
@@ -3,13 +3,13 @@
     "$id": "externalAsset.schema.json",
     "title": "External Asset",
     "type": "object",
-    "description": "An external asset referenced by a node.",
+    "description": "An external asset that references a file in the `files` array and may be instantiated by glTF scene nodes.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "file": {
             "$ref": "glTFid.schema.json",
             "description": "The index of the file reference used for this external asset.",
-            "gltf_detailedDescription": "The index of the file reference used for this external asset."
+            "gltf_detailedDescription": "The index of the file reference in the top-level `files` array used for this external asset."
         }
     },
     "required": [ "file" ]

--- a/specification/2.1/schema/externalAsset.schema.json
+++ b/specification/2.1/schema/externalAsset.schema.json
@@ -3,7 +3,7 @@
     "$id": "externalAsset.schema.json",
     "title": "External Asset",
     "type": "object",
-    "description": "An external asset that references a file in the `files` array and may be instantiated by glTF scene nodes.",
+    "description": "An external asset that references a file in the `files` array and may be instantiated by any node.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "file": {

--- a/specification/2.1/schema/file.alias.schema.json
+++ b/specification/2.1/schema/file.alias.schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "file.alias.schema.json",
+    "title": "Alias to External File",
+    "type": "object",
+    "description": "Used to alias files referenced within an external file to other paths by the parent.",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "alias": {
+            "type": "string",
+            "description": "String alias matched against an inner path."
+        },
+        "file": {
+            "$ref": "glTFid.schema.json",
+            "description": "The index of the file to the files array."
+        }
+    },
+    "required": [ "alias", "file" ]
+}

--- a/specification/2.1/schema/file.alias.schema.json
+++ b/specification/2.1/schema/file.alias.schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "file.alias.schema.json",
-    "title": "Alias to External File",
+    "title": "File Reference to External File Remap Alias",
     "type": "object",
     "description": "Used to alias files referenced within an external file to other paths by the parent.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
@@ -12,7 +12,7 @@
         },
         "file": {
             "$ref": "glTFid.schema.json",
-            "description": "The index of the file to the files array."
+            "description": "The index of the file in the files array."
         }
     },
     "required": [ "alias", "file" ]

--- a/specification/2.1/schema/file.schema.json
+++ b/specification/2.1/schema/file.schema.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "file.schema.json",
+    "title": "File Reference to External File",
+    "type": "object",
+    "description": "A file reference to an external file.",
+    "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
+    "properties": {
+        "uri": {
+            "type": "string",
+            "description": "The URI (or IRI) of the external file.",
+            "format": "iri-reference",
+            "gltf_detailedDescription": "The URI (or IRI) of the external file.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.",
+            "gltf_uriType": "external-file"
+        },
+        "mimeType": {
+            "type": "string",
+            "description": "The MIME type of the external file.",
+            "gltf_detailedDescription": "The MIME type of the external file.",
+            "anyOf": [
+                {
+                    "const": "model/gltf+json"
+                },
+                {
+                    "const": "model/gltf-binary"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "bufferView": {
+            "$ref": "glTFid.schema.json",
+            "description": "The index of the bufferView that contains the external file.",
+            "gltf_detailedDescription": "The index of the bufferView that contains the external file. This field **MUST NOT** be defined when `uri` is defined."
+        },
+        "aliases": {
+            "type": "array",
+            "description": "An array of aliases used for files within this external file. Aliases allow overriding inner file URIs.",
+            "items": {
+                "$ref": "file.alias.schema.json"
+            }
+        }
+    },
+    "required": [
+        "mimeType"
+    ],
+    "oneOf": [
+        { "required": [ "uri" ] },
+        { "required": [ "bufferView" ] }
+    ]
+}

--- a/specification/2.1/schema/file.schema.json
+++ b/specification/2.1/schema/file.schema.json
@@ -3,20 +3,25 @@
     "$id": "file.schema.json",
     "title": "File Reference to External File",
     "type": "object",
-    "description": "A file reference to an external file.",
+    "description": "A file reference to an external file. Files **MAY** be referenced by an URI (or IRI) or a buffer view index.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
-        "uri": {
-            "type": "string",
-            "description": "The URI (or IRI) of the external file.",
-            "format": "iri-reference",
-            "gltf_detailedDescription": "The URI (or IRI) of the external file.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.",
-            "gltf_uriType": "external-file"
+        "aliases": {
+            "type": "array",
+            "description": "An array of aliases used for files within this external file. Aliases allow overriding inner file URIs.",
+            "items": {
+                "$ref": "file.alias.schema.json"
+            }
+        },
+        "bufferView": {
+            "$ref": "glTFid.schema.json",
+            "description": "The index of the bufferView that contains the file data.",
+            "gltf_detailedDescription": "The index of the bufferView that contains the file data. This field **MUST NOT** be defined when `uri` is defined."
         },
         "mimeType": {
             "type": "string",
-            "description": "The MIME type of the external file.",
-            "gltf_detailedDescription": "The MIME type of the external file.",
+            "description": "The media type or MIME type of the external file.",
+            "gltf_detailedDescription": "The media type or MIME type of the external file. This field is required and **MUST** always be defined.",
             "anyOf": [
                 {
                     "const": "model/gltf+json"
@@ -29,17 +34,12 @@
                 }
             ]
         },
-        "bufferView": {
-            "$ref": "glTFid.schema.json",
-            "description": "The index of the bufferView that contains the external file.",
-            "gltf_detailedDescription": "The index of the bufferView that contains the external file. This field **MUST NOT** be defined when `uri` is defined."
-        },
-        "aliases": {
-            "type": "array",
-            "description": "An array of aliases used for files within this external file. Aliases allow overriding inner file URIs.",
-            "items": {
-                "$ref": "file.alias.schema.json"
-            }
+        "uri": {
+            "type": "string",
+            "description": "The URI (or IRI) of the external file.",
+            "format": "iri-reference",
+            "gltf_detailedDescription": "The URI (or IRI) of the external file.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.",
+            "gltf_uriType": "external-file"
         }
     },
     "required": [

--- a/specification/2.1/schema/file.schema.json
+++ b/specification/2.1/schema/file.schema.json
@@ -1,9 +1,9 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "file.schema.json",
-    "title": "File Reference to External File",
+    "title": "File Reference",
     "type": "object",
-    "description": "A file reference to an external file. Files **MAY** be referenced by an URI (or IRI) or a buffer view index.",
+    "description": "A reference to an external file. Files **MAY** be referenced by an URI (or IRI) or a buffer view index.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "aliases": {

--- a/specification/2.1/schema/file.schema.json
+++ b/specification/2.1/schema/file.schema.json
@@ -3,7 +3,7 @@
     "$id": "file.schema.json",
     "title": "File Reference",
     "type": "object",
-    "description": "A reference to an external file. Files **MAY** be referenced by an URI (or IRI) or a buffer view index.",
+    "description": "A reference to an external file. Files **MAY** be referenced by a URI (or IRI) or a buffer view index.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
     "properties": {
         "aliases": {

--- a/specification/2.1/schema/glTF.schema.json
+++ b/specification/2.1/schema/glTF.schema.json
@@ -72,6 +72,24 @@
             "minItems": 1,
             "gltf_detailedDescription": "An array of cameras.  A camera defines a projection matrix."
         },
+        "externalAssets": {
+            "type": "array",
+            "description": "An array of external assets.",
+            "items": {
+                "$ref": "externalAsset.schema.json"
+            },
+            "minItems": 1,
+            "gltf_detailedDescription": "An array of external assets.  An external asset is a node that references an external file."
+        },
+        "files": {
+            "type": "array",
+            "description": "An array of file references.",
+            "items": {
+                "$ref": "file.schema.json"
+            },
+            "minItems": 1,
+            "gltf_detailedDescription": "An array of file references.  A file reference is a pointer to an external file."
+        },
         "images": {
             "type": "array",
             "description": "An array of images.",

--- a/specification/2.1/schema/glTF.schema.json
+++ b/specification/2.1/schema/glTF.schema.json
@@ -79,7 +79,7 @@
                 "$ref": "externalAsset.schema.json"
             },
             "minItems": 1,
-            "gltf_detailedDescription": "An array of external assets.  An external asset is a node that references an external file."
+            "gltf_detailedDescription": "An array of external assets.  An external asset references a file in the `files` array and may be instantiated by glTF scene nodes."
         },
         "files": {
             "type": "array",

--- a/specification/2.1/schema/glTF.schema.json
+++ b/specification/2.1/schema/glTF.schema.json
@@ -79,7 +79,7 @@
                 "$ref": "externalAsset.schema.json"
             },
             "minItems": 1,
-            "gltf_detailedDescription": "An array of external assets.  An external asset references a file in the `files` array and may be instantiated by glTF scene nodes."
+            "gltf_detailedDescription": "An array of external assets.  An external asset references a file in the `files` array and may be instantiated by any node."
         },
         "files": {
             "type": "array",

--- a/specification/2.1/schema/node.schema.json
+++ b/specification/2.1/schema/node.schema.json
@@ -37,7 +37,11 @@
         },
         "mesh": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the mesh in this node."
+            "description": "The index of the mesh in this node. Cannot be used together with `externalAsset`."
+        },
+        "externalAsset": {
+            "$ref": "glTFid.schema.json",
+            "description": "The index of the external asset in this node. Cannot be used together with `mesh`."
         },
         "rotation": {
             "type": "array",

--- a/specification/2.1/schema/node.schema.json
+++ b/specification/2.1/schema/node.schema.json
@@ -37,7 +37,7 @@
         },
         "mesh": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the mesh in this node. Cannot be used together with `externalAsset`."
+            "description": "The index of the mesh in this node."
         },
         "externalAsset": {
             "$ref": "glTFid.schema.json",


### PR DESCRIPTION
This PR contains the draft changes for External Assets and Unified File References in glTF 2.1. This PR currently points towards the `draft-2.1` branch and should be safe to merge to that branch.

### Relevant Issues:

- https://github.com/KhronosGroup/glTF/issues/2586
- https://github.com/KhronosGroup/glTF/issues/2590

### Summary from Copilot:

**New external asset referencing system:**

* Added top-level `files` and `externalAssets` arrays to the glTF schema, enabling assets to reference external files and compose complex scenes from multiple glTF files. (`glTF.schema.json`, `file.schema.json`, `externalAsset.schema.json`, [[1]](diffhunk://#diff-49c121052eab7e3b5c7961ebdd28551d49efeb1b1eff44e78a592be21b463cabR75-R92) [[2]](diffhunk://#diff-8095630125a1c2d1ae148319ca4bb3cf65e0db151999054569c4732d86f19552R1-R52) [[3]](diffhunk://#diff-3c4ccc786add97902a57f52e2b5f532a004b2dbcff217dfaa5427b9a032d3bbaR1-R16)
* Nodes can now reference external assets via an `externalAsset` property, which cannot be used together with `mesh`. (`node.schema.json`, [specification/2.1/schema/node.schema.jsonL40-R44](diffhunk://#diff-b8cd660fe1441f70434b05a4b5fabafd72415b2dab8deff8c474bfd06a02efe0L40-R44))
* Introduced the concept of file aliases, allowing URIs within external assets to be remapped for efficient resource sharing or overriding. (`file.schema.json`, `file.alias.schema.json`, [[1]](diffhunk://#diff-8095630125a1c2d1ae148319ca4bb3cf65e0db151999054569c4732d86f19552R1-R52) [[2]](diffhunk://#diff-15b5eeeb206e352419208331a1760cc3d1474ed8a968e10c94404bae890d4b2dR1-R19)

**Specification and documentation updates:**

* Updated the specification to describe the new unified file reference system, external asset referencing, and aliasing mechanism, including normative requirements and implementation notes. (`Specification.adoc`, [[1]](diffhunk://#diff-4f9c15fb8bab9b0b7fab6bbd3ed60dc99409bf687a574a0f77b8156473aef95fR2592-R2729) [[2]](diffhunk://#diff-4f9c15fb8bab9b0b7fab6bbd3ed60dc99409bf687a574a0f77b8156473aef95fR755)
* Added a new appendix with diagrams and example JSON to illustrate the expected scene graph and asset hierarchy when using external assets. (`Specification.adoc`, [specification/2.1/Specification.adocR3516-R3644](diffhunk://#diff-4f9c15fb8bab9b0b7fab6bbd3ed60dc99409bf687a574a0f77b8156473aef95fR3516-R3644))