### PR TITLE
KHR_audio_graph

### DIFF
--- a/extensions/2.0/Khronos/KHR_audio_graph/README.md
+++ b/extensions/2.0/Khronos/KHR_audio_graph/README.md
@@ -27,7 +27,7 @@ This extension adds graph-based audio processing to `KHR_audio_emitter`. It allo
 - Document-level graph declarations.
 - Explicit graph bindings from `KHR_audio_emitter.sources[]` into graph inputs.
 - Explicit graph bindings from graph outputs to `KHR_audio_emitter.emitters[]`.
-- Graph-only procedural sources through oscillator nodes.
+- Procedural (oscillator) sources declared as `KHR_audio_emitter` source entries through this extension's source properties (section 8).
 - Optional encoding metadata and extended playback properties on `KHR_audio_emitter` audio and source objects.
 
 ### Motivation
@@ -75,7 +75,7 @@ Add `KHR_audio_graph` to `extensionsUsed`. The extension payload is declared und
 
 - Time values are expressed in seconds.
 - Angles are expressed in radians.
-- Gain values are linear, unitless multipliers in the range `[0, +inf)`.
+- Gain values are linear, unitless multipliers in the range `[0, +∞)`; a gain of `0` mutes the signal.
 - Frequencies are expressed in Hertz.
 - Connections use graph-local node indices with optional `input` and `output` port indices. Omitted ports refer to port `0`.
 - Graphs are directed acyclic graphs. Cycles are not permitted.
@@ -118,6 +118,14 @@ Graph inputs bind an existing `KHR_audio_emitter` source to a graph node input.
 }
 ```
 
+A source that should reach an emitter **with no processing applied** is bound
+through an identity node — e.g. a `gain` node with `gain: 1.0` — rather than
+a direct source-to-emitter binding: `inputs[]` and `outputs[]` always bind
+through a graph node index. If **none** of an emitter's sources require
+processing, the emitter should not be graph-bound at all — the base
+`KHR_audio_emitter` `emitter.sources[]` mechanism already plays it directly,
+and rule 12 only applies to emitters actually bound via `outputs[]`.
+
 ### 1.3 Graph Outputs
 
 Graph outputs bind a graph node output to a `KHR_audio_emitter` emitter.
@@ -136,6 +144,10 @@ Graph outputs bind a graph node output to a `KHR_audio_emitter` emitter.
     ]
 }
 ```
+
+`outputs[]` entries always bind a graph node; see the note in section 1.2 for
+the identity-node idiom and for when an emitter should not be graph-bound at
+all.
 
 ### 1.4 Connections
 
@@ -226,7 +238,6 @@ Each graph node is defined by a `kind` discriminator and a `params` object.
 
 | Kind | Category | I/O |
 |---|---|---|
-| `oscillator` | Source | `0 -> 1` |
 | `gain` | Processing | `1 -> 1` |
 | `delay` | Processing | `1 -> 1` |
 | `compressor` | Processing | `1 -> 1` |
@@ -244,46 +255,17 @@ Each graph node is defined by a `kind` discriminator and a `params` object.
 | `channelmixer` | Channel routing | `1 -> 1` |
 | `audiomixer` | Channel routing | `N -> 1` |
 
-## 3. Source Nodes
+## 3. Signal Sources
 
-Source nodes generate audio within the graph. `KHR_audio_graph` defines one graph-only source node: the oscillator.
-
-### 3.1 Oscillator Node
-
-The oscillator node generates a periodic waveform. It does not reference `KHR_audio_emitter.audio[]` or `KHR_audio_emitter.sources[]`.
-
-| Property | Type | Description | Required |
-|---|---|---|---|
-| **type** | `string` | Waveform: `sine`, `square`, `triangle`, `sawtooth`, `custom`. | Yes |
-| **frequency** | `number` | Frequency in Hertz. Default: `440`. | No |
-| **detune** | `number` | Detune in cents. Default: `0`. | No |
-| **pulseWidth** | `number` | Pulse width for `square` waveforms. Range: `[0, 1]`. Default: `0.5`. | No |
-| **periodicWave** | `object` | Custom waveform definition. **Required when `type` is `custom`**; ignored otherwise. | No |
-
-**Periodic wave object** (matching Web Audio / X3D 4.0 `PeriodicWave`): Fourier coefficients of the waveform.
-
-| Property | Type | Description | Required |
-|---|---|---|---|
-| **real** | `number[]` | Cosine (real) coefficients. Element 0 is DC and SHOULD be `0`. | Yes |
-| **imag** | `number[]` | Sine (imaginary) coefficients, same length as `real`. Element 0 is ignored. | Yes |
-
-Informative Web Audio mapping: implementations typically map this node to `OscillatorNode`, using `PeriodicWave` when `type` is `custom`, or when `type` is `square` and `pulseWidth` is not `0.5`.
-
-```json
-{
-    "name": "test-tone",
-    "nodes": [
-        { "kind": "oscillator", "params": { "type": "sine", "frequency": 440.0 } },
-        { "kind": "gain", "params": { "gain": 0.3 } }
-    ],
-    "connections": [
-        { "from": { "node": 0 }, "to": { "node": 1 } }
-    ],
-    "outputs": [
-        { "node": 1, "emitter": 0 }
-    ]
-}
-```
+Graphs contain no signal-originating node kinds: **every signal enters a graph
+through an `inputs[]` binding** of a `KHR_audio_emitter` source (section 1.2)
+and leaves through an `outputs[]` binding or terminal-node routing (sections
+1.3, 9). Clip sources reference `KHR_audio_emitter.audio[]`; procedural
+oscillator sources are sources without `audio` whose waveform is supplied by
+this extension (section 8). This gives every source type — clip or procedural
+— identical playback control (`autoplay`, gain, scheduling, and event-driven
+control via the glTF Object Model), matching the Web Audio API and X3D 4.0,
+where oscillators are scheduled sources exactly like buffer sources.
 
 ## 4. Processing Nodes
 
@@ -291,9 +273,12 @@ Processing nodes transform audio. Unless otherwise noted, they have one input an
 
 ### 4.1 Gain Node
 
+When **interpolation** is `custom`, **curve** MUST be present; it is ignored
+when **interpolation** is `linear`.
+
 | Property | Type | Description | Required |
 |---|---|---|---|
-| **gain** | `number` | Linear gain multiplier. Range `[0, +∞)`. Default: `1.0`. | No |
+| **gain** | `number` | Linear gain multiplier. Range `[0, +∞)` (0 mutes the signal). Default: `1.0`. | No |
 | **interpolation** | `string` | Gain transition curve: `linear` or `custom`. Default: `linear`. | No |
 | **duration** | `number` | Interpolation duration in seconds. Default: `0`. | No |
 | **curve** | `number[]` | Transition shape for `interpolation: "custom"`: gain factors in `[0, 1]` sampled uniformly over `duration`, scaled to the target gain, linearly interpolated between samples. **Required when `interpolation` is `custom`**; ignored otherwise. | No |
