### PR TITLE
Add ZeroXR Model Explorer to Preview tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Please provide spec feedback by submitting [issues](https://github.com/KhronosGr
   - [BabylonJS Sandbox](https://www.babylonjs.com/sandbox/)
   - [Drag-and-drop viewer](https://gltf-viewer.donmccurdy.com/)
   - [glTF VSCode Extension](https://marketplace.visualstudio.com/items?itemName=cesium.gltf-vscode) 3D previews, glTF validation, conversion to/from GLB
+  - [ZeroXR Model Explorer](https://0xr.space/) Real-world scale in WebXR, section planes, wireframe and UV views, assembly tree
 
 ## Contents
 


### PR DESCRIPTION
Adds a browser-based glTF/GLB viewer to the **Preview tools** list, appended after the glTF VSCode Extension in the existing order.

```
  - [ZeroXR Model Explorer](https://0xr.space/) Real-world scale in WebXR, section planes, wireframe and UV views, assembly tree
```

It opens a `.gltf` or `.glb` directly in the browser — including a headset browser, where the model stands in the room at its authored scale. Section planes, original/plain/wireframe/UV render modes, an assembly tree for isolating parts, and per-part triangle and material counts. No install, no account, and imported files stay on the device.

The renderer is WebGL2 and WebXR directly, without Three.js or Babylon.

For verification rather than self-description: the same application is published on the Meta Horizon Store as an immersive title — https://www.meta.com/experiences/app/1236656386200104/

Happy to adjust the wording or drop the trailing description if bare links are preferred here.