### PR TITLE
Draft changes for Multiple Scenes Deprecation in glTF 2.1

### DIFF
--- a/specification/2.1/Specification.adoc
+++ b/specification/2.1/Specification.adoc
@@ -688,6 +688,8 @@ glTF 2.1 assets **MAY** contain zero or more _scenes_, the set of visual objects
 
 An additional root-level property, `scene` (note singular), identifies which of the scenes in the array **SHOULD** be displayed at load time. When `scene` is undefined, client implementations **MAY** delay rendering until a particular scene is requested.
 
+As of glTF 2.1, the ability to define more than one scene is deprecated. The `scenes` array **SHOULD** contain at most one scene, and if the `scene` property is defined, it **SHOULD** be set to `0`. When importing glTF 2.x assets, client implementations **SHOULD** use the `scene` property. When exporting glTF 2.x assets, client implementations **SHOULD NOT** include more than one scene in the `scenes` array or set the `scene` property to a value other than `0`.
+
 A glTF asset that does not contain any scenes **SHOULD** be treated as a library of individual entities such as materials or meshes.
 
 The following example defines a glTF asset with a single scene that contains a single node.


### PR DESCRIPTION
This PR contains the draft changes for the deprecation of the ability to have multiple scenes in glTF 2.1. This PR currently points towards the `draft-2.1` branch and should be safe to merge to that branch.

The deprecation is done via the addition of a new paragraph which describes the deprecation. We generally don't prescribe how implementations need to import or export, but in this case, this is the best way to phrase it.

### Relevant Issues:

- https://github.com/KhronosGroup/glTF/issues/2591

### Summary of changes:

The specification text contains this:

> As of glTF 2.1, the ability to define more than one scene is deprecated. The `scenes` array **SHOULD** contain at most one scene, and if the `scene` property is defined, it **SHOULD** be set to `0`. Client implementations **SHOULD** use the `scene` property when importing glTF 2.x assets, and **SHOULD NOT** generate more than one scene or a `scene` property set to a value other than `0` when exporting glTF 2.1 assets.