@@ -510,6 +495,52 @@ When `KHR_audio_graph` is present, entries in `KHR_audio_emitter.sources[]` MAY 
 
 > **Note on removed properties**: earlier drafts defined `playbackRate` (duplicating the base `KHR_audio_emitter` source property — the base definition is authoritative) and a mutable `state` string (play/pause/stop semantics). Playback *control* is a cross-cutting concern being resolved jointly with `KHR_audio_emitter` (#2137) and KHR_interactivity; see the discussion in KhronosGroup/glTF#2561.
 
+### Oscillator Sources
+
+A `KHR_audio_emitter` source **without an `audio` property** (the base
+specification's placeholder form) MAY declare a procedural waveform through
+this extension. Such a source behaves like any other source — it is bound
+into graphs via `inputs[]`, and `autoplay`, `gain`, `when`, and `duration`
+apply normally; starting playback (including a re-trigger) begins the
+waveform at phase zero. `loop`, `loopStart`, `loopEnd`, `offset`, and
+`playbackRate` are ignored for oscillator sources (a continuous waveform has
+no loop region; pitch is controlled by `frequency` and `detune`).
+
+When **type** is `custom`, **periodicWave** MUST be present; it is ignored
+for every other waveform.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **type** | `string` | Waveform: `sine`, `square`, `triangle`, `sawtooth`, `custom`. | Yes |
+| **frequency** | `number` | Frequency in Hertz. Default: `440`. | No |
+| **detune** | `number` | Detune in cents. Default: `0`. | No |
+| **pulseWidth** | `number` | Pulse width for `square` waveforms. Range: `[0, 1]`. Default: `0.5`. | No |
+| **periodicWave** | `object` | Custom waveform as Fourier coefficients (`real[]`, `imag[]`), matching Web Audio / X3D 4.0 `PeriodicWave`. Required when `type` is `custom`. | No |
+
+```json
+{
+    "extensions": {
+        "KHR_audio_emitter": {
+            "sources": [
+                {
+                    "name": "test-tone",
+                    "autoplay": true,
+                    "extensions": {
+                        "KHR_audio_graph": {
+                            "oscillator": { "type": "sine", "frequency": 440.0 },
+                            "when": 0.0,
+                            "duration": 0.5
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+A source MUST NOT declare both `audio` and `oscillator`.
+
 ## 9. Graph Rules
 
 The following rules are normative:
@@ -522,8 +553,8 @@ The following rules are normative:
 6. Multiple graphs may reference the same sources and emitters.
 7. Fan-out is allowed: one node output may feed multiple downstream inputs.
 8. Fan-in is allowed: one node input may receive multiple upstream outputs. Signals are summed.
-9. Splitter output count equals the channel count of its input.
-10. Channel merger input count equals the channel count of its output.
+9. A splitter's output count is the highest `from.output` port index referenced on it in `connections[]`, plus one. Output ports beyond the runtime channel count of the splitter's input produce silence.
+10. A channel merger's input count is the highest input port index referenced on it in `connections[]` or `inputs[]`, plus one. Its output has that many channels; unconnected input ports contribute silent channels. (To pad a stream to a larger explicit channel count, follow the merger with a `channelmixer` using `outputChannels` and `discrete` interpretation.)
 11. Audio mixer inputs must have the same channel count.
 12. If an emitter is bound through `outputs[]`, that emitter's base `sources` array is ignored.
 13. If `outputs[]` is omitted, the implementation routes terminal graph outputs to the global audio destination.
@@ -536,6 +567,9 @@ Recorded so review does not re-litigate them:
 - **No audio-rate parameter connections.** Node outputs carry audio only; connecting a signal to another node's *parameter* (Web Audio's LFO/envelope mechanism) is deliberately out of scope. The connection form `to: {node, param}` is reserved for a future extension; X3D 4.0 made the same omission.
 - **No envelopes or scheduled automation curves.** The gain node's `interpolation`/`duration`/`curve` smoothing is the sanctioned transition mechanism; scene-driven parameter animation uses the glTF Object Model (KHR_animation_pointer / KHR_interactivity).
 - **Graphs process source signals before emission.** There is no post-spatialization insert point in this extension; master-bus processing is provided by `KHR_audio_environment`'s listener-bus hook.
+- **No reverb or convolution node kind.** Reverberation is an environment concern, deliberately layered into `KHR_audio_environment`: per-environment reverb (parametric presets or impulse response) fed by per-emitter `reverbLevel` sends, with zone-based selection. A graph-level convolver would duplicate that machinery inside the signal path and re-couple the layers this architecture separates.
+- **No direct source-to-emitter binding.** `inputs[]`/`outputs[]` always bind through a graph node (rules 2–3); pass-through is expressed with an identity `gain: 1.0` node — and an emitter none of whose sources need processing belongs to the base layer, not the graph (see section 1.2).
+- **No signal-originating node kinds.** All sources — clip and oscillator alike — are `KHR_audio_emitter` sources entering via `inputs[]`, so playback control is uniform (section 3).
 
 ## 10. Bypass Behavior
 
@@ -548,11 +582,13 @@ Implementations may realize bypass either by rewiring the graph or by providing 
 
 ## 11. Web Audio API Mapping
 
-The following mappings are informative.
+The following mappings are informative. Oscillator *sources* (section 8) map
+to `OscillatorNode`, scheduled with `start(when)` / `stop(when + duration)`
+exactly like buffer sources; `custom` waveforms (and `pulseWidth` square
+approximations) use `PeriodicWave`.
 
 | Node Kind | Web Audio API | Notes |
 |---|---|---|
-| `oscillator` | `OscillatorNode` | `pulseWidth` for square waves may be approximated with `PeriodicWave`. |
 | `gain` | `GainNode` | `interpolation = linear` maps to `linearRampToValueAtTime`; `custom` to `setValueCurveAtTime`. |
 | `delay` | `DelayNode` | |
 | `compressor` | `DynamicsCompressorNode` | |
@@ -582,9 +618,8 @@ The following JSON pointers are defined for mutable properties and may be used w
 |---|---|---|
 | `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/gain` | `float` | Gain node gain |
 | `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/delayTime` | `float` | Delay time in seconds |
-| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/frequency` | `float` | Filter or oscillator frequency |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/frequency` | `float` | Filter frequency |
 | `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/qualityFactor` | `float` | Filter Q factor |
-| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/detune` | `float` | Oscillator detune |
 | `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/threshold` | `float` | Compressor threshold (dB) |
 | `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/knee` | `float` | Compressor knee (dB) |
 | `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/ratio` | `float` | Compressor ratio |
@@ -602,6 +637,8 @@ The following JSON pointers are defined for mutable properties and may be used w
 | `/extensions/KHR_audio_emitter/sources/{}/extensions/KHR_audio_graph/when` | `float` |
 | `/extensions/KHR_audio_emitter/sources/{}/extensions/KHR_audio_graph/duration` | `float` |
 | `/extensions/KHR_audio_emitter/sources/{}/extensions/KHR_audio_graph/priority` | `int` |
+| `/extensions/KHR_audio_emitter/sources/{}/extensions/KHR_audio_graph/oscillator/frequency` | `float` |
+| `/extensions/KHR_audio_emitter/sources/{}/extensions/KHR_audio_graph/oscillator/detune` | `float` |
 
 (`playbackRate` is animatable through the base `KHR_audio_emitter` pointer table; the former `state` pointer is removed pending the joint playback-control resolution — see section 8.)
 

--- a/extensions/2.0/Khronos/KHR_audio_graph/README.md
+++ b/extensions/2.0/Khronos/KHR_audio_graph/README.md
@@ -1,0 +1,665 @@
+# KHR_audio_graph
+
+## Contributors
+
+- Chintan Shah, Meta
+- Alexey Medvedev, Meta
+
+Copyright 2024 The Khronos Group Inc.
+See [Appendix](#appendix-full-khronos-copyright-statement) for full Khronos Copyright Statement.
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 spec.
+
+- Required: `KHR_audio_emitter`
+
+## Overview
+
+This extension adds graph-based audio processing to `KHR_audio_emitter`. It allows authors to route one or more `KHR_audio_emitter` sources through a directed acyclic graph (DAG) of processors before sending the result to one or more `KHR_audio_emitter` emitters or to the implementation's global audio destination.
+
+`KHR_audio_graph` does not replace `KHR_audio_emitter`. Scene and node attachment, base audio asset references, and emitter placement remain defined by `KHR_audio_emitter`. This extension adds:
+
+- Document-level graph declarations.
+- Explicit graph bindings from `KHR_audio_emitter.sources[]` into graph inputs.
+- Explicit graph bindings from graph outputs to `KHR_audio_emitter.emitters[]`.
+- Graph-only procedural sources through oscillator nodes.
+- Optional encoding metadata and extended playback properties on `KHR_audio_emitter` audio and source objects.
+
+### Motivation
+
+Modern audio engines use graph-based routing to mix, filter, spatialize, and procedurally generate sound. A flat `audio -> source -> emitter` model is sufficient for simple playback, but it cannot express:
+
+- Multi-source mixes.
+- Shared processing chains.
+- Equalization and filtering.
+- Delay and distortion effects.
+- Explicit channel routing.
+- Procedural graph-only sources.
+
+`KHR_audio_graph` preserves the simple `KHR_audio_emitter` workflow while adding those capabilities when needed.
+
+### Design Principles
+
+- Extends `KHR_audio_emitter`; it does not duplicate its document model.
+- Keeps scene attachment in `KHR_audio_emitter`, not in `KHR_audio_graph`.
+- Uses seconds for timing and radians for angles, matching glTF and `KHR_audio_emitter`.
+- Uses non-negative linear gain values, matching `KHR_audio_emitter`.
+- Represents routing explicitly through graph nodes and connections.
+
+## Extension Declaration
+
+Add `KHR_audio_graph` to `extensionsUsed`. The extension payload is declared under the document root `extensions` object.
+
+```json
+{
+    "extensionsUsed": ["KHR_audio_emitter", "KHR_audio_graph"],
+    "extensions": {
+        "KHR_audio_emitter": {
+            "audio": [...],
+            "sources": [...],
+            "emitters": [...]
+        },
+        "KHR_audio_graph": {
+            "graphs": [...]
+        }
+    }
+}
+```
+
+## Conventions
+
+- Time values are expressed in seconds.
+- Angles are expressed in radians.
+- Gain values are linear, unitless multipliers in the range `[0, +inf)`.
+- Frequencies are expressed in Hertz.
+- Connections use graph-local node indices with optional `input` and `output` port indices. Omitted ports refer to port `0`.
+- Graphs are directed acyclic graphs. Cycles are not permitted.
+
+## 1. Graphs
+
+Graphs are the top-level construct of this extension. Each graph contains nodes, edges between nodes, optional bindings from `KHR_audio_emitter` sources, and optional bindings to `KHR_audio_emitter` emitters.
+
+### 1.1 Graph Object
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **name** | `string` | Human-readable name for debugging. | No |
+| **nodes** | `node[]` | Array of graph nodes. | Yes |
+| **connections** | `connection[]` | Array of edges between node endpoints. | Yes |
+| **inputs** | `graphInput[]` | Bindings from `KHR_audio_emitter.sources[]` into graph node inputs. | No |
+| **outputs** | `graphOutput[]` | Bindings from graph node outputs into `KHR_audio_emitter.emitters[]`. | No |
+
+A valid graph must have at least one sink. A sink is either:
+
+- A graph output entry in `outputs[]`, or
+- A graph with no `outputs[]`, where the implementation routes terminal nodes to the global audio destination.
+
+### 1.2 Graph Inputs
+
+Graph inputs bind an existing `KHR_audio_emitter` source to a graph node input.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **source** | `integer` | Index into `KHR_audio_emitter.sources[]`. | Yes |
+| **node** | `integer` | Target node index in this graph. | Yes |
+| **input** | `integer` | Input port on the target node. Default: `0`. | No |
+
+```json
+{
+    "inputs": [
+        { "source": 0, "node": 0 },
+        { "source": 1, "node": 0, "input": 1 }
+    ]
+}
+```
+
+### 1.3 Graph Outputs
+
+Graph outputs bind a graph node output to a `KHR_audio_emitter` emitter.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **node** | `integer` | Source node index in this graph. | Yes |
+| **output** | `integer` | Output port on the source node. Default: `0`. | No |
+| **emitter** | `integer` | Index into `KHR_audio_emitter.emitters[]`. | Yes |
+
+```json
+{
+    "outputs": [
+        { "node": 2, "emitter": 0 },
+        { "node": 3, "output": 1, "emitter": 1 }
+    ]
+}
+```
+
+### 1.4 Connections
+
+Connections describe graph-internal edges.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **from** | `endpoint` | Upstream endpoint. | Yes |
+| **to** | `endpoint` | Downstream endpoint. | Yes |
+
+Endpoint objects use the following properties:
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **node** | `integer` | Graph-local node index. | Yes |
+| **output** | `integer` | Output port index. | No |
+| **input** | `integer` | Input port index. | No |
+
+```json
+{
+    "connections": [
+        { "from": { "node": 0 }, "to": { "node": 1 } },
+        { "from": { "node": 1, "output": 0 }, "to": { "node": 2, "input": 0 } }
+    ]
+}
+```
+
+### 1.5 Complete Graph Example
+
+Two `KHR_audio_emitter` sources are mixed, filtered, and routed into one emitter.
+
+```json
+{
+    "extensionsUsed": ["KHR_audio_emitter", "KHR_audio_graph"],
+    "extensions": {
+        "KHR_audio_emitter": {
+            "audio": [
+                { "uri": "music.mp3" },
+                { "uri": "ambience.mp3" }
+            ],
+            "sources": [
+                { "audio": 0, "autoPlay": true, "loop": true, "gain": 1.0 },
+                { "audio": 1, "autoPlay": true, "loop": true, "gain": 0.5 }
+            ],
+            "emitters": [
+                { "type": "global", "gain": 1.0, "sources": [] }
+            ]
+        },
+        "KHR_audio_graph": {
+            "graphs": [
+                {
+                    "name": "music-mix",
+                    "nodes": [
+                        { "kind": "audiomixer", "params": {} },
+                        { "kind": "gain", "params": { "gain": 0.8 } },
+                        { "kind": "lowpass", "params": { "frequency": 8000.0 } }
+                    ],
+                    "connections": [
+                        { "from": { "node": 0 }, "to": { "node": 1 } },
+                        { "from": { "node": 1 }, "to": { "node": 2 } }
+                    ],
+                    "inputs": [
+                        { "source": 0, "node": 0 },
+                        { "source": 1, "node": 0 }
+                    ],
+                    "outputs": [
+                        { "node": 2, "emitter": 0 }
+                    ]
+                }
+            ]
+        }
+    }
+}
+```
+
+## 2. Node Kinds
+
+Each graph node is defined by a `kind` discriminator and a `params` object.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **kind** | `string` | Node type identifier. | Yes |
+| **params** | `object` | Node-kind-specific parameters. | Yes |
+| **label** | `string` | Human-readable label for debugging. | No |
+| **bypass** | `boolean` | When `true`, processing and filter nodes are bypassed. Default: `false`. | No |
+
+### Node Kind Summary
+
+| Kind | Category | I/O |
+|---|---|---|
+| `oscillator` | Source | `0 -> 1` |
+| `gain` | Processing | `1 -> 1` |
+| `delay` | Processing | `1 -> 1` |
+| `compressor` | Processing | `1 -> 1` |
+| `waveshaper` | Processing | `1 -> 1` |
+| `lowpass` | Filter | `1 -> 1` |
+| `highpass` | Filter | `1 -> 1` |
+| `bandpass` | Filter | `1 -> 1` |
+| `lowshelf` | Filter | `1 -> 1` |
+| `highshelf` | Filter | `1 -> 1` |
+| `peaking` | Filter | `1 -> 1` |
+| `notch` | Filter | `1 -> 1` |
+| `allpass` | Filter | `1 -> 1` |
+| `splitter` | Channel routing | `1 -> N` |
+| `channelmerger` | Channel routing | `N -> 1` |
+| `channelmixer` | Channel routing | `1 -> 1` |
+| `audiomixer` | Channel routing | `N -> 1` |
+
+## 3. Source Nodes
+
+Source nodes generate audio within the graph. `KHR_audio_graph` defines one graph-only source node: the oscillator.
+
+### 3.1 Oscillator Node
+
+The oscillator node generates a periodic waveform. It does not reference `KHR_audio_emitter.audio[]` or `KHR_audio_emitter.sources[]`.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **type** | `string` | Waveform: `sine`, `square`, `triangle`, `sawtooth`, `custom`. | Yes |
+| **frequency** | `number` | Frequency in Hertz. Default: `440`. | No |
+| **detune** | `number` | Detune in cents. Default: `0`. | No |
+| **pulseWidth** | `number` | Pulse width for `square` waveforms. Range: `[0, 1]`. Default: `0.5`. | No |
+| **periodicWave** | `object` | Custom waveform definition. **Required when `type` is `custom`**; ignored otherwise. | No |
+
+**Periodic wave object** (matching Web Audio / X3D 4.0 `PeriodicWave`): Fourier coefficients of the waveform.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **real** | `number[]` | Cosine (real) coefficients. Element 0 is DC and SHOULD be `0`. | Yes |
+| **imag** | `number[]` | Sine (imaginary) coefficients, same length as `real`. Element 0 is ignored. | Yes |
+
+Informative Web Audio mapping: implementations typically map this node to `OscillatorNode`, using `PeriodicWave` when `type` is `custom`, or when `type` is `square` and `pulseWidth` is not `0.5`.
+
+```json
+{
+    "name": "test-tone",
+    "nodes": [
+        { "kind": "oscillator", "params": { "type": "sine", "frequency": 440.0 } },
+        { "kind": "gain", "params": { "gain": 0.3 } }
+    ],
+    "connections": [
+        { "from": { "node": 0 }, "to": { "node": 1 } }
+    ],
+    "outputs": [
+        { "node": 1, "emitter": 0 }
+    ]
+}
+```
+
+## 4. Processing Nodes
+
+Processing nodes transform audio. Unless otherwise noted, they have one input and one output. Processing and filter nodes support `bypass`.
+
+### 4.1 Gain Node
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **gain** | `number` | Linear gain multiplier. Range `[0, +∞)`. Default: `1.0`. | No |
+| **interpolation** | `string` | Gain transition curve: `linear` or `custom`. Default: `linear`. | No |
+| **duration** | `number` | Interpolation duration in seconds. Default: `0`. | No |
+| **curve** | `number[]` | Transition shape for `interpolation: "custom"`: gain factors in `[0, 1]` sampled uniformly over `duration`, scaled to the target gain, linearly interpolated between samples. **Required when `interpolation` is `custom`**; ignored otherwise. | No |
+
+### 4.2 Delay Node
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **delayTime** | `number` | Delay time in seconds. Default: `0`. | No |
+| **maxDelayTime** | `number` | Maximum supported delay time in seconds. Default: `1.0`. | No |
+
+### 4.3 Compressor Node
+
+Dynamic range compression, matching the Web Audio `DynamicsCompressorNode` and X3D 4.0 `DynamicsCompressor` parameter sets. One input, one output.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **threshold** | `number` | Level in dB above which compression starts. Range `[-100, 0]`. Default: `-24`. | No |
+| **knee** | `number` | Width in dB of the transition into compression. Range `[0, 40]`. Default: `30`. | No |
+| **ratio** | `number` | Input/output dB ratio above the threshold. Range `[1, 20]`. Default: `12`. | No |
+| **attack** | `number` | Time in seconds to reduce gain by 10 dB. Range `[0, 1]`. Default: `0.003`. | No |
+| **release** | `number` | Time in seconds to increase gain by 10 dB. Range `[0, 1]`. Default: `0.25`. | No |
+
+### 4.4 Waveshaper Node
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **amount** | `number` | Distortion amount in the range `[0, 1]`. | No |
+| **oversample** | `string` | Oversampling factor: `none`, `2x`, `4x`. Default: `none`. | No |
+| **curve** | `number[]` | Explicit shaping curve in the range `[-1, 1]`. Takes precedence over `amount`. | No |
+
+When only `amount` is provided, the shaping curve is defined as `f(x) = tanh(x · d) / tanh(d)` with drive `d = 1 + 20 · amount`, sampled over `x ∈ [-1, 1]`. (Previously implementation-defined; now normative so the same asset distorts identically everywhere.)
+
+## 5. Filter Nodes
+
+Filter nodes implement biquad-style filtering. Each has one input and one output.
+
+### 5.1 Lowpass Filter
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **frequency** | `number` | Cutoff frequency in Hertz. | Yes |
+| **qualityFactor** | `number` | Resonance at the cutoff frequency. Default: `1.0`. | No |
+
+### 5.2 Highpass Filter
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **frequency** | `number` | Cutoff frequency in Hertz. | Yes |
+| **qualityFactor** | `number` | Resonance at the cutoff frequency. Default: `1.0`. | No |
+
+### 5.3 Bandpass Filter
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **frequency** | `number` | Center frequency in Hertz. | Yes |
+| **qualityFactor** | `number` | Bandwidth control. Default: `1.0`. | No |
+
+### 5.4 Lowshelf Filter
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **frequency** | `number` | Upper limit frequency for the shelf in Hertz. | Yes |
+| **gain** | `number` | Shelf gain in decibels. Default: `0`. | No |
+
+### 5.5 Highshelf Filter
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **frequency** | `number` | Lower limit frequency for the shelf in Hertz. | Yes |
+| **gain** | `number` | Shelf gain in decibels. Default: `0`. | No |
+
+### 5.6 Peaking Filter
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **frequency** | `number` | Center frequency in Hertz. | Yes |
+| **qualityFactor** | `number` | Bandwidth control. Default: `1.0`. | No |
+| **gain** | `number` | Gain in decibels. Default: `0`. | No |
+
+### 5.7 Notch Filter
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **frequency** | `number` | Center frequency in Hertz. | Yes |
+| **qualityFactor** | `number` | Bandwidth control. Default: `1.0`. | No |
+
+### 5.8 Allpass Filter
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **frequency** | `number` | Center frequency of the phase transition in Hertz. | Yes |
+| **qualityFactor** | `number` | Sharpness of the phase transition. Default: `1.0`. | No |
+
+## 6. Channel Routing Nodes
+
+### 6.1 Channel Splitter
+
+Splits a multichannel stream into separate mono outputs.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **channelInterpretation** | `string` | `speakers` or `discrete`. Default: `discrete`. | No |
+
+### 6.2 Channel Merger
+
+Merges multiple mono inputs into one multichannel output.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **channelInterpretation** | `string` | `speakers` or `discrete`. Default: `discrete`. | No |
+
+### 6.3 Channel Mixer
+
+Up-mixes or down-mixes channel count.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **outputChannels** | `integer` | Desired output channel count. | Yes |
+| **channelInterpretation** | `string` | `speakers` or `discrete`. Default: `speakers`. | No |
+
+### 6.4 Audio Mixer
+
+Sums multiple inputs with the same channel count into one output.
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **channelInterpretation** | `string` | `speakers` or `discrete`. Default: `speakers`. | No |
+
+## 7. Encoding Properties Extension
+
+When `KHR_audio_graph` is present, entries in `KHR_audio_emitter.audio[]` MAY include encoding metadata through an extension property. This metadata is useful when graph processing depends on channel count, sample rate, or known duration.
+
+```json
+{
+    "extensions": {
+        "KHR_audio_emitter": {
+            "audio": [
+                {
+                    "uri": "music.mp3",
+                    "extensions": {
+                        "KHR_audio_graph": {
+                            "encoding": {
+                                "sampleRate": 44100,
+                                "channels": 2,
+                                "bitsPerSample": 16,
+                                "duration": 180.5,
+                                "samples": 7960050
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+### Encoding Properties
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **sampleRate** | `number` | Sampling rate in Hertz. | Yes |
+| **channels** | `integer` | Number of channels. | Yes |
+| **bitsPerSample** | `integer` | Bits per sample. | No |
+| **duration** | `number` | Total asset duration in seconds. | No |
+| **samples** | `integer` | Total sample count. | No |
+
+## 8. Source Property Extensions
+
+When `KHR_audio_graph` is present, entries in `KHR_audio_emitter.sources[]` MAY include additional playback properties through an extension property.
+
+```json
+{
+    "extensions": {
+        "KHR_audio_emitter": {
+            "sources": [
+                {
+                    "audio": 0,
+                    "gain": 1.0,
+                    "loop": true,
+                    "autoPlay": true,
+                    "extensions": {
+                        "KHR_audio_graph": {
+                            "loopStart": 0.5,
+                            "loopEnd": 120.0,
+                            "offset": 0.0,
+                            "when": 0.0,
+                            "duration": 120.0,
+                            "priority": 128,
+                            "channelInterpretation": "speakers"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+### Extended Source Properties
+
+| Property | Type | Description | Required |
+|---|---|---|---|
+| **loopStart** | `number` | Loop start position in seconds. | No |
+| **loopEnd** | `number` | Loop end position in seconds. | No |
+| **offset** | `number` | Playback start offset in seconds. | No |
+| **when** | `number` | Scheduled start time in seconds on the asset audio clock (see below). | No |
+| **duration** | `number` | Requested playback duration in seconds. | No |
+| **priority** | `integer` | Playback priority, `0` = highest and `256` = lowest. Default: `128`. | No |
+| **channelInterpretation** | `string` | `speakers` or `discrete`. | No |
+
+**Playback clock (normative)**: `when` is measured on the *asset audio clock*, which starts at 0 when audio playback for the asset begins (at load, or at the first user activation where platform autoplay policy requires one). Anchoring scheduled playback to a glTF animation timeline is intentionally deferred to a future extension (USD's stage-time anchoring is the precedent under consideration).
+
+> **Note on removed properties**: earlier drafts defined `playbackRate` (duplicating the base `KHR_audio_emitter` source property — the base definition is authoritative) and a mutable `state` string (play/pause/stop semantics). Playback *control* is a cross-cutting concern being resolved jointly with `KHR_audio_emitter` (#2137) and KHR_interactivity; see the discussion in KhronosGroup/glTF#2561.
+
+## 9. Graph Rules
+
+The following rules are normative:
+
+1. Cycles are permitted **only** when every cycle contains at least one `delay` node; the effective delay of each cycle is clamped to a minimum of one processing block (matching the Web Audio API cycle rule, enabling feedback-delay effects). Graphs containing a cycle with no `delay` node are invalid.
+2. Each graph input binds one `KHR_audio_emitter` source to one graph node input port.
+3. Each graph output binds one graph node output port to one `KHR_audio_emitter` emitter.
+4. A `KHR_audio_emitter` source may be bound to multiple graph inputs.
+5. A `KHR_audio_emitter` emitter may be targeted by multiple graph outputs. Signals are summed.
+6. Multiple graphs may reference the same sources and emitters.
+7. Fan-out is allowed: one node output may feed multiple downstream inputs.
+8. Fan-in is allowed: one node input may receive multiple upstream outputs. Signals are summed.
+9. Splitter output count equals the channel count of its input.
+10. Channel merger input count equals the channel count of its output.
+11. Audio mixer inputs must have the same channel count.
+12. If an emitter is bound through `outputs[]`, that emitter's base `sources` array is ignored.
+13. If `outputs[]` is omitted, the implementation routes terminal graph outputs to the global audio destination.
+14. Implicit fan-in summing (rules 5 and 8) up/down-mixes per the Web Audio API mixing rules with `speakers` channel interpretation, unless a channel routing node specifies otherwise.
+
+### Design Decisions (informative)
+
+Recorded so review does not re-litigate them:
+
+- **No audio-rate parameter connections.** Node outputs carry audio only; connecting a signal to another node's *parameter* (Web Audio's LFO/envelope mechanism) is deliberately out of scope. The connection form `to: {node, param}` is reserved for a future extension; X3D 4.0 made the same omission.
+- **No envelopes or scheduled automation curves.** The gain node's `interpolation`/`duration`/`curve` smoothing is the sanctioned transition mechanism; scene-driven parameter animation uses the glTF Object Model (KHR_animation_pointer / KHR_interactivity).
+- **Graphs process source signals before emission.** There is no post-spatialization insert point in this extension; master-bus processing is provided by `KHR_audio_environment`'s listener-bus hook.
+
+## 10. Bypass Behavior
+
+Processing and filter nodes support the optional `bypass` property.
+
+- `false` or omitted: the node processes audio normally.
+- `true`: the node is skipped and audio passes through unchanged.
+
+Implementations may realize bypass either by rewiring the graph or by providing runtime passthrough behavior.
+
+## 11. Web Audio API Mapping
+
+The following mappings are informative.
+
+| Node Kind | Web Audio API | Notes |
+|---|---|---|
+| `oscillator` | `OscillatorNode` | `pulseWidth` for square waves may be approximated with `PeriodicWave`. |
+| `gain` | `GainNode` | `interpolation = linear` maps to `linearRampToValueAtTime`; `custom` to `setValueCurveAtTime`. |
+| `delay` | `DelayNode` | |
+| `compressor` | `DynamicsCompressorNode` | |
+| `waveshaper` | `WaveShaperNode` | |
+| `lowpass` | `BiquadFilterNode` | `type = "lowpass"` |
+| `highpass` | `BiquadFilterNode` | `type = "highpass"` |
+| `bandpass` | `BiquadFilterNode` | `type = "bandpass"` |
+| `lowshelf` | `BiquadFilterNode` | `type = "lowshelf"` |
+| `highshelf` | `BiquadFilterNode` | `type = "highshelf"` |
+| `peaking` | `BiquadFilterNode` | `type = "peaking"` |
+| `notch` | `BiquadFilterNode` | `type = "notch"` |
+| `allpass` | `BiquadFilterNode` | `type = "allpass"` |
+| `splitter` | `ChannelSplitterNode` | |
+| `channelmerger` | `ChannelMergerNode` | |
+| `channelmixer` | `GainNode` with explicit channel configuration | |
+| `audiomixer` | Connection summing into a shared input node | |
+
+When multiple graph outputs target the same emitter, implementations may realize the emitter as a shared input bus and rely on normal summing behavior before applying emitter gain and spatialization.
+
+## 12. glTF Object Model
+
+The following JSON pointers are defined for mutable properties and may be used with `KHR_animation_pointer` and `KHR_interactivity`.
+
+### Graph Node Parameters
+
+| JSON Pointer | Object Model Type | Description |
+|---|---|---|
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/gain` | `float` | Gain node gain |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/delayTime` | `float` | Delay time in seconds |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/frequency` | `float` | Filter or oscillator frequency |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/qualityFactor` | `float` | Filter Q factor |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/detune` | `float` | Oscillator detune |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/threshold` | `float` | Compressor threshold (dB) |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/knee` | `float` | Compressor knee (dB) |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/ratio` | `float` | Compressor ratio |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/attack` | `float` | Compressor attack (s) |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/params/release` | `float` | Compressor release (s) |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes/{}/bypass` | `bool` | Node bypass state |
+
+### Extended Source Properties
+
+| JSON Pointer | Object Model Type |
+|---|---|
+| `/extensions/KHR_audio_emitter/sources/{}/extensions/KHR_audio_graph/loopStart` | `float` |
+| `/extensions/KHR_audio_emitter/sources/{}/extensions/KHR_audio_graph/loopEnd` | `float` |
+| `/extensions/KHR_audio_emitter/sources/{}/extensions/KHR_audio_graph/offset` | `float` |
+| `/extensions/KHR_audio_emitter/sources/{}/extensions/KHR_audio_graph/when` | `float` |
+| `/extensions/KHR_audio_emitter/sources/{}/extensions/KHR_audio_graph/duration` | `float` |
+| `/extensions/KHR_audio_emitter/sources/{}/extensions/KHR_audio_graph/priority` | `int` |
+
+(`playbackRate` is animatable through the base `KHR_audio_emitter` pointer table; the former `state` pointer is removed pending the joint playback-control resolution — see section 8.)
+
+### Read-Only Properties
+
+| JSON Pointer | Object Model Type |
+|---|---|
+| `/extensions/KHR_audio_graph/graphs.length` | `int` |
+| `/extensions/KHR_audio_graph/graphs/{}/nodes.length` | `int` |
+| `/extensions/KHR_audio_graph/graphs/{}/connections.length` | `int` |
+
+## 13. JSON Schema Reference
+
+The following schema files are defined in the `schema/` directory:
+
+- `glTF.KHR_audio_graph.schema.json`
+- `KHR_audio_graph.graph.schema.json`
+- `KHR_audio_graph.node.schema.json`
+- `KHR_audio_graph.connection.schema.json`
+- `KHR_audio_graph.input.schema.json`
+- `KHR_audio_graph.output.schema.json`
+- `audio.KHR_audio_graph.schema.json`
+- `source.KHR_audio_graph.schema.json`
+- `KHR_audio_graph.encoding.schema.json`
+- `KHR_audio_graph.oscillator.schema.json`
+- `KHR_audio_graph.gain.schema.json`
+- `KHR_audio_graph.delay.schema.json`
+- `KHR_audio_graph.waveshaper.schema.json`
+- `KHR_audio_graph.lowpass.schema.json`
+- `KHR_audio_graph.highpass.schema.json`
+- `KHR_audio_graph.bandpass.schema.json`
+- `KHR_audio_graph.lowshelf.schema.json`
+- `KHR_audio_graph.highshelf.schema.json`
+- `KHR_audio_graph.peaking.schema.json`
+- `KHR_audio_graph.notch.schema.json`
+- `KHR_audio_graph.allpass.schema.json`
+- `KHR_audio_graph.splitter.schema.json`
+- `KHR_audio_graph.channelmerger.schema.json`
+- `KHR_audio_graph.channelmixer.schema.json`
+- `KHR_audio_graph.audiomixer.schema.json`
+
+## Appendix: Full Khronos Copyright Statement
+
+Copyright 2013-2017 The Khronos Group Inc.
+
+Some parts of this Specification are purely informative and do not define requirements
+necessary for compliance and so are outside the Scope of this Specification. These
+parts of the Specification are marked as being non-normative, or identified as
+**Implementation Notes**.
+
+Where this Specification includes normative references to external documents, only the
+specifically identified sections and functionality of those external documents are in
+Scope. Requirements defined by external documents not created by Khronos may contain
+contributions from non-members of Khronos not covered by the Khronos Intellectual
+Property Rights Policy.
+
+This specification is protected by copyright laws and contains material proprietary
+to Khronos. Except as described by these terms, it or any components
+may not be reproduced, republished, distributed, transmitted, displayed, broadcast
+or otherwise exploited in any manner without the express prior written permission
+of Khronos.

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.allpass.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.allpass.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Allpass Filter Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "frequency": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The center frequency in Hertz."
+        },
+        "qualityFactor": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The phase transition sharpness.",
+            "default": 1.0
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["frequency"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.audiomixer.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.audiomixer.schema.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Audio Mixer Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "channelInterpretation": {
+            "type": "string",
+            "enum": ["speakers", "discrete"],
+            "description": "The channel interpretation applied when summing inputs.",
+            "default": "speakers"
+        },
+        "extensions": {},
+        "extras": {}
+    }
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.bandpass.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.bandpass.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Bandpass Filter Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "frequency": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The center frequency in Hertz."
+        },
+        "qualityFactor": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The filter bandwidth control.",
+            "default": 1.0
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["frequency"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.channelmerger.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.channelmerger.schema.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Channel Merger Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "channelInterpretation": {
+            "type": "string",
+            "enum": ["speakers", "discrete"],
+            "description": "The channel interpretation applied by the merger.",
+            "default": "discrete"
+        },
+        "extensions": {},
+        "extras": {}
+    }
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.channelmixer.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.channelmixer.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Channel Mixer Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "outputChannels": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The desired output channel count."
+        },
+        "channelInterpretation": {
+            "type": "string",
+            "enum": ["speakers", "discrete"],
+            "description": "The channel interpretation applied by the mixer.",
+            "default": "speakers"
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["outputChannels"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.compressor.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.compressor.schema.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Compressor Node",
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "threshold": {
+            "type": "number",
+            "minimum": -100.0,
+            "maximum": 0.0,
+            "default": -24.0,
+            "description": "Level in dB above which compression starts."
+        },
+        "knee": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 40.0,
+            "default": 30.0,
+            "description": "Width in dB of the transition into compression."
+        },
+        "ratio": {
+            "type": "number",
+            "minimum": 1.0,
+            "maximum": 20.0,
+            "default": 12.0,
+            "description": "Input/output dB ratio above the threshold."
+        },
+        "attack": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "default": 0.003,
+            "description": "Time in seconds to reduce gain by 10 dB."
+        },
+        "release": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "default": 0.25,
+            "description": "Time in seconds to increase gain by 10 dB."
+        },
+        "extensions": {},
+        "extras": {}
+    }
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.connection.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.connection.schema.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Connection",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "from": {
+            "type": "object",
+            "description": "The upstream endpoint.",
+            "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+            "properties": {
+                "node": {
+                    "allOf": [{ "$ref": "glTFid.schema.json" }],
+                    "description": "The upstream node index."
+                },
+                "output": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "The upstream output port index."
+                },
+                "extensions": {},
+                "extras": {}
+            },
+            "required": ["node"]
+        },
+        "to": {
+            "type": "object",
+            "description": "The downstream endpoint.",
+            "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+            "properties": {
+                "node": {
+                    "allOf": [{ "$ref": "glTFid.schema.json" }],
+                    "description": "The downstream node index."
+                },
+                "input": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "The downstream input port index."
+                },
+                "extensions": {},
+                "extras": {}
+            },
+            "required": ["node"]
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["from", "to"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.delay.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.delay.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Delay Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "delayTime": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The delay time in seconds.",
+            "default": 0.0
+        },
+        "maxDelayTime": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The maximum supported delay time in seconds.",
+            "default": 1.0
+        },
+        "extensions": {},
+        "extras": {}
+    }
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.encoding.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.encoding.schema.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Encoding Properties",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "sampleRate": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The audio sampling rate in Hertz."
+        },
+        "channels": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The number of audio channels."
+        },
+        "bitsPerSample": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The number of bits per sample."
+        },
+        "duration": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The total audio duration in seconds."
+        },
+        "samples": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The total number of samples."
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["sampleRate", "channels"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.gain.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.gain.schema.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Gain Node",
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "gain": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The gain multiplier.",
+            "default": 1.0
+        },
+        "interpolation": {
+            "type": "string",
+            "enum": [
+                "linear",
+                "custom"
+            ],
+            "description": "The curve used when gain changes over time.",
+            "default": "linear"
+        },
+        "duration": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The interpolation duration in seconds.",
+            "default": 0.0
+        },
+        "extensions": {},
+        "extras": {},
+        "curve": {
+            "type": "array",
+            "items": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0
+            },
+            "minItems": 2,
+            "description": "Transition shape for interpolation 'custom': gain factors sampled uniformly over duration, scaled to the target gain."
+        }
+    }
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.gain.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.gain.schema.json
@@ -41,5 +41,26 @@
             "minItems": 2,
             "description": "Transition shape for interpolation 'custom': gain factors sampled uniformly over duration, scaled to the target gain."
         }
-    }
+    },
+    "anyOf": [
+        {
+            "not": {
+                "properties": {
+                    "interpolation": {
+                        "enum": [
+                            "custom"
+                        ]
+                    }
+                },
+                "required": [
+                    "interpolation"
+                ]
+            }
+        },
+        {
+            "required": [
+                "curve"
+            ]
+        }
+    ]
 }

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.graph.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.graph.schema.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Graph",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "An optional human-readable graph name."
+        },
+        "nodes": {
+            "type": "array",
+            "description": "The graph's audio nodes.",
+            "items": {
+                "$ref": "KHR_audio_graph.node.schema.json"
+            },
+            "minItems": 1
+        },
+        "connections": {
+            "type": "array",
+            "description": "Edges between graph nodes.",
+            "items": {
+                "$ref": "KHR_audio_graph.connection.schema.json"
+            }
+        },
+        "inputs": {
+            "type": "array",
+            "description": "Bindings from KHR_audio_emitter sources into graph nodes.",
+            "items": {
+                "$ref": "KHR_audio_graph.input.schema.json"
+            },
+            "minItems": 1
+        },
+        "outputs": {
+            "type": "array",
+            "description": "Bindings from graph nodes to KHR_audio_emitter emitters.",
+            "items": {
+                "$ref": "KHR_audio_graph.output.schema.json"
+            },
+            "minItems": 1
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["nodes", "connections"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.highpass.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.highpass.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Highpass Filter Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "frequency": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The cutoff frequency in Hertz."
+        },
+        "qualityFactor": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The resonance at the cutoff frequency.",
+            "default": 1.0
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["frequency"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.highshelf.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.highshelf.schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Highshelf Filter Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "frequency": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The lower shelf frequency in Hertz."
+        },
+        "gain": {
+            "type": "number",
+            "description": "The shelf gain in decibels.",
+            "default": 0.0
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["frequency"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.input.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.input.schema.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Graph Input",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "source": {
+            "allOf": [{ "$ref": "glTFid.schema.json" }],
+            "description": "The index of the KHR_audio_emitter source bound into this graph."
+        },
+        "node": {
+            "allOf": [{ "$ref": "glTFid.schema.json" }],
+            "description": "The target graph node."
+        },
+        "input": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The input port on the target node."
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["source", "node"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.lowpass.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.lowpass.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Lowpass Filter Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "frequency": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The cutoff frequency in Hertz."
+        },
+        "qualityFactor": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The resonance at the cutoff frequency.",
+            "default": 1.0
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["frequency"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.lowshelf.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.lowshelf.schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Lowshelf Filter Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "frequency": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The upper shelf frequency in Hertz."
+        },
+        "gain": {
+            "type": "number",
+            "description": "The shelf gain in decibels.",
+            "default": 0.0
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["frequency"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.node.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.node.schema.json
@@ -37,18 +37,6 @@
             "properties": {
                 "kind": {
                     "enum": [
-                        "oscillator"
-                    ]
-                },
-                "params": {
-                    "$ref": "KHR_audio_graph.oscillator.schema.json"
-                }
-            }
-        },
-        {
-            "properties": {
-                "kind": {
-                    "enum": [
                         "gain"
                     ]
                 },

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.node.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.node.schema.json
@@ -1,0 +1,241 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Node",
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "kind": {
+            "type": "string",
+            "description": "The node kind discriminator."
+        },
+        "label": {
+            "type": "string",
+            "description": "An optional human-readable label."
+        },
+        "bypass": {
+            "type": "boolean",
+            "description": "When true, processing and filter nodes are bypassed.",
+            "default": false
+        },
+        "params": {
+            "type": "object",
+            "description": "Node-kind-specific parameters."
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": [
+        "kind",
+        "params"
+    ],
+    "oneOf": [
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "oscillator"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.oscillator.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "gain"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.gain.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "delay"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.delay.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "waveshaper"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.waveshaper.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "lowpass"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.lowpass.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "highpass"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.highpass.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "bandpass"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.bandpass.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "lowshelf"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.lowshelf.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "highshelf"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.highshelf.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "peaking"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.peaking.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "notch"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.notch.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "allpass"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.allpass.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "splitter"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.splitter.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "channelmerger"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.channelmerger.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "channelmixer"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.channelmixer.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "audiomixer"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.audiomixer.schema.json"
+                }
+            }
+        },
+        {
+            "properties": {
+                "kind": {
+                    "enum": [
+                        "compressor"
+                    ]
+                },
+                "params": {
+                    "$ref": "KHR_audio_graph.compressor.schema.json"
+                }
+            }
+        }
+    ]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.notch.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.notch.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Notch Filter Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "frequency": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The center frequency in Hertz."
+        },
+        "qualityFactor": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The filter bandwidth control.",
+            "default": 1.0
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["frequency"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.oscillator.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.oscillator.schema.json
@@ -1,0 +1,93 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Oscillator Node",
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "type": {
+            "type": "string",
+            "enum": [
+                "sine",
+                "square",
+                "triangle",
+                "sawtooth",
+                "custom"
+            ],
+            "description": "The oscillator waveform."
+        },
+        "frequency": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The oscillator frequency in Hertz.",
+            "default": 440.0
+        },
+        "detune": {
+            "type": "number",
+            "description": "Oscillator detune in cents.",
+            "default": 0.0
+        },
+        "pulseWidth": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "description": "The pulse width used for square waves.",
+            "default": 0.5
+        },
+        "extensions": {},
+        "extras": {},
+        "periodicWave": {
+            "type": "object",
+            "description": "Custom waveform as Fourier coefficients (Web Audio / X3D PeriodicWave). Required when type is 'custom'.",
+            "properties": {
+                "real": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    },
+                    "minItems": 2,
+                    "description": "Cosine (real) coefficients; element 0 is DC and should be 0."
+                },
+                "imag": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    },
+                    "minItems": 2,
+                    "description": "Sine (imaginary) coefficients, same length as real; element 0 is ignored."
+                }
+            },
+            "required": [
+                "real",
+                "imag"
+            ]
+        }
+    },
+    "required": [
+        "type"
+    ],
+    "anyOf": [
+        {
+            "not": {
+                "properties": {
+                    "type": {
+                        "enum": [
+                            "custom"
+                        ]
+                    }
+                },
+                "required": [
+                    "type"
+                ]
+            }
+        },
+        {
+            "required": [
+                "periodicWave"
+            ]
+        }
+    ]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.oscillator.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.oscillator.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_audio_graph Oscillator Node",
+    "title": "KHR_audio_graph Oscillator Source Data",
     "type": "object",
     "allOf": [
         {

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.output.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.output.schema.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Graph Output",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "node": {
+            "allOf": [{ "$ref": "glTFid.schema.json" }],
+            "description": "The source graph node."
+        },
+        "output": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The output port on the source node."
+        },
+        "emitter": {
+            "allOf": [{ "$ref": "glTFid.schema.json" }],
+            "description": "The index of the target KHR_audio_emitter emitter."
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["node", "emitter"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.peaking.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.peaking.schema.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Peaking Filter Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "frequency": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The center frequency in Hertz."
+        },
+        "qualityFactor": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The filter bandwidth control.",
+            "default": 1.0
+        },
+        "gain": {
+            "type": "number",
+            "description": "The gain in decibels.",
+            "default": 0.0
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["frequency"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.splitter.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.splitter.schema.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Splitter Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "channelInterpretation": {
+            "type": "string",
+            "enum": ["speakers", "discrete"],
+            "description": "The channel interpretation applied by the splitter.",
+            "default": "discrete"
+        },
+        "extensions": {},
+        "extras": {}
+    }
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.waveshaper.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/KHR_audio_graph.waveshaper.schema.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Waveshaper Node",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "amount": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "description": "The distortion amount."
+        },
+        "oversample": {
+            "type": "string",
+            "enum": ["none", "2x", "4x"],
+            "description": "The oversampling factor.",
+            "default": "none"
+        },
+        "curve": {
+            "type": "array",
+            "description": "An explicit shaping curve in the range [-1, 1].",
+            "items": {
+                "type": "number",
+                "minimum": -1.0,
+                "maximum": 1.0
+            }
+        },
+        "extensions": {},
+        "extras": {}
+    }
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/audio.KHR_audio_graph.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/audio.KHR_audio_graph.schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Audio Data Extension",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "encoding": {
+            "$ref": "KHR_audio_graph.encoding.schema.json",
+            "description": "Encoding metadata for the referenced audio asset."
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["encoding"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/glTF.KHR_audio_graph.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/glTF.KHR_audio_graph.schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph glTF Document Extension",
+    "type": "object",
+    "allOf": [{ "$ref": "glTFProperty.schema.json" }],
+    "properties": {
+        "graphs": {
+            "type": "array",
+            "description": "Audio graphs declared at the document level.",
+            "items": {
+                "$ref": "KHR_audio_graph.graph.schema.json"
+            },
+            "minItems": 1
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["graphs"]
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/source.KHR_audio_graph.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/source.KHR_audio_graph.schema.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "KHR_audio_graph Source Extension",
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "loopStart": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The loop start position in seconds."
+        },
+        "loopEnd": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The loop end position in seconds."
+        },
+        "offset": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The playback start offset in seconds."
+        },
+        "when": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The scheduled start time in seconds."
+        },
+        "duration": {
+            "type": "number",
+            "minimum": 0.0,
+            "description": "The requested playback duration in seconds."
+        },
+        "priority": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 256,
+            "description": "Playback priority where 0 is highest and 256 is lowest.",
+            "default": 128
+        },
+        "channelInterpretation": {
+            "type": "string",
+            "enum": [
+                "speakers",
+                "discrete"
+            ],
+            "description": "The channel interpretation applied when graph processing needs one."
+        },
+        "extensions": {},
+        "extras": {}
+    }
+}

--- a/extensions/2.0/Khronos/KHR_audio_graph/schema/source.KHR_audio_graph.schema.json
+++ b/extensions/2.0/Khronos/KHR_audio_graph/schema/source.KHR_audio_graph.schema.json
@@ -49,6 +49,14 @@
             "description": "The channel interpretation applied when graph processing needs one."
         },
         "extensions": {},
-        "extras": {}
+        "extras": {},
+        "oscillator": {
+            "allOf": [
+                {
+                    "$ref": "KHR_audio_graph.oscillator.schema.json"
+                }
+            ],
+            "description": "Procedural waveform for a source without an 'audio' property. A source MUST NOT declare both audio and oscillator. loop/loopStart/loopEnd/offset/playbackRate are ignored for oscillator sources."
+        }
     }
 }


### PR DESCRIPTION
Adds **KHR_audio_graph**, the processing layer (layer 2) of the layered audio architecture proposed in #2561: a declarative DAG of audio processing nodes that consumes `KHR_audio_emitter` sources via `inputs[]` bindings and feeds emitters via `outputs[]` bindings. `README.md` + 26 JSON schemas.

### Relationship to #2572
This is a refresh of #2572 from a clean fork history, folding in the self-review posted there ([comment](https://github.com/KhronosGroup/glTF/pull/2572#issuecomment-5176971328)). Changes relative to #2572:

- **`periodicWave { real[], imag[] }` defined for `oscillator` type `custom`** (was an enum value with no data model), matching Web Audio / X3D 4.0 `PeriodicWave`.
- **`compressor` node added** (Web Audio / X3D `DynamicsCompressor` parameter set) — it was the only roster gap vs both benchmark standards.
- **Feedback cycles permitted when every cycle contains a `delay` node** (the Web Audio cycle rule; minimum one processing block of delay) — enables feedback-delay effects while staying validator-checkable.
- **Custom gain-interpolation curve and the waveshaper `amount` mapping are now normative** (previously implementation-defined), so the same asset sounds the same everywhere.
- **Playback clock defined** for the extended source `when` property (asset audio clock; animation-timeline anchoring deferred with USD stage-time named as precedent).
- **Extended source properties cleaned up**: `playbackRate` removed (duplicated the base `KHR_audio_emitter` property), mutable `state` removed pending the joint playback-control resolution with #2137 / KHR_interactivity.
- **Rule 14 added**: implicit fan-in summing follows the Web Audio mixing rules with `speakers` interpretation unless a channel node overrides.
- **Design decisions recorded** (informative): no audio-rate parameter connections (`to: {node, param}` syntax reserved for a future extension), no envelope/automation timelines, graphs are strictly pre-spatialization (master-bus processing belongs to the environment layer — see #2631).
- **No vendored `KHR_audio_emitter` copy** — depends on #2137 as-is (the copy in #2572 had drifted from the upstream plural-`emitters` change).

### Implementations
- Web Audio reference runtime whose CI validates example assets against these schemas: https://github.com/rudybear/AudioGraphJS/tree/feature/environment-v2
- WebGPU viewer implementing all 16 node kinds with `inputs[]`/`outputs[]` bindings and rule-12 semantics: https://github.com/rudybear/gltf-webgpu/tree/feature/khr-audio
- Demo asset using a processing graph alongside direct-fed emitters (playable drum kit): https://github.com/rudybear/gltf-webgpu/tree/feature/khr-audio/examples/drum-kit

Layer 1 is #2137 (KHR_audio_emitter); layer 3 is #2631 (KHR_audio_environment). Gap analysis vs Web Audio / X3D 4.0: https://github.com/rudybear/KHR_audio_proposals/blob/feature/environment-v2/analysis/2026-08-session/03-gap-analysis-audio-graph.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrRJ9hLK9L9HK5ZsJjNdw7
