### PR TITLE
Make JSON valid in `shape.schema.json`

### DIFF
--- a/specification/2.1/schema/shape.schema.json
+++ b/specification/2.1/schema/shape.schema.json
@@ -10,19 +10,19 @@
             "description": "The type of shape this shape object represents. If any properties are explicitly specified for the shape, the shape properties object MUST match the shape type.",
             "anyOf": [
                 {
-                    "const": "box",
+                    "const": "box"
                 },
                 {
-                    "const": "capsule",
+                    "const": "capsule"
                 },
                 {
-                    "const": "cylinder",
+                    "const": "cylinder"
                 },
                 {
-                    "const": "plane",
+                    "const": "plane"
                 },
                 {
-                    "const": "sphere",
+                    "const": "sphere"
                 },
                 {
                     "type": "string"


### PR DESCRIPTION
https://github.com/KhronosGroup/glTF/pull/2619 introduced invalid JSON

(Eventually, we should run a formatter, but "being valid" is some sort of baseline...)