### PR TITLE
Draft changes for Thumbnails in glTF 2.1

### DIFF
--- a/specification/2.1/Specification.adoc
+++ b/specification/2.1/Specification.adoc
@@ -600,7 +600,9 @@ image::figures/objects.svg[pdfwidth=6in,align=left]
 [[asset]]
 == Asset
 
-Each glTF asset **MUST** have an `asset` property. The `asset` object **MUST** contain a `version` property that specifies the target glTF version of the asset. Additionally, an optional `minVersion` property **MAY** be used to specify the minimum glTF version support required to load the asset. The `minVersion` property allows asset creators to specify a minimum version that a client implementation **MUST** support in order to load the asset. This is very similar to the `extensionsRequired` concept described in <<specifying-extensions>>, where an asset **SHOULD NOT** be loaded if the client does not support the specified extension. Additional metadata **MAY** be stored in optional properties such as `generator` or `copyright`.  For example,
+Each glTF asset **MUST** have an `asset` property. The `asset` object **MUST** contain a `version` property that specifies the target glTF version of the asset. Additionally, an optional `minVersion` property **MAY** be used to specify the minimum glTF version support required to load the asset. The `minVersion` property allows asset creators to specify a minimum version that a client implementation **MUST** support in order to load the asset. This is very similar to the `extensionsRequired` concept described in <<specifying-extensions>>, where an asset **SHOULD NOT** be loaded if the client does not support the specified extension.
+
+Additional metadata **MAY** be stored in optional properties such as `generator`, `copyright`, and/or `thumbnail`. For example:
 
 [source,json]
 ----
@@ -608,7 +610,8 @@ Each glTF asset **MUST** have an `asset` property. The `asset` object **MUST** c
     "asset": {
         "version": "2.1",
         "generator": "collada2gltf@f356b99aef8868f74877c7ca545f2cd206b9d3b7",
-        "copyright": "2017 (c) Khronos Group"
+        "copyright": "2026 (c) Khronos Group",
+        "thumbnail": 0
     }
 }
 ----

--- a/specification/2.1/schema/asset.schema.json
+++ b/specification/2.1/schema/asset.schema.json
@@ -14,6 +14,10 @@
             "type": "string",
             "description": "Tool that generated this glTF model.  Useful for debugging."
         },
+        "thumbnail": {
+            "allOf" : [ { "$ref" : "glTFid.schema.json" } ],
+            "description": "The index of the image in the `images` array to use as a thumbnail for this asset. The image **SHOULD** be a common, widely-supported format, but **MAY** have any media type."
+        },
         "version": {
             "type": "string",
             "description": "The glTF version in the form of `<major>.<minor>` that this asset targets.",


### PR DESCRIPTION
This PR contains the draft changes for the thumbnails feature in glTF 2.1. This PR currently points towards the `draft-2.1` branch and should be safe to merge to that branch.

This pull request only includes a JSON property. Changes to the binary format to enable a dedicated thumbnail chunk are up for discussion in the issue, but out-of-scope for this pull request.

### Relevant Issues:

- https://github.com/KhronosGroup/glTF/issues/2593

### Summary of changes:

A new `"thumbnail"` property to has been added to the glTF asset schema, and referenced in the specification text.

The JSON property contains this description:

> The index of the image in the `images` array to use as a thumbnail for this asset. The image SHOULD be a common widely-supported format, but MAY have any media type.